### PR TITLE
Addressable Asset System - Scene load / unload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ ExportedObj/
 *.booproj
 *.svd
 *.pdb
+.vs/
 
 # Builds
 *.apk

--- a/Assets/AddressableAssetsData.meta
+++ b/Assets/AddressableAssetsData.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b59f3b64def2d4699832094ffadd2c47
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AddressableAssetsData/AddressableAssetSettings.asset
+++ b/Assets/AddressableAssetsData/AddressableAssetSettings.asset
@@ -1,0 +1,112 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 468a46d0ae32c3544b7d98094e6448a9, type: 3}
+  m_Name: AddressableAssetSettings
+  m_EditorClassIdentifier: 
+  m_DefaultGroup: 36fdf415407fc4d90bf691d9413d4847
+  m_BuildRemoteCatalog: 0
+  m_DisableCatalogUpdateOnStart: 0
+  m_UniqueBundleIds: 0
+  m_RemoteCatalogBuildPath:
+    m_Id: 2d299c530184245d08d5501197a42f3f
+  m_RemoteCatalogLoadPath:
+    m_Id: e0fa534d5eaf540c6b53d8cbc2ccd5b1
+  m_overridePlayerVersion: 
+  m_GroupAssets:
+  - {fileID: 11400000, guid: bfab886d0f2944e3abf27bb48efb7ee0, type: 2}
+  - {fileID: 11400000, guid: 2def9eceafca74c988999c070bb73434, type: 2}
+  - {fileID: 11400000, guid: c08c02254fa2f4e7ca6958c8c242dc67, type: 2}
+  m_BuildSettings:
+    m_CompileScriptsInVirtualMode: 0
+    m_CleanupStreamingAssetsAfterBuilds: 1
+    m_LogResourceManagerExceptions: 1
+    m_BundleBuildPath: Temp/com.unity.addressables/AssetBundles
+  m_ProfileSettings:
+    m_Profiles:
+    - m_InheritedParent: 
+      m_Id: 1a86b2cce39a8407c908544cfc0c53ee
+      m_ProfileName: Default
+      m_Values:
+      - m_Id: ff5642b6e5c0143dfa3cda541ede06c3
+        m_Value: '[UnityEditor.EditorUserBuildSettings.activeBuildTarget]'
+      - m_Id: a9b5368d1231e476bb417f6a1922047a
+        m_Value: '[UnityEngine.AddressableAssets.Addressables.BuildPath]/[BuildTarget]'
+      - m_Id: 6f9b3a0e47375479fbd0ec8a54ace3f7
+        m_Value: '{UnityEngine.AddressableAssets.Addressables.RuntimePath}/[BuildTarget]'
+      - m_Id: 2d299c530184245d08d5501197a42f3f
+        m_Value: ServerData/[BuildTarget]
+      - m_Id: e0fa534d5eaf540c6b53d8cbc2ccd5b1
+        m_Value: http://localhost/[BuildTarget]
+    m_ProfileEntryNames:
+    - m_Id: ff5642b6e5c0143dfa3cda541ede06c3
+      m_Name: BuildTarget
+      m_InlineUsage: 0
+    - m_Id: a9b5368d1231e476bb417f6a1922047a
+      m_Name: LocalBuildPath
+      m_InlineUsage: 0
+    - m_Id: 6f9b3a0e47375479fbd0ec8a54ace3f7
+      m_Name: LocalLoadPath
+      m_InlineUsage: 0
+    - m_Id: 2d299c530184245d08d5501197a42f3f
+      m_Name: RemoteBuildPath
+      m_InlineUsage: 0
+    - m_Id: e0fa534d5eaf540c6b53d8cbc2ccd5b1
+      m_Name: RemoteLoadPath
+      m_InlineUsage: 0
+    m_ProfileVersion: 1
+  m_LabelTable:
+    m_LabelNames:
+    - default
+  m_SchemaTemplates: []
+  m_GroupTemplateObjects:
+  - {fileID: 11400000, guid: ec738e3e12a1445dfb9aa50871201ebc, type: 2}
+  m_InitializationObjects: []
+  m_CertificateHandlerType:
+    m_AssemblyName: 
+    m_ClassName: 
+  m_ActivePlayerDataBuilderIndex: 3
+  m_DataBuilders:
+  - {fileID: 11400000, guid: 5a4ef00662ef54e62bb90b795bfcaadd, type: 2}
+  - {fileID: 11400000, guid: a030ffddb3e0140db9b77e534c0a6817, type: 2}
+  - {fileID: 11400000, guid: 06be1d706588c4e6a83dbd1a0377e105, type: 2}
+  - {fileID: 11400000, guid: ae89c3803ce7e409fad4f0096c77312d, type: 2}
+  m_ActiveProfileId: 1a86b2cce39a8407c908544cfc0c53ee
+  m_HostingServicesManager:
+    m_HostingServiceInfos:
+    - classRef: UnityEditor.AddressableAssets.HostingServices.HttpHostingService,
+        Unity.Addressables.Editor
+      dataStore:
+        m_SerializedData:
+        - m_AssemblyName: mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089
+          m_ClassName: System.Int32
+          m_Data: 53923
+          m_Key: HostingServicePort
+        - m_AssemblyName: mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089
+          m_ClassName: System.String
+          m_Data: Library/com.unity.addressables/StreamingAssetsCopy/aa/OSX/StandaloneOSX
+          m_Key: ContentRoot
+        - m_AssemblyName: mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089
+          m_ClassName: System.Boolean
+          m_Data: False
+          m_Key: IsEnabled
+        - m_AssemblyName: mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089
+          m_ClassName: System.String
+          m_Data: Local Hosting 0
+          m_Key: DescriptiveName
+        - m_AssemblyName: mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089
+          m_ClassName: System.Int32
+          m_Data: 0
+          m_Key: InstanceId
+    m_Settings: {fileID: 11400000}
+    m_NextInstanceId: 1
+    m_RegisteredServiceTypeRefs:
+    - UnityEditor.AddressableAssets.HostingServices.HttpHostingService, Unity.Addressables.Editor

