### PR TITLE
拡大縮小時に道の太さを調整する

### DIFF
--- a/Assets/Project/Scenes/MenuSelectScene.unity
+++ b/Assets/Project/Scenes/MenuSelectScene.unity
@@ -2166,6 +2166,11 @@ PrefabInstance:
       propertyPath: endObject
       value: 
       objectReference: {fileID: 577116084}
+    - target: {fileID: 4879365460225979789, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
+        type: 3}
+      propertyPath: width
+      value: 0.03
+      objectReference: {fileID: 0}
     - target: {fileID: 6435458436284193576, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_Name
@@ -3045,6 +3050,11 @@ PrefabInstance:
       propertyPath: endObject
       value: 
       objectReference: {fileID: 298569367}
+    - target: {fileID: 4879365460225979789, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
+        type: 3}
+      propertyPath: width
+      value: 0.03
+      objectReference: {fileID: 0}
     - target: {fileID: 6435458436284193576, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_Name
@@ -4673,6 +4683,11 @@ PrefabInstance:
       propertyPath: constraintObjects.Array.data[0]
       value: 
       objectReference: {fileID: 1980677753}
+    - target: {fileID: 4879365460225979789, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
+        type: 3}
+      propertyPath: width
+      value: 0.03
+      objectReference: {fileID: 0}
     - target: {fileID: 6435458436284193576, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_Name
@@ -5014,6 +5029,11 @@ PrefabInstance:
       propertyPath: constraintObjects.Array.data[0]
       value: 
       objectReference: {fileID: 1444357907}
+    - target: {fileID: 4879365460225979789, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
+        type: 3}
+      propertyPath: width
+      value: 0.05
+      objectReference: {fileID: 0}
     - target: {fileID: 6435458436284193576, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_Name
@@ -5332,6 +5352,11 @@ PrefabInstance:
       propertyPath: endObject
       value: 
       objectReference: {fileID: 1431962647}
+    - target: {fileID: 4879365460225979789, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
+        type: 3}
+      propertyPath: width
+      value: 0.05
+      objectReference: {fileID: 0}
     - target: {fileID: 6435458436284193576, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_Name
@@ -7270,6 +7295,11 @@ PrefabInstance:
       propertyPath: endObject
       value: 
       objectReference: {fileID: 1444357907}
+    - target: {fileID: 4879365460225979789, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
+        type: 3}
+      propertyPath: width
+      value: 0.05
+      objectReference: {fileID: 0}
     - target: {fileID: 6435458436284193576, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_Name
@@ -8392,6 +8422,11 @@ PrefabInstance:
       propertyPath: endObject
       value: 
       objectReference: {fileID: 207612754}
+    - target: {fileID: 4879365460225979789, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
+        type: 3}
+      propertyPath: width
+      value: 0.03
+      objectReference: {fileID: 0}
     - target: {fileID: 6435458436284193576, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_Name
@@ -9524,6 +9559,11 @@ PrefabInstance:
       propertyPath: endObject
       value: 
       objectReference: {fileID: 376709737}
+    - target: {fileID: 4879365460225979789, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
+        type: 3}
+      propertyPath: width
+      value: 0.03
+      objectReference: {fileID: 0}
     - target: {fileID: 6435458436284193576, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_Name
@@ -12073,6 +12113,11 @@ PrefabInstance:
       propertyPath: constraintObjects.Array.data[0]
       value: 
       objectReference: {fileID: 1980677753}
+    - target: {fileID: 4879365460225979789, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
+        type: 3}
+      propertyPath: width
+      value: 0.03
+      objectReference: {fileID: 0}
     - target: {fileID: 6435458436284193576, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_Name
@@ -12758,6 +12803,11 @@ PrefabInstance:
       propertyPath: endObject
       value: 
       objectReference: {fileID: 1729005524}
+    - target: {fileID: 4879365460225979789, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
+        type: 3}
+      propertyPath: width
+      value: 0.03
+      objectReference: {fileID: 0}
     - target: {fileID: 6435458436284193576, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_Name
@@ -13144,6 +13194,11 @@ PrefabInstance:
       propertyPath: endObject
       value: 
       objectReference: {fileID: 1560756402}
+    - target: {fileID: 4879365460225979789, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
+        type: 3}
+      propertyPath: width
+      value: 0.03
+      objectReference: {fileID: 0}
     - target: {fileID: 6435458436284193576, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_Name
@@ -14443,6 +14498,11 @@ PrefabInstance:
       propertyPath: constraintObjects.Array.data[0]
       value: 
       objectReference: {fileID: 1980677753}
+    - target: {fileID: 4879365460225979789, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
+        type: 3}
+      propertyPath: width
+      value: 0.05
+      objectReference: {fileID: 0}
     - target: {fileID: 6435458436284193576, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_Name

--- a/Assets/Project/Scripts/MenuSelectScene/LevelSelect/LevelSelectDirector.cs
+++ b/Assets/Project/Scripts/MenuSelectScene/LevelSelect/LevelSelectDirector.cs
@@ -50,5 +50,14 @@ namespace Project.Scripts.MenuSelectScene.LevelSelect
             _trees.ForEach(tree => tree.Reset());
             _roads.ForEach(road => road.Reset());
         }
+
+        /// <summary>
+        /// 道の幅の変更
+        /// </summary>
+        /// <param name="scale"> 拡大率 </param>
+        public void ScaleRoad(float scale)
+        {
+            _roads.ForEach(road => road.ScaleWidth(scale));
+        }
     }
 }

--- a/Assets/Project/Scripts/MenuSelectScene/LevelSelect/LineController.cs
+++ b/Assets/Project/Scripts/MenuSelectScene/LevelSelect/LineController.cs
@@ -39,7 +39,7 @@ namespace Project.Scripts.MenuSelectScene.LevelSelect
         /// <summary>
         /// 道の幅
         /// </summary>
-        [SerializeField] [Range(0, 0.2f)] private float _width;
+        [SerializeField] [Range(0, 0.2f)] protected float width;
 
         /// <summary>
         /// 道の長さ
@@ -85,7 +85,7 @@ namespace Project.Scripts.MenuSelectScene.LevelSelect
         {
             if (lineRenderer == null) return;
             lineRenderer.positionCount = _middlePointNum + 2;
-            lineRenderer.startWidth = lineRenderer.endWidth = (float)Screen.width * _width;
+            lineRenderer.startWidth = lineRenderer.endWidth = (float)Screen.width * width;
 
             var startPointLocalPosition = startObject.transform.localPosition;
             var endPointLocalPosition = endObject.transform.localPosition;

--- a/Assets/Project/Scripts/MenuSelectScene/LevelSelect/LineController.cs
+++ b/Assets/Project/Scripts/MenuSelectScene/LevelSelect/LineController.cs
@@ -1,5 +1,4 @@
 ﻿using UnityEngine;
-using UnityEngine.UI;
 
 namespace Project.Scripts.MenuSelectScene.LevelSelect
 {

--- a/Assets/Project/Scripts/MenuSelectScene/LevelSelect/RoadController.cs
+++ b/Assets/Project/Scripts/MenuSelectScene/LevelSelect/RoadController.cs
@@ -93,7 +93,6 @@ namespace Project.Scripts.MenuSelectScene.LevelSelect
         /// <param name="scale"> 拡大率 </param>
         public void ScaleWidth(float scale)
         {
-            Debug.Log(scale);
             lineRenderer.startWidth = lineRenderer.endWidth = (float)Screen.width * width * scale;
         }
     }

--- a/Assets/Project/Scripts/MenuSelectScene/LevelSelect/RoadController.cs
+++ b/Assets/Project/Scripts/MenuSelectScene/LevelSelect/RoadController.cs
@@ -86,5 +86,15 @@ namespace Project.Scripts.MenuSelectScene.LevelSelect
         {
             PlayerPrefs.SetInt(saveKey, Convert.ToInt32(released));
         }
+
+        /// <summary>
+        /// 線の幅の変更
+        /// </summary>
+        /// <param name="scale"> 拡大率 </param>
+        public void ScaleWidth(float scale)
+        {
+            Debug.Log(scale);
+            lineRenderer.startWidth = lineRenderer.endWidth = (float)Screen.width * width * scale;
+        }
     }
 }

--- a/Assets/Project/Scripts/MenuSelectScene/ScaleContent.cs
+++ b/Assets/Project/Scripts/MenuSelectScene/ScaleContent.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Linq;
 using TouchScript.Gestures.TransformGestures;
 using UnityEngine;
 using UnityEngine.UI;
-using Project.Scripts.UIComponents;
 using Project.Scripts.MenuSelectScene.LevelSelect;
 using Project.Scripts.Utils.Definitions;
 using Project.Scripts.Utils.PlayerPrefsUtils;

--- a/Assets/Project/Scripts/MenuSelectScene/ScaleContent.cs
+++ b/Assets/Project/Scripts/MenuSelectScene/ScaleContent.cs
@@ -4,6 +4,7 @@ using TouchScript.Gestures.TransformGestures;
 using UnityEngine;
 using UnityEngine.UI;
 using Project.Scripts.UIComponents;
+using Project.Scripts.MenuSelectScene.LevelSelect;
 using Project.Scripts.Utils.Definitions;
 using Project.Scripts.Utils.PlayerPrefsUtils;
 
@@ -98,6 +99,8 @@ namespace Project.Scripts.MenuSelectScene
             _newScale = Mathf.Clamp(_newScale, _SCALE_MIN, _SCALE_MAX);
             // Contentの拡大縮小
             _contentRect.localScale = new Vector2(_newScale, _newScale);
+            // 道の拡大縮小
+            LevelSelectDirector.Instance.ScaleRoad(_newScale);
 
             // 拡大縮小前の中点を拡大縮小後の中点に合わせるようにContentの平行移動量を求める
             var _preContentPoint = ConvertFromScreenToContent(_preMeanPoint, _preScale);

--- a/Assets/Project/Scripts/MenuSelectScene/ScaleContent.cs
+++ b/Assets/Project/Scripts/MenuSelectScene/ScaleContent.cs
@@ -60,6 +60,8 @@ namespace Project.Scripts.MenuSelectScene
         {
             _preScale = UserSettings.LevelSelectCanvasScale;
             _contentRect.localScale = new Vector2(_preScale, _preScale);
+            // 道の拡大縮小
+            LevelSelectDirector.Instance.ScaleRoad(_preScale);
             // 2点のタッチ開始時
             _transformGesture.TransformStarted += OnTransformStarted;
             // 2点のタッチ中


### PR DESCRIPTION
### 対象イシュー
Close #491

### 概要
ピンチイン・ピンチアウトに伴う拡大率を道の幅にも適用する

### 詳細
特になし

#### 現実装になった経緯
特になし

#### 技術的な内容
特になし

### キャプチャ
変更前
<img width="218" alt="スクリーンショット 2020-08-17 22 03 58" src="https://user-images.githubusercontent.com/26213141/90399770-7643cf00-e0d6-11ea-8675-e744fa28868c.png"><img width="221" alt="スクリーンショット 2020-08-17 22 04 09" src="https://user-images.githubusercontent.com/26213141/90399774-780d9280-e0d6-11ea-8a48-0535b24d0092.png"><img width="222" alt="スクリーンショット 2020-08-17 22 04 20" src="https://user-images.githubusercontent.com/26213141/90399779-7a6fec80-e0d6-11ea-884b-26e42cd573ed.png">

変更後
<img width="218" alt="スクリーンショット 2020-08-17 22 03 19" src="https://user-images.githubusercontent.com/26213141/90399822-8a87cc00-e0d6-11ea-9f81-3fbb9dec30fe.png"><img width="219" alt="スクリーンショット 2020-08-17 22 02 46" src="https://user-images.githubusercontent.com/26213141/90399830-8cea2600-e0d6-11ea-8247-009a8beec29f.png"><img width="222" alt="スクリーンショット 2020-08-17 22 02 57" src="https://user-images.githubusercontent.com/26213141/90399832-8eb3e980-e0d6-11ea-926a-452f3041da1f.png">


### 動作確認方法

- [ ] LevelSelectSceneでピンチインやピンチアウトを行い、道の幅も変化することを確認する

- [ ] 別のSceneから戻ってきた時も、道の幅が保たれていることを確認する

- [ ] リセットした時に、拡大率がデフォルト値に戻ることに伴い、道の幅もデフォルトの幅になることを確認する

### 参考 URL
