### PR TITLE
設定画面からレビューできるようにする

### DIFF
--- a/Assets/Project/Scenes/MenuSelectScene.unity
+++ b/Assets/Project/Scenes/MenuSelectScene.unity
@@ -2764,6 +2764,94 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &634221104
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 634221105}
+  - component: {fileID: 634221108}
+  - component: {fileID: 634221107}
+  - component: {fileID: 634221106}
+  m_Layer: 5
+  m_Name: Review
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &634221105
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 634221104}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1412558643}
+  - {fileID: 1108274619}
+  m_Father: {fileID: 1116460072}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.275}
+  m_AnchorMax: {x: 1, y: 0.325}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &634221106
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 634221104}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 95c7c5d2ccd543c9b8e5adf73aaf4122, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &634221107
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 634221104}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.392}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &634221108
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 634221104}
+  m_CullTransparentMesh: 0
 --- !u!1 &643647760
 GameObject:
   m_ObjectHideFlags: 0
@@ -4900,6 +4988,134 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &1108274618
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1108274619}
+  - component: {fileID: 1108274622}
+  - component: {fileID: 1108274621}
+  - component: {fileID: 1108274620}
+  m_Layer: 5
+  m_Name: Button
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1108274619
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1108274618}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 634221105}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.7, y: 0}
+  m_AnchorMax: {x: 0.8, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1108274620
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1108274618}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1108274621}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 634221106}
+        m_MethodName: ReviewButtonDown
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &1108274621
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1108274618}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 4f38d6c6b12bc42f69af854c75666b34, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1108274622
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1108274618}
+  m_CullTransparentMesh: 0
 --- !u!1 &1109214965
 GameObject:
   m_ObjectHideFlags: 0
@@ -5014,6 +5230,7 @@ RectTransform:
   - {fileID: 1978334003}
   - {fileID: 991492823}
   - {fileID: 83999335}
+  - {fileID: 634221105}
   m_Father: {fileID: 387558868}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -6030,6 +6247,83 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &1412558642
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1412558643}
+  - component: {fileID: 1412558645}
+  - component: {fileID: 1412558644}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1412558643
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1412558642}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 634221105}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.15, y: 0}
+  m_AnchorMax: {x: 0.45, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!114 &1412558644
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1412558642}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 1
+    m_MinSize: 10
+    m_MaxSize: 200
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: "\u30EC\u30D3\u30E5\u30FC"
+--- !u!222 &1412558645
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1412558642}
+  m_CullTransparentMesh: 0
 --- !u!1 &1420897543
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Project/Scripts/MenuSelectScene/Settings/ReviewController.cs
+++ b/Assets/Project/Scripts/MenuSelectScene/Settings/ReviewController.cs
@@ -8,8 +8,8 @@ namespace Project.Scripts.MenuSelectScene.Settings
     public class ReviewController : MonoBehaviour
     {
         #if UNITY_IOS
-        // TODO: 適切な iOS の ID を設定
-        private const string _IOS_ID = "hoge";
+        // TODO: 適切な iOS の ID を設定 (現状，前作の ID を仕様)
+        private const string _IOS_ID = "1281004285";
         #elif UNITY_ANDROID
         // TODO: 適切な Android の ID を設定
         private const string _ANDROID_ID = "hoge";
@@ -24,7 +24,7 @@ namespace Project.Scripts.MenuSelectScene.Settings
             // iOS の場合
             #if UNITY_IOS
             if (!Device.RequestStoreReview()) {
-                // アプリ内レビューができない場合（iOS10.3未満で発生)
+                // アプリ内レビューができない場合（iOS10.3以上でなければ発生)
                 Application.OpenURL($"itms-apps://itunes.apple.com/jp/app/id{_IOS_ID}?mt=8&action=write-review");
             }
             // Android の場合

--- a/Assets/Project/Scripts/MenuSelectScene/Settings/ReviewController.cs
+++ b/Assets/Project/Scripts/MenuSelectScene/Settings/ReviewController.cs
@@ -1,0 +1,36 @@
+﻿using UnityEngine;
+#if UNITY_IOS
+using UnityEngine.iOS;
+#endif
+
+namespace Project.Scripts.MenuSelectScene.Settings
+{
+    public class ReviewController : MonoBehaviour
+    {
+        #if UNITY_IOS
+        // TODO: 適切な iOS の ID を設定
+        private const string _IOS_ID = "hoge";
+        #elif UNITY_ANDROID
+        // TODO: 適切な Android の ID を設定
+        private const string _ANDROID_ID = "hoge";
+        #endif
+
+
+        /// <summary>
+        /// レビューボタンを押した場合の処理
+        /// </summary>
+        public void ReviewButtonDown()
+        {
+            // iOS の場合
+            #if UNITY_IOS
+            if (!Device.RequestStoreReview()) {
+                // アプリ内レビューができない場合（iOS10.3未満で発生)
+                Application.OpenURL($"itms-apps://itunes.apple.com/jp/app/id{_IOS_ID}?mt=8&action=write-review");
+            }
+            // Android の場合
+            #elif UNITY_ANDROID
+                Application.OpenURL($"market://details?id={_ANDROID_ID}");
+            #endif
+        }
+    }
+}

--- a/Assets/Project/Scripts/MenuSelectScene/Settings/ReviewController.cs
+++ b/Assets/Project/Scripts/MenuSelectScene/Settings/ReviewController.cs
@@ -29,7 +29,7 @@ namespace Project.Scripts.MenuSelectScene.Settings
             }
             // Android の場合
             #elif UNITY_ANDROID
-                Application.OpenURL($"market://details?id={_ANDROID_ID}");
+            Application.OpenURL($"market://details?id={_ANDROID_ID}");
             #endif
         }
     }

--- a/Assets/Project/Scripts/MenuSelectScene/Settings/ReviewController.cs
+++ b/Assets/Project/Scripts/MenuSelectScene/Settings/ReviewController.cs
@@ -8,7 +8,7 @@ namespace Project.Scripts.MenuSelectScene.Settings
     public class ReviewController : MonoBehaviour
     {
         #if UNITY_IOS
-        // TODO: 適切な iOS の ID を設定 (現状，前作の ID を仕様)
+        // TODO: 適切な iOS の ID を設定 (現状，前作の ID を使用)
         private const string _IOS_ID = "1281004285";
         #elif UNITY_ANDROID
         // TODO: 適切な Android の ID を設定

--- a/Assets/Project/Scripts/MenuSelectScene/Settings/ReviewController.cs.meta
+++ b/Assets/Project/Scripts/MenuSelectScene/Settings/ReviewController.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 95c7c5d2ccd543c9b8e5adf73aaf4122
+timeCreated: 1587646641


### PR DESCRIPTION
## 対象イシュー
Close #106 

## 概要
- 設定画面に新たなボタンを追加し，能動的なレビューをできるようにした
- iOS と Android で処理を分けた

参考 URL：https://eiki.hatenablog.jp/entry/ios_android_unity_rate

注意点：以下の条件が揃わないと，実装が成功しているかわからない
- iOS と Android において，実機（or シミュ，エミュ）で実行
- iOS と Android において，アプリの ID を取得

## 動作確認
- とりあえず iOS において，AppStore（前作）へ飛ぶようになった
