### PR TITLE
upgrade com.unity.ads 2.0.8 => 3.4.5

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -3,7 +3,7 @@
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.2d.tilemap": "1.0.0",
     "com.unity.addressables": "1.7.4",
-    "com.unity.ads": "2.0.8",
+    "com.unity.ads": "3.4.5",
     "com.unity.analytics": "3.3.5",
     "com.unity.collab-proxy": "1.2.16",
     "com.unity.device-simulator": "2.1.0-preview",


### PR DESCRIPTION
## 対象イシュー
なし

## 概要
アプリのビルド出てたエラー
```
 "Calling TargetGuidByNameWithName="Unity-iPhone" is deprecated. 
```
を調べたら[この記事](https://forum.unity.com/threads/2019-3-0b3-0b4-calling-targetguidbynamewithname-unity-iphone-is-deprecated-wont-build.749003/)を見つけました。
どうやらパッケージに問題があるらしく、アップグレードすることでビルドに成功しました。

## 技術的な内容


## キャプチャ
1. Unityでビルドしたあと、もしXCodeでSignがないとか言われたら、 図の設定のようにしてからもう一回ビルドしてみてください。

![image](https://user-images.githubusercontent.com/17778395/81051524-c23e7f80-8efc-11ea-87c3-5c97bb4b99e2.png)
1. Project 設定を開く
2. Signing & Capabilities タブをクリック
3. Automatically manage signing にチェックを入れる
4. Teamを自分のApple IDにする



