### PR TITLE
fix specification of CustomTimer

### DIFF
--- a/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
+++ b/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
@@ -297,7 +297,6 @@ namespace Project.Scripts.GamePlayScene
                 // タイマー設定
                 _timerText = GameObject.Find(_TIMER_TEXT_NAME).GetComponent<Text>();
                 _customTimer = caller.gameObject.AddComponent<CustomTimer>();
-                _customTimer.enabled = false;
                 _customTimer.Initialize(_timerText);
 
                 // ステージID表示

--- a/Assets/Project/Scripts/Utils/CustomTimer.cs
+++ b/Assets/Project/Scripts/Utils/CustomTimer.cs
@@ -16,6 +16,11 @@ namespace Project.Scripts.Utils
         /// </summary>
         private double _second;
 
+        private void Awake()
+        {
+            enabled = false;
+        }
+
         /// <summary>
         /// 初期化 (表示 UI あり)
         /// </summary>


### PR DESCRIPTION
### 対象イシュー
Close #395 

### 概要
`CustomTimer` は `StartTimer`が呼ばれてから時間計るはずだが、ゲームオブジェクトにアタッチした直後に時間を計るようになっていたので、`StartTimer`が呼ばれてから時間を計るように修正する。

### 詳細
`CustomTimer`の`Awake`で`disabled`にする。
-> `StartTimer`が呼ばれるまでは非アクティブなので時間を計る関数である`Update`が呼ばれない。


#### 現実装になった経緯


#### 技術的な内容


### キャプチャ


### 動作確認方法


### 参考 URL