--- a/Assets/AddressableAssetsData/AddressableAssetSettings.asset.meta
+++ b/Assets/AddressableAssetsData/AddressableAssetSettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 86a9d3876e9534cd69e69f31dd11bb5f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AddressableAssetsData/AssetGroupTemplates.meta
+++ b/Assets/AddressableAssetsData/AssetGroupTemplates.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6e4dbb5a43ca541e8bcba832ad4359f8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AddressableAssetsData/AssetGroupTemplates/Packed Assets.asset
+++ b/Assets/AddressableAssetsData/AssetGroupTemplates/Packed Assets.asset
@@ -1,0 +1,67 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-2504941498235909364
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e5d17a21594effb4e9591490b009e7aa, type: 3}
+  m_Name: BundledAssetGroupSchema
+  m_EditorClassIdentifier: 
+  m_Group: {fileID: 0}
+  m_Compression: 1
+  m_IncludeInBuild: 1
+  m_BundledAssetProviderType:
+    m_AssemblyName: 
+    m_ClassName: 
+  m_ForceUniqueProvider: 0
+  m_UseAssetBundleCache: 1
+  m_UseAssetBundleCrc: 1
+  m_Timeout: 0
+  m_ChunkedTransfer: 0
+  m_RedirectLimit: -1
+  m_RetryCount: 0
+  m_BuildPath:
+    m_Id: 
+  m_LoadPath:
+    m_Id: 
+  m_BundleMode: 0
+  m_AssetBundleProviderType:
+    m_AssemblyName: 
+    m_ClassName: 
+  m_BundleNaming: 0
+--- !u!114 &-1391494566382946069
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5834b5087d578d24c926ce20cd31e6d6, type: 3}
+  m_Name: ContentUpdateGroupSchema
+  m_EditorClassIdentifier: 
+  m_Group: {fileID: 0}
+  m_StaticContent: 0
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1a3c5d64ac83548c09dd1678b9f6f1cd, type: 3}
+  m_Name: Packed Assets
+  m_EditorClassIdentifier: 
+  m_SchemaObjects:
+  - {fileID: -2504941498235909364}
+  - {fileID: -1391494566382946069}
+  m_Description: Pack assets into asset bundles.
+  m_Settings: {fileID: 0}

--- a/Assets/AddressableAssetsData/AssetGroupTemplates/Packed Assets.asset.meta
+++ b/Assets/AddressableAssetsData/AssetGroupTemplates/Packed Assets.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ec738e3e12a1445dfb9aa50871201ebc
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AddressableAssetsData/AssetGroups.meta
+++ b/Assets/AddressableAssetsData/AssetGroups.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7755189f15d11465fb60974fb8bd99df
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AddressableAssetsData/AssetGroups/Built In Data.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Built In Data.asset
@@ -1,0 +1,34 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bbb281ee3bf0b054c82ac2347e9e782c, type: 3}
+  m_Name: Built In Data
+  m_EditorClassIdentifier: 
+  m_GroupName: Built In Data
+  m_Data:
+    m_SerializedData: []
+  m_GUID: 498c298ab693c4524a8659296e45f36a
+  m_SerializeEntries:
+  - m_GUID: EditorSceneList
+    m_Address: EditorSceneList
+    m_ReadOnly: 1
+    m_SerializedLabels: []
+    m_mainAssetType: 
+  - m_GUID: Resources
+    m_Address: Resources
+    m_ReadOnly: 1
+    m_SerializedLabels: []
+    m_mainAssetType: 
+  m_ReadOnly: 1
+  m_Settings: {fileID: 11400000, guid: 86a9d3876e9534cd69e69f31dd11bb5f, type: 2}
+  m_SchemaSet:
+    m_Schemas:
+    - {fileID: 11400000, guid: 792a48e457a5b42cd9268f7fe0ebacde, type: 2}

