### PR TITLE
タイルを予めシーンに配置する

### DIFF
--- a/Assets/Project/Scenes/GamePlayScene.unity
+++ b/Assets/Project/Scenes/GamePlayScene.unity
@@ -187,6 +187,195 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &302136306
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 719677483}
+    m_Modifications:
+    - target: {fileID: 1202584627454472, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_Name
+      value: NormalTile2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+--- !u!4 &302136307 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e,
+    type: 3}
+  m_PrefabInstance: {fileID: 302136306}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &340422694
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 719677483}
+    m_Modifications:
+    - target: {fileID: 1202584627454472, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_Name
+      value: NormalTile8
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+--- !u!4 &340422695 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e,
+    type: 3}
+  m_PrefabInstance: {fileID: 340422694}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &355486363
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 719677483}
+    m_Modifications:
+    - target: {fileID: 1202584627454472, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_Name
+      value: NormalTile7
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+--- !u!4 &355486364 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e,
+    type: 3}
+  m_PrefabInstance: {fileID: 355486363}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &374185329
 GameObject:
   m_ObjectHideFlags: 0
@@ -290,6 +479,132 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!1001 &386244178
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 719677483}
+    m_Modifications:
+    - target: {fileID: 1202584627454472, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_Name
+      value: NormalTile14
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_RootOrder
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+--- !u!4 &386244179 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e,
+    type: 3}
+  m_PrefabInstance: {fileID: 386244178}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &490682300
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 719677483}
+    m_Modifications:
+    - target: {fileID: 1202584627454472, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_Name
+      value: NormalTile1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+--- !u!4 &490682301 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e,
+    type: 3}
+  m_PrefabInstance: {fileID: 490682300}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &574476884
 GameObject:
   m_ObjectHideFlags: 0
@@ -468,6 +783,195 @@ MonoBehaviour:
     serializedVersion: 2
     m_Bits: 4294967295
   useHitFilters: 0
+--- !u!1001 &661999911
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 719677483}
+    m_Modifications:
+    - target: {fileID: 1202584627454472, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_Name
+      value: NormalTile11
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_RootOrder
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+--- !u!4 &661999912 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e,
+    type: 3}
+  m_PrefabInstance: {fileID: 661999911}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &679540253
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 719677483}
+    m_Modifications:
+    - target: {fileID: 1202584627454472, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_Name
+      value: NormalTile13
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_RootOrder
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+--- !u!4 &679540254 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e,
+    type: 3}
+  m_PrefabInstance: {fileID: 679540253}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &681615921
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 719677483}
+    m_Modifications:
+    - target: {fileID: 1202584627454472, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_Name
+      value: NormalTile6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+--- !u!4 &681615922 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e,
+    type: 3}
+  m_PrefabInstance: {fileID: 681615921}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &719677482
 GameObject:
   m_ObjectHideFlags: 0
@@ -495,7 +999,22 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 490682301}
+  - {fileID: 302136307}
+  - {fileID: 1542554564}
+  - {fileID: 1398619169}
+  - {fileID: 1883675502}
+  - {fileID: 681615922}
+  - {fileID: 355486364}
+  - {fileID: 340422695}
+  - {fileID: 768947037}
+  - {fileID: 2078572774}
+  - {fileID: 661999912}
+  - {fileID: 1891721821}
+  - {fileID: 679540254}
+  - {fileID: 386244179}
+  - {fileID: 1022829848}
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -511,6 +1030,69 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 633aaf5d1ee7d4e199e9bb156394d2b4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &768947036
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 719677483}
+    m_Modifications:
+    - target: {fileID: 1202584627454472, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_Name
+      value: NormalTile9
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+--- !u!4 &768947037 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e,
+    type: 3}
+  m_PrefabInstance: {fileID: 768947036}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &854681651
 GameObject:
   m_ObjectHideFlags: 0
