### PR TITLE
fix Waring: ErrorLoadSceneFailed is not a valid enum value

### DIFF
--- a/Assets/Project/Scripts/Utils/Definitions/TextDefinitions.cs
+++ b/Assets/Project/Scripts/Utils/Definitions/TextDefinitions.cs
@@ -37,5 +37,6 @@ namespace Project.Scripts.Utils.Definitions
 
         ErrorTextStart = 10000, // ここからはエラーメッセージ
         ErrorUnknown = ErrorTextStart, // 不明なエラー
+        ErrorLoadSceneFailed, // ローディングが失敗しました
     }
 }


### PR DESCRIPTION
### 対象イシュー
Close #376 

### 概要
`Warning: ErrorLoadSceneFailed is not a valid enum value`を直す

### 詳細
`translation.csv`にある`ErrorLoadSceneFailed`が`ETextIndex`に定義されていなかったので追加することで直した。

#### 現実装になった経緯


#### 技術的な内容


### キャプチャ


### 動作確認方法
1. 一度`develop`ブランチで`Tools > Load Text`を実行し、ワーニングが出ることを確認する。
2. `git checkout "invalid/#376"`でブランチを切り替え、もう一度`Tools > Load Text`を実行し、ワーニングが出ないことを確認する。 

### 参考 URL