--- a/Assets/AddressableAssetsData/AssetGroups/Built In Data.asset.meta
+++ b/Assets/AddressableAssetsData/AssetGroups/Built In Data.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bfab886d0f2944e3abf27bb48efb7ee0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AddressableAssetsData/AssetGroups/Default Local Group.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Default Local Group.asset
@@ -18,7 +18,7 @@ MonoBehaviour:
   m_GUID: 36fdf415407fc4d90bf691d9413d4847
   m_SerializeEntries:
   - m_GUID: 47c09d9777db0433eab6b66eac0abee4
-    m_Address: Assets/Project/Scenes/MenuSelectScene.unity
+    m_Address: MenuSelectScene
     m_ReadOnly: 0
     m_SerializedLabels: []
     m_mainAssetType: UnityEditor.SceneAsset, UnityEditor, Version=0.0.0.0, Culture=neutral,
@@ -29,6 +29,11 @@ MonoBehaviour:
     m_SerializedLabels: []
     m_mainAssetType: UnityEditor.SceneAsset, UnityEditor, Version=0.0.0.0, Culture=neutral,
       PublicKeyToken=null
+  - m_GUID: dcec7563bff464223b7c21f17f5902f5
+    m_Address: GamePlayScene
+    m_ReadOnly: 0
+    m_SerializedLabels: []
+    m_mainAssetType: 
   m_ReadOnly: 0
   m_Settings: {fileID: 11400000, guid: 86a9d3876e9534cd69e69f31dd11bb5f, type: 2}
   m_SchemaSet:

--- a/Assets/AddressableAssetsData/AssetGroups/Default Local Group.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Default Local Group.asset
@@ -1,0 +1,37 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bbb281ee3bf0b054c82ac2347e9e782c, type: 3}
+  m_Name: Default Local Group
+  m_EditorClassIdentifier: 
+  m_GroupName: Default Local Group
+  m_Data:
+    m_SerializedData: []
+  m_GUID: 36fdf415407fc4d90bf691d9413d4847
+  m_SerializeEntries:
+  - m_GUID: 47c09d9777db0433eab6b66eac0abee4
+    m_Address: Assets/Project/Scenes/MenuSelectScene.unity
+    m_ReadOnly: 0
+    m_SerializedLabels: []
+    m_mainAssetType: UnityEditor.SceneAsset, UnityEditor, Version=0.0.0.0, Culture=neutral,
+      PublicKeyToken=null
+  - m_GUID: bd321d6187a974e9e808df4b07e0b634
+    m_Address: StageSelectScene
+    m_ReadOnly: 0
+    m_SerializedLabels: []
+    m_mainAssetType: UnityEditor.SceneAsset, UnityEditor, Version=0.0.0.0, Culture=neutral,
+      PublicKeyToken=null
+  m_ReadOnly: 0
+  m_Settings: {fileID: 11400000, guid: 86a9d3876e9534cd69e69f31dd11bb5f, type: 2}
+  m_SchemaSet:
+    m_Schemas:
+    - {fileID: 11400000, guid: ef51613067a7847cbaa11f15c0054b96, type: 2}
+    - {fileID: 11400000, guid: fa93ffed9ac90445bab55e2f82fe44c9, type: 2}

--- a/Assets/AddressableAssetsData/AssetGroups/Default Local Group.asset.meta
+++ b/Assets/AddressableAssetsData/AssetGroups/Default Local Group.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2def9eceafca74c988999c070bb73434
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AddressableAssetsData/AssetGroups/Packed Assets.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Packed Assets.asset
@@ -1,0 +1,25 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bbb281ee3bf0b054c82ac2347e9e782c, type: 3}
+  m_Name: Packed Assets
+  m_EditorClassIdentifier: 
+  m_GroupName: Packed Assets
+  m_Data:
+    m_SerializedData: []
+  m_GUID: 8f864bf0c7b5142f585c1a17b629e9d8
+  m_SerializeEntries: []
+  m_ReadOnly: 0
+  m_Settings: {fileID: 11400000, guid: 86a9d3876e9534cd69e69f31dd11bb5f, type: 2}
+  m_SchemaSet:
+    m_Schemas:
+    - {fileID: 11400000, guid: bbe13f79e03fa45c4a75e735932cde60, type: 2}
+    - {fileID: 11400000, guid: 60a8bbcead7334dc28698c1b65a22bbe, type: 2}

