### PR TITLE
StageDataがリセットされていない問題の修正

### DIFF
--- a/Assets/Project/Scripts/StageSelectScene/BranchController.cs
+++ b/Assets/Project/Scripts/StageSelectScene/BranchController.cs
@@ -19,6 +19,7 @@ namespace Project.Scripts.StageSelectScene
 
         protected override void Awake()
         {
+            base.Awake();
             _endObjectButton = endObject.GetComponent<Button>();
         }
 

--- a/Assets/Project/Scripts/Utils/PlayerPrefsUtils/StageStatus.cs
+++ b/Assets/Project/Scripts/Utils/PlayerPrefsUtils/StageStatus.cs
@@ -83,7 +83,7 @@ namespace Project.Scripts.Utils.PlayerPrefsUtils
             foreach (ETreeId treeId in Enum.GetValues(typeof(ETreeId))) {
                 var stageNum = TreeInfo.NUM[treeId];
 
-                Enumerable.Range(1, stageNum).ToList().ForEach(s => PlayerPrefs.DeleteKey(StageData.EncodeStageIdKey(treeId, s)));
+                Enumerable.Range(1, stageNum).ToList().ForEach(stageId => PlayerPrefs.DeleteKey(StageData.EncodeStageIdKey(treeId, stageId)));
             }
         }
 

--- a/Assets/Project/Scripts/Utils/PlayerPrefsUtils/StageStatus.cs
+++ b/Assets/Project/Scripts/Utils/PlayerPrefsUtils/StageStatus.cs
@@ -83,7 +83,7 @@ namespace Project.Scripts.Utils.PlayerPrefsUtils
             foreach (ETreeId treeId in Enum.GetValues(typeof(ETreeId))) {
                 var stageNum = TreeInfo.NUM[treeId];
 
-                Enumerable.Range(1, stageNum).ToList().ForEach(s => PlayerPrefs.DeleteKey(StageData.EncodeStageIdKey(treeId, stageNum)));
+                Enumerable.Range(1, stageNum).ToList().ForEach(s => PlayerPrefs.DeleteKey(StageData.EncodeStageIdKey(treeId, s)));
             }
         }
 


### PR DESCRIPTION
### 対象イシュー
Close #484

### 概要
- 4fdbab1 : StageDataのリセット時のindexが間違っており、リセットされていなかった問題を修正
- 2c121b9 : StageSelectSceneのBranchが正しく現在のStageのクリア状況を参照できていなかった問題を修正

### 補足
- Spring_3-1など、まだステージが作成されていない木の"1"のStageは鍵画像がついていますが、そもそもステージが無いので、ステージの解放とかの処理が走っていない正常な挙動です。
- Spring3-2など、まだステージが作成されていない木だが、鍵がついてないStageは、"2"番のStageを終点とするBranchがステージを解放しているので鍵がついていません。こちらも正常な挙動です。
- developでSpring_1-1クリア後、リセット→MenuSelectScene→SettingScene→MenuSelectSceneと遷移すると、木は解放されているけれどRoadが黒いままです。Roadも解放状態にはなっていますが、一度色を変更したものを戻していないためです。MenuSelectSceneから遷移することなくStageがクリアされていること(現在のバグ)は想定していないので、色を戻す、という処理自体を想定していません。こちらも正常な挙動です。

### キャプチャ
修正前  : データリセット直後
<img width="272" alt="スクリーンショット 2020-07-18 8 36 25" src="https://user-images.githubusercontent.com/26213141/87838839-4638be80-c8d3-11ea-9419-57b4e0fb0c2b.png"><img width="269" alt="スクリーンショット 2020-07-18 8 36 34" src="https://user-images.githubusercontent.com/26213141/87838845-489b1880-c8d3-11ea-838a-805638da74ba.png">

修正後 : データリセット直後
<img width="273" alt="スクリーンショット 2020-07-18 8 34 44" src="https://user-images.githubusercontent.com/26213141/87838830-3d47ed00-c8d3-11ea-93c2-09b823d160ef.png"><img width="270" alt="スクリーンショット 2020-07-18 8 34 51" src="https://user-images.githubusercontent.com/26213141/87838831-3f11b080-c8d3-11ea-9b77-05fe45c547b0.png">


### 動作確認方法

- [ ] developでSpring_1-1クリア後にリセットしてキャプチャ状態になることを確認

- [ ] branchでSpring_1-1クリア後にリセットしてキャプチャ状態になることを確認