@@ -653,6 +1235,195 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 5723118930208174235, guid: 38df95ff559d540b7b005fc170e98692,
     type: 3}
   m_PrefabInstance: {fileID: 5723118929261642196}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1022829847
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 719677483}
+    m_Modifications:
+    - target: {fileID: 1202584627454472, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_Name
+      value: NormalTile15
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_RootOrder
+      value: 14
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+--- !u!4 &1022829848 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e,
+    type: 3}
+  m_PrefabInstance: {fileID: 1022829847}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1398619168
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 719677483}
+    m_Modifications:
+    - target: {fileID: 1202584627454472, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_Name
+      value: NormalTile4
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+--- !u!4 &1398619169 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e,
+    type: 3}
+  m_PrefabInstance: {fileID: 1398619168}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1542554563
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 719677483}
+    m_Modifications:
+    - target: {fileID: 1202584627454472, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_Name
+      value: NormalTile3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+--- !u!4 &1542554564 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e,
+    type: 3}
+  m_PrefabInstance: {fileID: 1542554563}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &1638029895
 GameObject:
@@ -1219,6 +1990,195 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1883675501
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 719677483}
+    m_Modifications:
+    - target: {fileID: 1202584627454472, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_Name
+      value: NormalTile5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+--- !u!4 &1883675502 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e,
+    type: 3}
+  m_PrefabInstance: {fileID: 1883675501}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1891721820
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 719677483}
+    m_Modifications:
+    - target: {fileID: 1202584627454472, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_Name
+      value: NormalTile12
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_RootOrder
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+--- !u!4 &1891721821 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e,
+    type: 3}
+  m_PrefabInstance: {fileID: 1891721820}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2078572773
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 719677483}
+    m_Modifications:
+    - target: {fileID: 1202584627454472, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_Name
+      value: NormalTile10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_RootOrder
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 10615e735d661461a88777d89755bf0e, type: 3}
+--- !u!4 &2078572774 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e,
+    type: 3}
+  m_PrefabInstance: {fileID: 2078572773}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &2118484156
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
+++ b/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
@@ -333,10 +333,11 @@ namespace Project.Scripts.GamePlayScene
         /// </summary>
         private static void CleanObject()
         {
-            var tiles = GameObject.FindGameObjectsWithTag(TagName.TILE);
-            foreach (var tile in tiles) {
-                // タイルの削除 (に伴いパネルも削除される)
-                DestroyImmediate(tile);
+            // パネル関連のタグ全部取る必要ある（もしかしたらタグ統一した方がいい？）
+            var panels = GameObject.FindGameObjectsWithTag(TagName.NUMBER_PANEL).Concat(GameObject.FindGameObjectsWithTag(TagName.DUMMY_PANEL));
+            foreach (var panel in panels) {
+                // パネルの削除
+                DestroyImmediate(panel);
             }
 
             var bullets = GameObject.FindGameObjectsWithTag(TagName.BULLET);

--- a/Assets/Project/Scripts/GamePlayScene/Tile/TileGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Tile/TileGenerator.cs
@@ -16,8 +16,8 @@ namespace Project.Scripts.GamePlayScene.Tile
         private void Awake()
         {
             // シーンに配置したタイルを初期化
-            for (int i = 0; i < StageSize.ROW ; ++i) {
-                for (int j = 0; j < StageSize.COLUMN; ++j) {
+            for (var i = 0; i < StageSize.ROW ; ++i) {
+                for (var j = 0; j < StageSize.COLUMN; ++j) {
                     var tileNum = i * StageSize.COLUMN + j + 1;
                     var currTile = transform.Find($"NormalTile{tileNum}").gameObject;
 

--- a/Assets/Project/Scripts/GamePlayScene/Tile/WarpTileController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Tile/WarpTileController.cs
@@ -19,7 +19,7 @@ namespace Project.Scripts.GamePlayScene.Tile
         protected override void Awake()
         {
             base.Awake();
-            _warpTileEffect = transform.Find("warpTileEffectPrefab").gameObject;
+            _warpTileEffect = transform.Find("WarpTileEffectPrefab").gameObject;
         }
 
         /// <summary>


### PR DESCRIPTION
## 対象イシュー

close #319 

## 概要
ノーマルタイルは基本全ステージあるので、予め配置する。

## 技術的な内容
1. `GamePlayScene` に `TileGenerator` の下にNormalTile1~15を配置
2. `TileGenerator.cs` の `NormalTile` の生成に関する記述削除
3. `GamePlayDirector.cs` にリトライするたびにタイル削除する記述をパネルだけ削除する記述に変更

## キャプチャ