--- a/Assets/AddressableAssetsData/AssetGroups/Packed Assets.asset.meta
+++ b/Assets/AddressableAssetsData/AssetGroups/Packed Assets.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c08c02254fa2f4e7ca6958c8c242dc67
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AddressableAssetsData/AssetGroups/Schemas.meta
+++ b/Assets/AddressableAssetsData/AssetGroups/Schemas.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 24debf3ca31254eb29c008ff8560a3a3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AddressableAssetsData/AssetGroups/Schemas/36fdf415407fc4d90bf691d9413d4847_BundledAssetGroupSchema.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Schemas/36fdf415407fc4d90bf691d9413d4847_BundledAssetGroupSchema.asset
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e5d17a21594effb4e9591490b009e7aa, type: 3}
+  m_Name: 36fdf415407fc4d90bf691d9413d4847_BundledAssetGroupSchema
+  m_EditorClassIdentifier: 
+  m_Group: {fileID: 11400000, guid: 2def9eceafca74c988999c070bb73434, type: 2}
+  m_Compression: 1
+  m_IncludeInBuild: 1
+  m_BundledAssetProviderType:
+    m_AssemblyName: Unity.ResourceManager, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    m_ClassName: UnityEngine.ResourceManagement.ResourceProviders.BundledAssetProvider
+  m_ForceUniqueProvider: 0
+  m_UseAssetBundleCache: 1
+  m_UseAssetBundleCrc: 1
+  m_Timeout: 0
+  m_ChunkedTransfer: 0
+  m_RedirectLimit: -1
+  m_RetryCount: 0
+  m_BuildPath:
+    m_Id: a9b5368d1231e476bb417f6a1922047a
+  m_LoadPath:
+    m_Id: 6f9b3a0e47375479fbd0ec8a54ace3f7
+  m_BundleMode: 0
+  m_AssetBundleProviderType:
+    m_AssemblyName: Unity.ResourceManager, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    m_ClassName: UnityEngine.ResourceManagement.ResourceProviders.AssetBundleProvider
+  m_BundleNaming: 0

--- a/Assets/AddressableAssetsData/AssetGroups/Schemas/36fdf415407fc4d90bf691d9413d4847_BundledAssetGroupSchema.asset.meta
+++ b/Assets/AddressableAssetsData/AssetGroups/Schemas/36fdf415407fc4d90bf691d9413d4847_BundledAssetGroupSchema.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fa93ffed9ac90445bab55e2f82fe44c9
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AddressableAssetsData/AssetGroups/Schemas/36fdf415407fc4d90bf691d9413d4847_ContentUpdateGroupSchema.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Schemas/36fdf415407fc4d90bf691d9413d4847_ContentUpdateGroupSchema.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5834b5087d578d24c926ce20cd31e6d6, type: 3}
+  m_Name: 36fdf415407fc4d90bf691d9413d4847_ContentUpdateGroupSchema
+  m_EditorClassIdentifier: 
+  m_Group: {fileID: 0}
+  m_StaticContent: 0

--- a/Assets/AddressableAssetsData/AssetGroups/Schemas/36fdf415407fc4d90bf691d9413d4847_ContentUpdateGroupSchema.asset.meta
+++ b/Assets/AddressableAssetsData/AssetGroups/Schemas/36fdf415407fc4d90bf691d9413d4847_ContentUpdateGroupSchema.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ef51613067a7847cbaa11f15c0054b96
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AddressableAssetsData/AssetGroups/Schemas/498c298ab693c4524a8659296e45f36a_PlayerDataGroupSchema.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Schemas/498c298ab693c4524a8659296e45f36a_PlayerDataGroupSchema.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1487f5d688e4f94f828f879d599dbdc, type: 3}
+  m_Name: 498c298ab693c4524a8659296e45f36a_PlayerDataGroupSchema
+  m_EditorClassIdentifier: 
+  m_Group: {fileID: 0}
+  m_IncludeResourcesFolders: 1
+  m_IncludeBuildSettingsScenes: 1

