### PR TITLE
【ステージ選択画面】木の間の遷移実装

### DIFF
--- a/Assets/Project/Scripts/StageSelectScene/StageSelectDirector.cs
+++ b/Assets/Project/Scripts/StageSelectScene/StageSelectDirector.cs
@@ -96,7 +96,7 @@ namespace Project.Scripts.StageSelectScene
             // ページ遷移時のイベント登録
             _snapScrollView.OnPageChanged += () => {
                 // 木IDを更新
-                treeId = (ETreeId)((_snapScrollView.Page + 1) + ((int)treeId / 1000));
+                treeId = (ETreeId)((_snapScrollView.Page + 1) + ((int)treeId / TreeInfo.MAX_TREE_NUM_IN_SEASON));
 
                 // ボタン表示/非表示
                 _leftButton.SetActive(_snapScrollView.Page != 0);
@@ -104,7 +104,7 @@ namespace Project.Scripts.StageSelectScene
             };
 
             // ページの設定
-            _snapScrollView.Page = (int)treeId % 1000 - 1;
+            _snapScrollView.Page = (int)treeId % TreeInfo.MAX_TREE_NUM_IN_SEASON - 1;
             _snapScrollView.RefreshPage(false);
 
             // UIの設定
@@ -125,9 +125,8 @@ namespace Project.Scripts.StageSelectScene
         /// <summary>
         /// ページ移動
         /// </summary>
-        /// <param name="displacement"> ページ移動量 </param>
-        /// <param name="isPlayAnimation"> アニメーション再生するか </param>
-        private void PageMove(int displacement)
+        /// <param name="displacement"> ページ数の増減量 </param>
+        private void MovePage(int displacement)
         {
             _snapScrollView.Page += displacement;
             _snapScrollView.Page = Mathf.Clamp(_snapScrollView.Page, 0, _snapScrollView.MaxPage);
@@ -181,7 +180,7 @@ namespace Project.Scripts.StageSelectScene
         public void LeftButtonDown()
         {
             // ページ数-1
-            PageMove(-1);
+            MovePage(-1);
         }
 
         /// <summary>
@@ -190,7 +189,7 @@ namespace Project.Scripts.StageSelectScene
         public void RightButtonDown()
         {
             // ページ数+1
-            PageMove(1);
+            MovePage(1);
         }
 
         /// <summary>

--- a/Assets/Project/Scripts/StageSelectScene/StageSelectDirector.cs
+++ b/Assets/Project/Scripts/StageSelectScene/StageSelectDirector.cs
@@ -104,8 +104,8 @@ namespace Project.Scripts.StageSelectScene
             };
 
             // ページの設定
-            var pageNum = (int)treeId % 1000;
-            SetPage(pageNum, false);
+            _snapScrollView.Page = (int)treeId % 1000 - 1;
+            _snapScrollView.RefreshPage(false);
 
             // UIの設定
             _treeName = GameObject.Find(_TREENAME);
@@ -123,17 +123,15 @@ namespace Project.Scripts.StageSelectScene
         }
 
         /// <summary>
-        /// ページ設定
+        /// ページ移動
         /// </summary>
-        /// <param name="pageNum"> ページ数(1から数える) </param>
+        /// <param name="displacement"> ページ移動量 </param>
         /// <param name="isPlayAnimation"> アニメーション再生するか </param>
-        private void SetPage(int pageNum, bool isPlayAnimation = true)
+        private void PageMove(int displacement)
         {
-            if (_snapScrollView.Page == pageNum - 1)
-                return;
-
-            _snapScrollView.Page = pageNum - 1;
-            _snapScrollView.RefreshPage(isPlayAnimation);
+            _snapScrollView.Page += displacement;
+            _snapScrollView.Page = Mathf.Clamp(_snapScrollView.Page, 0, _snapScrollView.MaxPage);
+            _snapScrollView.RefreshPage();
         }
 
         /// <summary>
@@ -182,8 +180,8 @@ namespace Project.Scripts.StageSelectScene
         /// </summary>
         public void LeftButtonDown()
         {
-            treeId -= 1;
-            SetPage((int)treeId % 1000);
+            // ページ数-1
+            PageMove(-1);
         }
 
         /// <summary>
