### PR TITLE
チュートリアルUI作成

### DIFF
--- a/Assets/Project/Prefabs/GamePlayScene/TutorialWindow.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/TutorialWindow.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8624659819804652248}
   - component: {fileID: 8624659819804652249}
+  - component: {fileID: 4940370312866831868}
   m_Layer: 5
   m_Name: Content
   m_TagString: Untagged
@@ -44,6 +45,20 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8624659819804652251}
   m_CullTransparentMesh: 0
+--- !u!114 &4940370312866831868
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8624659819804652251}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_AspectMode: 2
+  m_AspectRatio: 0.5625
 --- !u!1 &8624659820823176703
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Project/Prefabs/GamePlayScene/TutorialWindow.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/TutorialWindow.prefab
@@ -1,0 +1,156 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8624659819804652251
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8624659819804652248}
+  - component: {fileID: 8624659819804652249}
+  m_Layer: 5
+  m_Name: Content
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8624659819804652248
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8624659819804652251}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 8624659820823176700}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.1, y: 0.1}
+  m_AnchorMax: {x: 0.9, y: 0.9}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8624659819804652249
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8624659819804652251}
+  m_CullTransparentMesh: 0
+--- !u!1 &8624659820823176703
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8624659820823176700}
+  m_Layer: 5
+  m_Name: TutorialWindow
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8624659820823176700
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8624659820823176703}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 8624659821325451859}
+  - {fileID: 8624659819804652248}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.1, y: 0.15}
+  m_AnchorMax: {x: 0.9, y: 0.85}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &8624659821325451858
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8624659821325451859}
+  - component: {fileID: 8624659821325451857}
+  - component: {fileID: 8624659821325451856}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8624659821325451859
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8624659821325451858}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 8624659820823176700}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8624659821325451857
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8624659821325451858}
+  m_CullTransparentMesh: 0
+--- !u!114 &8624659821325451856
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8624659821325451858}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.392}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1

--- a/Assets/Project/Prefabs/GamePlayScene/TutorialWindow.prefab.meta
+++ b/Assets/Project/Prefabs/GamePlayScene/TutorialWindow.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8f987594265eb4a5fb448ad7ff851ce4
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/Scenes/GamePlayScene.unity
+++ b/Assets/Project/Scenes/GamePlayScene.unity
@@ -602,6 +602,7 @@ RectTransform:
   - {fileID: 1807235817}
   - {fileID: 973531278}
   - {fileID: 1663358810}
+  - {fileID: 1119965506}
   m_Father: {fileID: 0}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1324,7 +1325,7 @@ PrefabInstance:
     - target: {fileID: 5723118930208174235, guid: e8186ef0fac024c0cbbd6efa9516f133,
         type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 5723118930208174235, guid: e8186ef0fac024c0cbbd6efa9516f133,
         type: 3}
@@ -1471,6 +1472,12 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4482315734691428, guid: 10615e735d661461a88777d89755bf0e,
     type: 3}
   m_PrefabInstance: {fileID: 1022829847}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &1119965506 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 8624659820823176700, guid: 8f987594265eb4a5fb448ad7ff851ce4,
+    type: 3}
+  m_PrefabInstance: {fileID: 8624659819778716862}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1398619168
 PrefabInstance:
@@ -2032,7 +2039,7 @@ PrefabInstance:
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
@@ -2330,7 +2337,7 @@ PrefabInstance:
     - target: {fileID: 5723118930208174235, guid: 64b30569cb608457c8725f4c9ed52724,
         type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 5723118930208174235, guid: 64b30569cb608457c8725f4c9ed52724,
         type: 3}
@@ -2500,7 +2507,8 @@ MonoBehaviour:
   sendMessageEvents: 252
   sendMessageTarget: {fileID: 0}
   useUnityEvents: 0
-  layers: []
+  layers:
+  - {fileID: 574476890}
 --- !u!4 &1854169849
 Transform:
   m_ObjectHideFlags: 0