--- a/Assets/AddressableAssetsData/AssetGroups/Schemas/498c298ab693c4524a8659296e45f36a_PlayerDataGroupSchema.asset.meta
+++ b/Assets/AddressableAssetsData/AssetGroups/Schemas/498c298ab693c4524a8659296e45f36a_PlayerDataGroupSchema.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 792a48e457a5b42cd9268f7fe0ebacde
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AddressableAssetsData/AssetGroups/Schemas/8f864bf0c7b5142f585c1a17b629e9d8_BundledAssetGroupSchema.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Schemas/8f864bf0c7b5142f585c1a17b629e9d8_BundledAssetGroupSchema.asset
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e5d17a21594effb4e9591490b009e7aa, type: 3}
+  m_Name: 8f864bf0c7b5142f585c1a17b629e9d8_BundledAssetGroupSchema
+  m_EditorClassIdentifier: 
+  m_Group: {fileID: 11400000, guid: c08c02254fa2f4e7ca6958c8c242dc67, type: 2}
+  m_Compression: 1
+  m_IncludeInBuild: 1
+  m_BundledAssetProviderType:
+    m_AssemblyName: Unity.ResourceManager, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    m_ClassName: UnityEngine.ResourceManagement.ResourceProviders.BundledAssetProvider
+  m_ForceUniqueProvider: 0
+  m_UseAssetBundleCache: 1
+  m_UseAssetBundleCrc: 1
+  m_Timeout: 0
+  m_ChunkedTransfer: 0
+  m_RedirectLimit: -1
+  m_RetryCount: 0
+  m_BuildPath:
+    m_Id: a9b5368d1231e476bb417f6a1922047a
+  m_LoadPath:
+    m_Id: 6f9b3a0e47375479fbd0ec8a54ace3f7
+  m_BundleMode: 0
+  m_AssetBundleProviderType:
+    m_AssemblyName: Unity.ResourceManager, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    m_ClassName: UnityEngine.ResourceManagement.ResourceProviders.AssetBundleProvider
+  m_BundleNaming: 0

--- a/Assets/AddressableAssetsData/AssetGroups/Schemas/8f864bf0c7b5142f585c1a17b629e9d8_BundledAssetGroupSchema.asset.meta
+++ b/Assets/AddressableAssetsData/AssetGroups/Schemas/8f864bf0c7b5142f585c1a17b629e9d8_BundledAssetGroupSchema.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bbe13f79e03fa45c4a75e735932cde60
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AddressableAssetsData/AssetGroups/Schemas/8f864bf0c7b5142f585c1a17b629e9d8_ContentUpdateGroupSchema.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Schemas/8f864bf0c7b5142f585c1a17b629e9d8_ContentUpdateGroupSchema.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5834b5087d578d24c926ce20cd31e6d6, type: 3}
+  m_Name: 8f864bf0c7b5142f585c1a17b629e9d8_ContentUpdateGroupSchema
+  m_EditorClassIdentifier: 
+  m_Group: {fileID: 11400000, guid: c08c02254fa2f4e7ca6958c8c242dc67, type: 2}
+  m_StaticContent: 0

--- a/Assets/AddressableAssetsData/AssetGroups/Schemas/8f864bf0c7b5142f585c1a17b629e9d8_ContentUpdateGroupSchema.asset.meta
+++ b/Assets/AddressableAssetsData/AssetGroups/Schemas/8f864bf0c7b5142f585c1a17b629e9d8_ContentUpdateGroupSchema.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 60a8bbcead7334dc28698c1b65a22bbe
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AddressableAssetsData/DataBuilders.meta
+++ b/Assets/AddressableAssetsData/DataBuilders.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 45eb98ac605044ef79ad36fd58a87177
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AddressableAssetsData/DataBuilders/BuildScriptFastMode.asset
+++ b/Assets/AddressableAssetsData/DataBuilders/BuildScriptFastMode.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 88d21199f5d473f4db36845f2318f180, type: 3}
+  m_Name: BuildScriptFastMode
+  m_EditorClassIdentifier: 
+  instanceProviderType:
+    m_AssemblyName: Unity.ResourceManager, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    m_ClassName: UnityEngine.ResourceManagement.ResourceProviders.InstanceProvider
+  sceneProviderType:
+    m_AssemblyName: Unity.ResourceManager, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    m_ClassName: UnityEngine.ResourceManagement.ResourceProviders.SceneProvider

--- a/Assets/AddressableAssetsData/DataBuilders/BuildScriptFastMode.asset.meta
+++ b/Assets/AddressableAssetsData/DataBuilders/BuildScriptFastMode.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5a4ef00662ef54e62bb90b795bfcaadd
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AddressableAssetsData/DataBuilders/BuildScriptPackedMode.asset
+++ b/Assets/AddressableAssetsData/DataBuilders/BuildScriptPackedMode.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3e2e0ffa088c91d41a086d0b8cb16bdc, type: 3}
+  m_Name: BuildScriptPackedMode
+  m_EditorClassIdentifier: 
+  instanceProviderType:
+    m_AssemblyName: Unity.ResourceManager, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    m_ClassName: UnityEngine.ResourceManagement.ResourceProviders.InstanceProvider
+  sceneProviderType:
+    m_AssemblyName: Unity.ResourceManager, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    m_ClassName: UnityEngine.ResourceManagement.ResourceProviders.SceneProvider

