### PR TITLE
ワープタイルが二回作られる問題を修正

### DIFF
--- a/Assets/Project/AddressableResources/GameDatas/Stages/1_1.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/1_1.asset
@@ -17,9 +17,6 @@ MonoBehaviour:
   - type: 1
     number: 1
     pairNumber: 2
-  - type: 1
-    number: 2
-    pairNumber: 1
   bottles:
   - type: 0
     initPos: 3

--- a/Assets/Project/Scripts/Editor/StageDataEditor.cs
+++ b/Assets/Project/Scripts/Editor/StageDataEditor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Project.Scripts.GameDatas;
 using Project.Scripts.Utils.Definitions;
 using UnityEditor;
@@ -47,6 +48,8 @@ namespace Project.Scripts.Editor
             DrawBulletGroupList();
 
             if (!EditorGUI.EndChangeCheck()) return;
+
+            ClearConsole();
 
             // Set object dirty, this will make it be saved after saving the project.
             EditorUtility.SetDirty(serializedObject.targetObject);
@@ -420,6 +423,14 @@ namespace Project.Scripts.Editor
         private IEnumerable<BottleData> GetAttackableBottles()
         {
             return _src.BottleDatas?.Where(x => x.type == EBottleType.Normal || x.type == EBottleType.Life);
+        }
+
+        private static void ClearConsole()
+        {
+            var assembly = Assembly.GetAssembly(typeof(UnityEditor.Editor));
+            var type = assembly.GetType("UnityEditor.LogEntries");
+            var method = type.GetMethod("Clear");
+            method.Invoke(new object(), null);
         }
     }
 }

--- a/Assets/Project/Scripts/Editor/StageDataEditor.cs
+++ b/Assets/Project/Scripts/Editor/StageDataEditor.cs
@@ -46,12 +46,39 @@ namespace Project.Scripts.Editor
 
             DrawBulletGroupList();
 
-            // Set object dirty, this will make it be saved after saving the project.
             if (!EditorGUI.EndChangeCheck()) return;
 
+            // Set object dirty, this will make it be saved after saving the project.
             EditorUtility.SetDirty(serializedObject.targetObject);
+
             serializedObject.ApplyModifiedProperties();
             _numOfAttackableBottles = GetAttackableBottles()?.Count() ?? 0;
+            ValidateTiles();
+        }
+
+        /// <summary>
+        /// タイル番号が被っているかを確認
+        /// </summary>
+        private void ValidateTiles()
+        {
+            var tiles = _src.TileDatas;
+
+            // 検証済みのタイル番号
+            HashSet<int> validatedTileNumbers = new HashSet<int>();
+
+            tiles.ForEach(tile => {
+                if (tile.number != 0 && validatedTileNumbers.Contains(tile.number)) {
+                    Debug.LogWarning($"Tile {tile.number} has already been set");
+                } else {
+                    validatedTileNumbers.Add(tile.number);
+                }
+
+                if (tile.pairNumber != 0 && validatedTileNumbers.Contains(tile.pairNumber)) {
+                    Debug.LogWarning($"Tile {tile.pairNumber} has already been set");
+                } else {
+                    validatedTileNumbers.Add(tile.pairNumber);
+                }
+            });
         }
 
         private void DrawTutorialData()


### PR DESCRIPTION
### 対象イシュー
Close #369 

### 概要
1ー1にてワープタイルが2対となって作成されていたので修正する。

### 詳細

#### 現実装になった経緯
ワープタイル作る際どちらか一つだけ設定すれば問題なく二つとも作られ、ステージ作成時に、全てのタイルの`pairNum` と `number`が被らなければいいことに気づきました。
したがって編集した後にタイルの番号を検証するように記述を加わりました。

#### 技術的な内容


### キャプチャ


### 動作確認方法
1-1 をプレイし、ワープタイルが二つだけ作成されたことを確認する。

現状：
![image](https://user-images.githubusercontent.com/17778395/82917052-d7637700-9fad-11ea-8a6e-bfd573820f3c.png)

修正後：
![image](https://user-images.githubusercontent.com/17778395/82916935-ab47f600-9fad-11ea-86ea-8eb574de75fa.png)


### 参考 URL