@@ -191,8 +189,8 @@ namespace Project.Scripts.StageSelectScene
         /// </summary>
         public void RightButtonDown()
         {
-            treeId += 1;
-            SetPage((int)treeId % 1000);
+            // ページ数+1
+            PageMove(1);
         }
 
         /// <summary>

--- a/Assets/Project/Scripts/StageSelectScene/StageSelectDirector.cs
+++ b/Assets/Project/Scripts/StageSelectScene/StageSelectDirector.cs
@@ -131,13 +131,8 @@ namespace Project.Scripts.StageSelectScene
             if (_snapScrollView.Page == pageNum - 1)
                 return;
 
-            var pageWidth = _snapScrollView.PageSize;
-            var originalPos = _snapScrollView.content.localPosition;
-
             _snapScrollView.Page = pageNum - 1;
-            _snapScrollView.content.localPosition = new Vector2(pageWidth * (pageNum - 1), originalPos.y);
-            _snapScrollView.horizontalScrollbar.value = (float)(pageNum - 1) / (float)_snapScrollView.MaxPage;
-            _snapScrollView.RefreshPage(false);
+            _snapScrollView.RefreshPage(true);
         }
 
         /// <summary>

--- a/Assets/Project/Scripts/StageSelectScene/StageSelectDirector.cs
+++ b/Assets/Project/Scripts/StageSelectScene/StageSelectDirector.cs
@@ -105,7 +105,7 @@ namespace Project.Scripts.StageSelectScene
 
             // ページの設定
             var pageNum = (int)treeId % 1000;
-            SetPage(pageNum);
+            SetPage(pageNum, false);
 
             // UIの設定
             _treeName = GameObject.Find(_TREENAME);
@@ -126,13 +126,14 @@ namespace Project.Scripts.StageSelectScene
         /// ページ設定
         /// </summary>
         /// <param name="pageNum"> ページ数(1から数える) </param>
-        private void SetPage(int pageNum)
+        /// <param name="isPlayAnimation"> アニメーション再生するか </param>
+        private void SetPage(int pageNum, bool isPlayAnimation = true)
         {
             if (_snapScrollView.Page == pageNum - 1)
                 return;
 
             _snapScrollView.Page = pageNum - 1;
-            _snapScrollView.RefreshPage(true);
+            _snapScrollView.RefreshPage(isPlayAnimation);
         }
 
         /// <summary>

--- a/Assets/Project/Scripts/Utils/Definitions/TreeDefinitions.cs
+++ b/Assets/Project/Scripts/Utils/Definitions/TreeDefinitions.cs
@@ -25,6 +25,11 @@ namespace Project.Scripts.Utils.Definitions
     public static class TreeInfo
     {
         /// <summary>
+        /// 一季節が許容できる木の数
+        /// </summary>
+        public static int MAX_TREE_NUM_IN_SEASON = 1000;
+
+        /// <summary>
         /// ステージ数
         /// </summary>
         /// TODO: 実際にある木のステージ数で決める


### PR DESCRIPTION
### 対象イシュー
Close #432 

### 概要
`StageSelectScene` における同じ季節内の木の間の遷移実装

### 詳細

#### 現実装になった経緯
a7d623a 最初は瞬間移動でいいからとりあえずページサイズで計算して位置を設定する感じでやった
0c77362 これだけでアニメーションを再生することができると気づき、修正した
7933aa37 シーンに入る時もアニメーション再生すると少し違和感があるので、シーンに入る時だけ再生しないようにする

#### 技術的な内容
`SnapScrollView` を制御する方法

1. 遷移先の `Page` を設定する
2. `RefreshPage(isPlayAnimation)` を呼び出す 
> `isPlayAnimation` が `true` の場合、スムーズな遷移ができます

3. `RefreshPage` は `OnPageChange` を呼び出すので、そこでボタンの表示処理や木のIDの更新を行います

### キャプチャ


### 動作確認方法
1. Spring_1、Spring_2、Spring_3から StageSelectSceneに入り、正確の位置にスクロールしているかを確認
2. 右ボタン、左ボタンをクリックし、正確に遷移するか確認
3. フリックでも正常に動作するか確認


### 参考 URL