--- a/Assets/AddressableAssetsData/DataBuilders/BuildScriptPackedMode.asset.meta
+++ b/Assets/AddressableAssetsData/DataBuilders/BuildScriptPackedMode.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ae89c3803ce7e409fad4f0096c77312d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AddressableAssetsData/DataBuilders/BuildScriptPackedPlayMode.asset
+++ b/Assets/AddressableAssetsData/DataBuilders/BuildScriptPackedPlayMode.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ad8c280d42ee0ed41a27db23b43dd2bf, type: 3}
+  m_Name: BuildScriptPackedPlayMode
+  m_EditorClassIdentifier: 
+  instanceProviderType:
+    m_AssemblyName: Unity.ResourceManager, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    m_ClassName: UnityEngine.ResourceManagement.ResourceProviders.InstanceProvider
+  sceneProviderType:
+    m_AssemblyName: Unity.ResourceManager, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    m_ClassName: UnityEngine.ResourceManagement.ResourceProviders.SceneProvider

--- a/Assets/AddressableAssetsData/DataBuilders/BuildScriptPackedPlayMode.asset.meta
+++ b/Assets/AddressableAssetsData/DataBuilders/BuildScriptPackedPlayMode.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 06be1d706588c4e6a83dbd1a0377e105
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AddressableAssetsData/DataBuilders/BuildScriptVirtualMode.asset
+++ b/Assets/AddressableAssetsData/DataBuilders/BuildScriptVirtualMode.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bb0e4994b34add1409fd8ccaf4a82de5, type: 3}
+  m_Name: BuildScriptVirtualMode
+  m_EditorClassIdentifier: 
+  instanceProviderType:
+    m_AssemblyName: Unity.ResourceManager, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    m_ClassName: UnityEngine.ResourceManagement.ResourceProviders.InstanceProvider
+  sceneProviderType:
+    m_AssemblyName: Unity.ResourceManager, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    m_ClassName: UnityEngine.ResourceManagement.ResourceProviders.SceneProvider

--- a/Assets/AddressableAssetsData/DataBuilders/BuildScriptVirtualMode.asset.meta
+++ b/Assets/AddressableAssetsData/DataBuilders/BuildScriptVirtualMode.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a030ffddb3e0140db9b77e534c0a6817
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AddressableAssetsData/DefaultObject.asset
+++ b/Assets/AddressableAssetsData/DefaultObject.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3a189bb168d8d90478a09ea08c2f3d72, type: 3}
+  m_Name: DefaultObject
+  m_EditorClassIdentifier: 
+  m_AddressableAssetSettingsGuid: 86a9d3876e9534cd69e69f31dd11bb5f

--- a/Assets/AddressableAssetsData/DefaultObject.asset.meta
+++ b/Assets/AddressableAssetsData/DefaultObject.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e820ac43ca1f64515a53deeca63430e6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/Scripts/GamePlayScene/PauseWindow.cs
+++ b/Assets/Project/Scripts/GamePlayScene/PauseWindow.cs
@@ -1,4 +1,5 @@
-﻿using Project.Scripts.Utils.Definitions;
+﻿using Project.Scripts.Utils;
+using Project.Scripts.Utils.Definitions;
 using Project.Scripts.Utils.PlayerPrefsUtils;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -65,7 +66,7 @@ namespace Project.Scripts.GamePlayScene
             // ゲーム内の時間を元に戻す
             Time.timeScale = 1.0f;
             // StageSelectSceneに戻る
-            SceneManager.LoadScene(SceneName.MENU_SELECT_SCENE);
+            AddressableAssetManager.Instance.LoadScene(SceneName.MENU_SELECT_SCENE);
         }
     }
 }

--- a/Assets/Project/Scripts/GamePlayScene/ResultPopup.cs
+++ b/Assets/Project/Scripts/GamePlayScene/ResultPopup.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using System.IO;
 using Project.Scripts.UIComponents;
+using Project.Scripts.Utils;
 using Project.Scripts.Utils.Definitions;
 using Project.Scripts.Utils.PlayerPrefsUtils;
 using UnityEngine;
@@ -92,7 +93,7 @@ namespace Project.Scripts.GamePlayScene
         private static void BackButtonDown()
         {
             // StageSelectSceneに戻る
-            SceneManager.LoadScene(SceneName.MENU_SELECT_SCENE);
+            AddressableAssetManager.Instance.LoadScene(SceneName.STAGE_SELECT_SCENE);
         }
 
         /// <summary>

