### PR TITLE
fix:StaticDummyBottle、DynamicDummyBottleが表示されなくなっている

### DIFF
--- a/Assets/Project/Scripts/GamePlayScene/Bottle/AbstractBottleController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bottle/AbstractBottleController.cs
@@ -95,7 +95,7 @@ namespace Project.Scripts.GamePlayScene.Bottle
             // ボトルをボードに設定
             BoardManager.SetBottle(this, Id);
 
-            if (bottleData.bottleSprite != null) {
+            if (bottleData.bottleSprite.RuntimeKeyIsValid()) {
                 var bottleSprite = AddressableAssetManager.GetAsset<Sprite>(bottleData.bottleSprite);
                 GetComponent<SpriteRenderer>().sprite = bottleSprite;
             }

--- a/Assets/Project/Scripts/Utils/AddressableAssetManager.cs
+++ b/Assets/Project/Scripts/Utils/AddressableAssetManager.cs
@@ -181,9 +181,9 @@ namespace Project.Scripts.Utils
                     default:
                         throw new System.NotImplementedException();
                 }
-                if (bottleData.bottleSprite != null) LoadAsset<Sprite>(bottleData.bottleSprite);
+                if (bottleData.bottleSprite.RuntimeKeyIsValid()) LoadAsset<Sprite>(bottleData.bottleSprite);
                 // 対応するTileのSpriteを先に読み込む
-                if (bottleData.targetTileSprite != null) LoadAsset<Sprite>(bottleData.targetTileSprite);
+                if (bottleData.targetTileSprite.RuntimeKeyIsValid()) LoadAsset<Sprite>(bottleData.targetTileSprite);
             });
 
             stage.TileDatas.ForEach(tileData => {


### PR DESCRIPTION
### 対象イシュー
Close #377 

### 概要
`StaticDummyBottle`と`DynamicDummyBottle`が表示されなくなっていたので修正する。


#### 技術的な内容
`BottleData.bottleSprite`が設定されてるかの判定について`null`判定を用いましたが、どうやら`AssetReference`タイプは空のときな`null`ではなく`{[]null}`でした（VSCodeのデバッガから見た時の表示）。したがって、`AssetReference`が設定されているかどうかの判定は`RuntimeKeyValid()`に修正しました。皆さんも今後気をつけましょう。


### キャプチャ
設定されていない`AssetReference`の値をVSCodeのデバッガで見た結果
![image](https://user-images.githubusercontent.com/17778395/82142382-f14ade80-9876-11ea-9ba0-f56644eb3906.png)




### 動作確認方法
1-1をプレイし、エラーが出ないことを確認してください。


### 参考 URL
なし