### PR TITLE
任意のデバイスでポーズ画面が画面全体を覆うように修正する

### DIFF
--- a/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
+++ b/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
@@ -389,10 +389,6 @@ namespace Project.Scripts.GamePlayScene
                 if (Camera.main != null) Camera.main.rect = new Rect(0f, rectY, 1f, ratio);
                 yield return null;
             }
-            // 結果ウィンドウの大きさを変える
-            _resultWindow.transform.localScale = new Vector2(ratio, ratio);
-            // 一時停止ウィンドウの大きさを変える
-            _pauseWindow.transform.localScale = new Vector2(ratio, ratio);
         }
 
         /// <summary>

--- a/Assets/Project/Scripts/StageSelectScene/StageSelectDirector.cs
+++ b/Assets/Project/Scripts/StageSelectScene/StageSelectDirector.cs
@@ -161,6 +161,8 @@ namespace Project.Scripts.StageSelectScene
             GamePlayDirector.levelName = levelName;
             GamePlayDirector.treeId = treeId;
             GamePlayDirector.stageId = stageId;
+            // ポップアップを非表示にする
+            _overviewPopup.gameObject.SetActive(false);
             // ロード中の背景を表示する
             _loadingBackground.SetActive(true);
             // ロード中のアニメーションを開始する


### PR DESCRIPTION
## 対象イシュー
Closed #249

## 概要
タイトルの通り

## 技術的な内容
理想的なデバイスで正しく写る背景をあらかじめ配置している
理想的ではないデバイスに対して、カメラの写す範囲を狭める
一時停止背景は、カメラの写す範囲を満たすように表示されれば良いが、狭めたカメラ範囲に対してさらに狭めてしまっていた


## キャプチャ
<img width="326" alt="bugfix:pause_correctly" src="https://user-images.githubusercontent.com/26213141/78101327-2663b480-7422-11ea-87d6-76c63ceae809.png">