--- a/Assets/Project/Scripts/MenuSelectScene/LevelSelect/LevelTreeController.cs
+++ b/Assets/Project/Scripts/MenuSelectScene/LevelSelect/LevelTreeController.cs
@@ -1,7 +1,7 @@
 ﻿using Project.Scripts.StageSelectScene;
+using Project.Scripts.Utils;
 using Project.Scripts.Utils.Definitions;
 using UnityEngine;
-using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 
 namespace Project.Scripts.MenuSelectScene.LevelSelect
@@ -28,7 +28,7 @@ namespace Project.Scripts.MenuSelectScene.LevelSelect
         {
             StageSelectDirector.levelName = _levelName;
             StageSelectDirector.treeId = _treeId;
-            SceneManager.LoadSceneAsync("StageSelectScene");
+            AddressableAssetManager.Instance.LoadScene(SceneName.STAGE_SELECT_SCENE);
         }
     }
 }

--- a/Assets/Project/Scripts/StageSelectScene/StageSelectDirector.cs
+++ b/Assets/Project/Scripts/StageSelectScene/StageSelectDirector.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using Project.Scripts.GamePlayScene;
+using Project.Scripts.Utils;
 using Project.Scripts.Utils.Definitions;
 using Project.Scripts.Utils.PlayerPrefsUtils;
 using SnapScroll;
@@ -147,20 +148,7 @@ namespace Project.Scripts.StageSelectScene
             // ロード中のアニメーションを開始する
             _loading.SetActive(true);
             // シーン遷移
-            StartCoroutine(LoadGamePlayScene());
-        }
-
-        /// <summary>
-        /// GamePlaySceneに遷移する
-        /// ロード中にアニメーションを動かすために非同期にロードする
-        /// </summary>
-        /// <returns></returns>
-        private static IEnumerator LoadGamePlayScene()
-        {
-            var async = SceneManager.LoadSceneAsync(SceneName.GAME_PLAY_SCENE);
-            while (!async.isDone) {
-                yield return null;
-            }
+            AddressableAssetManager.Instance.LoadScene(SceneName.GAME_PLAY_SCENE);
         }
     }
 }

--- a/Assets/Project/Scripts/Utils/AddressableAssetManager.cs
+++ b/Assets/Project/Scripts/Utils/AddressableAssetManager.cs
@@ -1,0 +1,86 @@
+﻿using System.Collections.Generic;
+using Project.Scripts.Utils.Patterns;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.AddressableAssets;
+using UnityEngine.ResourceManagement.AsyncOperations;
+using UnityEngine.ResourceManagement.ResourceProviders;
+
+namespace Project.Scripts.Utils
+{
+    public class AddressableAssetManager : Singleton<AddressableAssetManager>
+    {
+        /// <summary>
+        /// あとでアンロードするために保持するロードした各シーンのハンドル
+        /// </summary>
+        private readonly Dictionary<string, SceneInstance> _loadedScenes;
+
+        public AddressableAssetManager()
+        {
+            _loadedScenes = new Dictionary<string, SceneInstance>();
+        }
+
+        /// <summary>
+        /// シーンをロードする
+        /// </summary>
+        /// <param name="sceneName">ロードするシーンのaddress</param>
+        /// <param name="loadSceneMode">ロードモード（Single/Additive)を指定</param>
+        /// <returns>呼び出し先もイベントを登録できるよう、ハンドルを返す</returns>
+        public AsyncOperationHandle<SceneInstance> LoadScene(string sceneName, LoadSceneMode loadSceneMode = LoadSceneMode.Single)
+        {
+            // 辞書にシーンのインスタンスが入ってる場合
+            if (_loadedScenes.ContainsKey(sceneName)) {
+                var scene = _loadedScenes[sceneName].Scene;
+
+                if (!scene.isLoaded) {
+                    // 自動でアンロードされたら削除（他のシーンがSingleでロードした時）
+                    _loadedScenes.Remove(sceneName);
+                } else {
+                    // シーンがすでにロードしている
+                    return default;
+                }
+            }
+
+            var ret = Addressables.LoadSceneAsync(sceneName, loadSceneMode);
+
+            // TODO show progress bar
+
+            ret.Completed += (obj) => {
+                if (obj.Status == AsyncOperationStatus.Succeeded) {
+                    // ロード完了したら、ハンドルを保存する（今後アンロードするために）
+                    _loadedScenes.Add(sceneName, ret.Result);
+                } else {
+                    // TODO popup error message box, return to top
+                    Debug.LogError($"Load Scene {sceneName} Failed.");
+                }
+            };
+            return ret;
+        }
+
+        /// <summary>
+        /// シーンをアンロードする
+        /// </summary>
+        /// <param name="sceneName">アンロードするシーンのaddress</param>
+        /// <returns>呼び出し先もイベントを登録できるよう、ハンドルを返す</returns>
+        public AsyncOperationHandle<SceneInstance> UnloadScene(string sceneName)
+        {
+            // シーンがロードしていなければ終了
+            if (!_loadedScenes.ContainsKey(sceneName))
+                return default;
+
+            var handle = _loadedScenes[sceneName];
+            var ret = Addressables.UnloadSceneAsync(handle);
+            ret.Completed += (obj) => {
+                if (obj.Status == AsyncOperationStatus.Succeeded) {
+                    // アンロード終了後、辞書から削除
+                    _loadedScenes.Remove(sceneName);
+                } else {
+                    // TODO popup error message box, return to top
+                    Debug.LogError($"Unload Scene {sceneName} Failed.");
+                }
+            };
+
+            return ret;
+        }
+    }
+}

