### PR TITLE
デフォルトボタン押下時に，更新されない問題を解決

### DIFF
--- a/Assets/Project/Scripts/MenuSelectScene/Settings/ToDefaultController.cs
+++ b/Assets/Project/Scripts/MenuSelectScene/Settings/ToDefaultController.cs
@@ -17,9 +17,8 @@ namespace Project.Scripts.MenuSelectScene.Settings
         /// </summary>
         public void ToDefaultButtonDown()
         {
-            PlayerPrefs.DeleteKey(PlayerPrefsKeys.BGM_VOLUME);
-            PlayerPrefs.DeleteKey(PlayerPrefsKeys.SE_VOLUME);
-            PlayerPrefs.DeleteKey(PlayerPrefsKeys.STAGE_DETAILS);
+            // 設定の更新
+            UserSettings.ToDefault();
 
             // Canvasの更新
             OnUpdate?.Invoke();

--- a/Assets/Project/Scripts/Utils/PlayerPrefsUtils/UserSettings.cs
+++ b/Assets/Project/Scripts/Utils/PlayerPrefsUtils/UserSettings.cs
@@ -93,5 +93,16 @@ namespace Project.Scripts.Utils.PlayerPrefsUtils
                 _levelSelectScrollPosition = Default.LEVEL_SELECT_SCROLL_POSITION;
             }
         }
+
+        public static void ToDefault()
+        {
+            PlayerPrefs.DeleteKey(PlayerPrefsKeys.BGM_VOLUME);
+            PlayerPrefs.DeleteKey(PlayerPrefsKeys.SE_VOLUME);
+            PlayerPrefs.DeleteKey(PlayerPrefsKeys.STAGE_DETAILS);
+
+            BGMVolume = Default.BGM_VOLUME;
+            SEVolume = Default.SE_VOLUME;
+            StageDetails = Default.STAGE_DETAILS;
+        }
     }
 }


### PR DESCRIPTION
### 対象イシュー
Close #449 

### 概要
- デフォルトボタン押下時に，更新がうまくいっていなかった
- おそらく，PlayerPrefs の管理を UserSettings に任せたタスクの時に追従していなかったことが原因
- UserSettings でデフォルトにしたい値を更新する

### 動作確認方法
- [x] デフォルトボタン押下時に，BGM がデフォルトになり，設定画面でも即座にその内容が反映される
- [x] デフォルトボタン押下時に，SE がデフォルトになり，設定画面でも即座にその内容が反映される
- [x] デフォルトボタン押下時に，ステージ概要表示有無がデフォルトになる