### PR TITLE
ステータスバーを表示する

### DIFF
--- a/Assets/Project/Scripts/MenuSelectScene/UIManager.cs
+++ b/Assets/Project/Scripts/MenuSelectScene/UIManager.cs
@@ -42,6 +42,11 @@ namespace Project.Scripts.MenuSelectScene
         // Start is called before the first frame update
         private void Start()
         {
+            #if !UNITY_EDITOR && UNITY_ANDROID
+            // ステータスバーを表示する
+            StatusBarController.Show();
+            #endif
+            
             // キャンバスがなければ作る
             if (GetComponentInChildren<Canvas>() == null) {
                 gameObject.AddComponent<Canvas>();

--- a/Assets/Project/Scripts/UIComponents/StatusBarController.cs
+++ b/Assets/Project/Scripts/UIComponents/StatusBarController.cs
@@ -12,6 +12,7 @@ namespace Project.Scripts.UIComponents
 
         public static void Show()
         {
+            #if !UNITY_EDITOR && UNITY_ANDROID
             // フルスクリーン表示をやめる 
             using (var unityPlayer = new AndroidJavaClass("com.unity3d.player.UnityPlayer"))
             {
@@ -21,6 +22,7 @@ namespace Project.Scripts.UIComponents
                     activity.Call("runOnUiThread", new AndroidJavaRunnable(RunOnUiThread));
                 }
             }
+            #endif
         }
 
         /// <summary>
@@ -28,6 +30,7 @@ namespace Project.Scripts.UIComponents
         /// </summary>
         private static void RunOnUiThread()
         {
+            #if !UNITY_EDITOR && UNITY_ANDROID
             using (var unityPlayer = new AndroidJavaClass("com.unity3d.player.UnityPlayer"))
             {
                 using (var activity = unityPlayer.GetStatic<AndroidJavaObject>("currentActivity"))
@@ -39,6 +42,7 @@ namespace Project.Scripts.UIComponents
                     }
                 }
             }
+            #endif
         }
     }
 }

--- a/Assets/Project/Scripts/UIComponents/StatusBarController.cs
+++ b/Assets/Project/Scripts/UIComponents/StatusBarController.cs
@@ -1,0 +1,44 @@
+﻿using UnityEngine;
+
+namespace Project.Scripts.UIComponents
+{
+    /// <summary>
+    /// ステータスバーの表示を行う
+    /// </summary>
+    class StatusBarController
+    {
+        private static int _FLAG_FULLSCREEN = 0x00000400;
+        private static int _FLAG_FORCE_NOT_FULLSCREEN = 0x00000800;
+
+        public static void Show()
+        {
+            // フルスクリーン表示をやめる 
+            using (var unityPlayer = new AndroidJavaClass("com.unity3d.player.UnityPlayer"))
+            {
+                using (var activity = unityPlayer.GetStatic<AndroidJavaObject>("currentActivity"))
+                {
+                    // 別スレッド
+                    activity.Call("runOnUiThread", new AndroidJavaRunnable(RunOnUiThread));
+                }
+            }
+        }
+
+        /// <summary>
+        /// フルスクリーン表示をやめるフラッグを管理する
+        /// </summary>
+        private static void RunOnUiThread()
+        {
+            using (var unityPlayer = new AndroidJavaClass("com.unity3d.player.UnityPlayer"))
+            {
+                using (var activity = unityPlayer.GetStatic<AndroidJavaObject>("currentActivity"))
+                {
+                    using (var window = activity.Call<AndroidJavaObject>("getWindow"))
+                    {
+                        window.Call("clearFlags", _FLAG_FULLSCREEN);
+                        window.Call("addFlags", _FLAG_FORCE_NOT_FULLSCREEN);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Assets/Project/Scripts/UIComponents/StatusBarController.cs.meta
+++ b/Assets/Project/Scripts/UIComponents/StatusBarController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d7d88419357714547b504ce5b5bf4dbb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -63,7 +63,7 @@ PlayerSettings:
   use32BitDisplayBuffer: 1
   preserveFramebufferAlpha: 0
   disableDepthAndStencilBuffers: 0
-  androidStartInFullscreen: 1
+  androidStartInFullscreen: 0
   androidRenderOutsideSafeArea: 1
   androidUseSwappy: 0
   androidBlitType: 0

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -188,7 +188,7 @@ PlayerSettings:
   uIPrerenderedIcon: 0
   uIRequiresPersistentWiFi: 0
   uIRequiresFullScreen: 1
-  uIStatusBarHidden: 1
+  uIStatusBarHidden: 0
   uIExitOnSuspend: 0
   uIStatusBarStyle: 0
   iPhoneSplashScreen: {fileID: 0}


### PR DESCRIPTION
## 対象イシュー
Closed #115

## 概要
- ステータスバーを表示する
- (やっていないこと)ステータスバーを考慮したUIのレイアウトを行う
ステータスバーを表示するように実装したが実機テストをしていなく、表示されるのかどうかわからない。また、ステータスバーのサイズではなくセーフエリアのサイズを参照してUIのレイアウトを行うべきであると考える。
#117において、セーフエリアを参照したUIのレイアウトを行うので、今回は見送った。

## 技術的な内容
- iOSは`PlaySettings/Player/iOS/Resolution and Presentation/Status Bar/Status Bar Hidden`の項目をOFFにした
- Androidは`PlayerSettings/Player/Android/Resolution and Presentation/Start in full screen mode`の項目をOFFにした上で、はじめのシーンの`Start()`で、ステータスバーを表示するメソッドを呼び出す。
(シーンが作成されるより前にステータスバーのON/OFFが出来ない)

## 参照したサイト
iOSの実装
https://develop.hateblo.jp/entry/unity-status-bar
Androidの実装
https://qiita.com/tanakashu/items/cef98e8e5149eb7d7f77
`StatusBarController.cs`の補足説明
- `using` ステートメント
https://www.sejuku.net/blog/43105
- `AndroidJavaRunnable`
https://docs.unity3d.com/jp/460/ScriptReference/AndroidJavaRunnable.html

## テスト方法

## キャプチャ