--- a/Assets/Project/Scripts/Utils/AddressableAssetManager.cs.meta
+++ b/Assets/Project/Scripts/Utils/AddressableAssetManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 38c5bfcc43af84e8485a94a00a693535
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.2d.tilemap": "1.0.0",
+    "com.unity.addressables": "1.6.0",
     "com.unity.ads": "2.0.8",
     "com.unity.analytics": "3.3.5",
     "com.unity.collab-proxy": "1.2.16",

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -9,22 +9,22 @@ EditorBuildSettings:
     path: Assets/Project/Scenes/MenuSelectScene.unity
     guid: 47c09d9777db0433eab6b66eac0abee4
   - enabled: 0
-    path: Assets/Project/Scenes/RecordScene.unity
+    path: 
     guid: 18cf95513fb264923b06e37802106396
   - enabled: 0
-    path: Assets/Project/Scenes/TutorialScene.unity
+    path: 
     guid: 4c58e4497d73f446a97f095eb60e0f49
   - enabled: 0
-    path: Assets/Project/Scenes/ConfigScene.unity
+    path: 
     guid: faae0a216de3f4763a9095c08f1a3573
-  - enabled: 1
+  - enabled: 0
     path: Assets/Project/Scenes/GamePlayScene.unity
     guid: dcec7563bff464223b7c21f17f5902f5
   - enabled: 0
     path: Assets/Project/Scenes/StageSelectScene.unity
     guid: bd321d6187a974e9e808df4b07e0b634
   - enabled: 0
-    path: Assets/Project/Scenes/LevelSelectScene.unity
+    path: 
     guid: 173f038f3cfb7476a92155a9061883d6
   m_configObjects:
     com.unity.addressableassets: {fileID: 11400000, guid: e820ac43ca1f64515a53deeca63430e6,

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -5,25 +5,27 @@ EditorBuildSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Scenes:
-  - enabled: 1
+  - enabled: 0
     path: Assets/Project/Scenes/MenuSelectScene.unity
     guid: 47c09d9777db0433eab6b66eac0abee4
-  - enabled: 1
+  - enabled: 0
     path: Assets/Project/Scenes/RecordScene.unity
     guid: 18cf95513fb264923b06e37802106396
-  - enabled: 1
+  - enabled: 0
     path: Assets/Project/Scenes/TutorialScene.unity
     guid: 4c58e4497d73f446a97f095eb60e0f49
-  - enabled: 1
+  - enabled: 0
     path: Assets/Project/Scenes/ConfigScene.unity
     guid: faae0a216de3f4763a9095c08f1a3573
   - enabled: 1
     path: Assets/Project/Scenes/GamePlayScene.unity
     guid: dcec7563bff464223b7c21f17f5902f5
-  - enabled: 1
+  - enabled: 0
     path: Assets/Project/Scenes/StageSelectScene.unity
     guid: bd321d6187a974e9e808df4b07e0b634
-  - enabled: 1
+  - enabled: 0
     path: Assets/Project/Scenes/LevelSelectScene.unity
     guid: 173f038f3cfb7476a92155a9061883d6
-  m_configObjects: {}
+  m_configObjects:
+    com.unity.addressableassets: {fileID: 11400000, guid: e820ac43ca1f64515a53deeca63430e6,
+      type: 2}


### PR DESCRIPTION
## 対象イシュー
close #286 

## 概要
`MenuSelectScene` におけるシーンの転換処理をAASに移行

## 技術的な内容
ついてにトグル周りの処理をレファクタリングした、元々 `MenuSelectDirector` 経由で現在選択したトグルを管理しているのを、`MenuSelectToggle` のstatic変数でその情報を保持する。


## デバッグ
LevelSelectScene、StageSelectScene、ConfigScenen、RecordScene、TutorialSceneの中で行ったり来たりして挙動が正常であることを確かめてください。

