### PR TITLE
overviewpopup背景微調整

### DIFF
--- a/Assets/Project/Prefabs/StageSelectScene/OverviewPopup.prefab
+++ b/Assets/Project/Prefabs/StageSelectScene/OverviewPopup.prefab
@@ -36,7 +36,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 150, y: 533.6}
+  m_SizeDelta: {x: 1000, y: 1000}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1052226765
 CanvasRenderer:
@@ -92,7 +92,7 @@ MonoBehaviour:
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
     m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
+  m_Transition: 0
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
     m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}


### PR DESCRIPTION
## 対象イシュー

close #326 

## 概要
OverviewPopupの背景の調整

## 技術的な内容
![スクリーンショット 2020-03-31 午前0 15 48](https://user-images.githubusercontent.com/17778395/77930432-d8e22d00-72e5-11ea-8b83-7d60bd9d63dd.png)
⬇️ 
![スクリーンショット 2020-03-31 午前0 16 13](https://user-images.githubusercontent.com/17778395/77930422-d5e73c80-72e5-11ea-8e85-b2c0f40a47e0.png)

![スクリーンショット 2020-03-31 午前0 16 22](https://user-images.githubusercontent.com/17778395/77930408-d089f200-72e5-11ea-9a76-711f538a13d5.png)
⬇️ 
![スクリーンショット 2020-03-31 午前0 16 30](https://user-images.githubusercontent.com/17778395/77930327-ba7c3180-72e5-11ea-84be-c23ca5fa9615.png)



## キャプチャ

