### PR TITLE
【GameplayScene】竜巻初期位置の修正

### DIFF
--- a/Assets/Project/Scripts/GamePlayScene/Gimmick/TornadoController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Gimmick/TornadoController.cs
@@ -74,6 +74,11 @@ namespace Project.Scripts.GamePlayScene.Gimmick
         /// </summary>
         private GameObject _warningObj;
 
+        /// <summary>
+        /// 警告のオフセット（ウィンドウの幅に対する比率）
+        /// </summary>
+        private const float _WARNING_OFFSET_RATIO = 0.16f;
+
         private void Awake()
         {
             _rigidBody = GetComponent<Rigidbody2D>();
@@ -315,7 +320,8 @@ namespace Project.Scripts.GamePlayScene.Gimmick
                 throw new NotImplementedException();
             }
             // 画面端から、警告の幅(or高さ)/2の分だけ画面内に移動させた座標に警告を配置
-            warningPosition += Vector2.Scale(motionVector, new Vector2(CartridgeWarningSize.POSITION_X, CartridgeWarningSize.POSITION_Y)) / 2;
+            var warningOffset = WindowSize.WIDTH * _WARNING_OFFSET_RATIO;
+            warningPosition += Vector2.Scale(motionVector, new Vector2(warningOffset, warningOffset)) / 2;
             return warningPosition;
         }
 
@@ -352,15 +358,16 @@ namespace Project.Scripts.GamePlayScene.Gimmick
         private void SetInitialPosition(ETornadoDirection direction, int line)
         {
             float x = 0, y = 0;
+            var tornadoSize = GetComponent<SpriteRenderer>().size;
             if (IsHorizontal(direction)) {
                 // 目標列の一番右端のタイルのY座標を取得
                 var tileNum = line * StageSize.COLUMN;
                 y = BoardManager.Instance.GetTilePos(tileNum).y;
 
                 if (direction == ETornadoDirection.ToLeft) {
-                    x = (WindowSize.WIDTH + CartridgeSize.WIDTH) / 2;
+                    x = (WindowSize.WIDTH + tornadoSize.x) / 2;
                 } else {
-                    x = -(WindowSize.WIDTH + CartridgeSize.WIDTH) / 2;
+                    x = -(WindowSize.WIDTH + tornadoSize.x) / 2;
                 }
             } else if (IsVertical(direction)) {
                 // 目標行の一列目のタイルのx座標を取得
@@ -368,9 +375,9 @@ namespace Project.Scripts.GamePlayScene.Gimmick
                 x = BoardManager.Instance.GetTilePos(tileNum).x;
 
                 if (direction == ETornadoDirection.ToUp) {
-                    y = -(WindowSize.HEIGHT + CartridgeSize.HEIGHT) / 2;
+                    y = -(WindowSize.HEIGHT + tornadoSize.y) / 2;
                 } else {
-                    y = (WindowSize.HEIGHT + CartridgeSize.HEIGHT) / 2;
+                    y = (WindowSize.HEIGHT + tornadoSize.y) / 2;
                 }
             } else {
                 throw new NotImplementedException();

--- a/Assets/Project/Scripts/Utils/Definitions/SizeDefinitions.cs
+++ b/Assets/Project/Scripts/Utils/Definitions/SizeDefinitions.cs
@@ -38,26 +38,6 @@ namespace Project.Scripts.Utils.Definitions
     }
 
     /// <summary>
-    /// Cartridge タイプの銃弾の大きさ
-    /// </summary>
-    public static class CartridgeSize
-    {
-        public const float WIDTH = WindowSize.WIDTH * 0.15f;
-        public const float HEIGHT = WIDTH / 3.0f;
-    }
-
-    /// <summary>
-    /// Cartridge タイプの銃弾警告の大きさ
-    /// </summary>
-    public static class CartridgeWarningSize
-    {
-        public const float WIDTH = WindowSize.WIDTH * 0.15f;
-        public const float HEIGHT = WIDTH;
-        public const float POSITION_X = WindowSize.WIDTH * 0.16f;
-        public const float POSITION_Y = POSITION_X;
-    }
-
-    /// <summary>
     /// Hole タイプの銃弾警告の大きさ
     /// </summary>
     public static class HoleWarningSize


### PR DESCRIPTION
refactoring to remove cartridge relation codes

### 対象イシュー
Close #289 

### 概要

#289 で報告したバグは発生していないが、キャプチャの画像のように、上下方向の竜巻の初期位置がズレる問題があるので、修正します。

### 詳細

#### 現実装になった経緯
* バグの原因：
    * 竜巻の初期化で使ってる `CartridgeSize`は従来の銃弾用のサイズのため、`HIEGHT`が今使ってる画像より短い。
    * 今は画像の大きさは`SizeDefinition`で定義するではなく、`ObjectUnifier`にて制御している。

* 解決方法：
    * 位置の初期化の際、`SpriteRender`から最適化された画像のサイズを取得

* その他：
`CartridgeSize`と`CartridgeWarningSize`が存在するのはおかしいのでそれらを削除し、該当する場所を書き換えました。

#### 技術的な内容


### キャプチャ
![F71B6391-FFAB-44B4-A996-A50395075559](https://user-images.githubusercontent.com/17778395/89730302-74e02a00-da78-11ea-8277-2e54ff2a896c.png)



### 動作確認方法
`Spring_1-2`と`Sprint_1-6`をプレイ、おかしいな挙動がないことを確認してください。

### 参考 URL