@@ -2759,7 +2767,7 @@ PrefabInstance:
     - target: {fileID: 5318317733216246900, guid: bcbe9f3b3c5db4dab84b8cb55946d747,
         type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 5318317733216246900, guid: bcbe9f3b3c5db4dab84b8cb55946d747,
         type: 3}
@@ -2838,6 +2846,130 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: bcbe9f3b3c5db4dab84b8cb55946d747, type: 3}
+--- !u!1001 &8624659819778716862
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 374185333}
+    m_Modifications:
+    - target: {fileID: 8624659820823176700, guid: 8f987594265eb4a5fb448ad7ff851ce4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8624659820823176700, guid: 8f987594265eb4a5fb448ad7ff851ce4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8624659820823176700, guid: 8f987594265eb4a5fb448ad7ff851ce4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8624659820823176700, guid: 8f987594265eb4a5fb448ad7ff851ce4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8624659820823176700, guid: 8f987594265eb4a5fb448ad7ff851ce4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8624659820823176700, guid: 8f987594265eb4a5fb448ad7ff851ce4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8624659820823176700, guid: 8f987594265eb4a5fb448ad7ff851ce4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8624659820823176700, guid: 8f987594265eb4a5fb448ad7ff851ce4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8624659820823176700, guid: 8f987594265eb4a5fb448ad7ff851ce4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8624659820823176700, guid: 8f987594265eb4a5fb448ad7ff851ce4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8624659820823176700, guid: 8f987594265eb4a5fb448ad7ff851ce4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8624659820823176700, guid: 8f987594265eb4a5fb448ad7ff851ce4,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8624659820823176700, guid: 8f987594265eb4a5fb448ad7ff851ce4,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8624659820823176700, guid: 8f987594265eb4a5fb448ad7ff851ce4,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8624659820823176700, guid: 8f987594265eb4a5fb448ad7ff851ce4,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8624659820823176700, guid: 8f987594265eb4a5fb448ad7ff851ce4,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8624659820823176700, guid: 8f987594265eb4a5fb448ad7ff851ce4,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.15
+      objectReference: {fileID: 0}
+    - target: {fileID: 8624659820823176700, guid: 8f987594265eb4a5fb448ad7ff851ce4,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8624659820823176700, guid: 8f987594265eb4a5fb448ad7ff851ce4,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.85
+      objectReference: {fileID: 0}
+    - target: {fileID: 8624659820823176700, guid: 8f987594265eb4a5fb448ad7ff851ce4,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8624659820823176700, guid: 8f987594265eb4a5fb448ad7ff851ce4,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8624659820823176703, guid: 8f987594265eb4a5fb448ad7ff851ce4,
+        type: 3}
+      propertyPath: m_Name
+      value: TutorialWindow
+      objectReference: {fileID: 0}
+    - target: {fileID: 8624659820823176703, guid: 8f987594265eb4a5fb448ad7ff851ce4,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8f987594265eb4a5fb448ad7ff851ce4, type: 3}
 --- !u!224 &9042073102754128979 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 5318317733216246900, guid: bcbe9f3b3c5db4dab84b8cb55946d747,


### PR DESCRIPTION
### 対象イシュー
Close #312 

### 概要

チュートリアル用のUIを用意する

### 詳細

階層：
![image](https://user-images.githubusercontent.com/17778395/81495724-3d34db00-92ed-11ea-8946-ee26e7bdf609.png)

`Background` : 背景画像を貼り付ける用（ポップアップのデザインを適用？）
`Content`: チュートリアル画像、映像を表示用。今は何もないが、チュートリアルのファイル種類によって、表示時に `VideoPlayer` か `Image` コンポーネントをアタッチする実装にする予定。

#### 現実装になった経緯

特になし

#### 技術的な内容


### キャプチャ

ウィンドウの大きさ
![image](https://user-images.githubusercontent.com/17778395/81495891-8d606d00-92ee-11ea-98fa-2bf73091ca42.png)

コンテンツの大きさ
![image](https://user-images.githubusercontent.com/17778395/81495903-a537f100-92ee-11ea-98fb-249da2e9b7ed.png)



### 動作確認方法
パネルの大きさ、コンテンツの大きさが適切かどうかについて確認してほしい。

### 参考 URL
