### PR TITLE
仮ステージデータ作成

### DIFF
--- a/Assets/AddressableAssetsData/AssetGroups/Default Local Group.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Default Local Group.asset
@@ -45,8 +45,8 @@ MonoBehaviour:
     m_Address: SummerStageSelectScene
     m_ReadOnly: 0
     m_SerializedLabels: []
-    m_MainAsset: {fileID: 0}
-    m_TargetAsset: {fileID: 0}
+    m_MainAsset: {fileID: 102900000, guid: 2e3f7758a15714f3795287619f50fc82, type: 3}
+    m_TargetAsset: {fileID: 102900000, guid: 2e3f7758a15714f3795287619f50fc82, type: 3}
   - m_GUID: 358175ea13e4e4b71ad0826173ab32a8
     m_Address: AimingMeteoriteWarningPrefab
     m_ReadOnly: 0

--- a/Assets/AddressableAssetsData/AssetGroups/Default Local Group.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Default Local Group.asset
@@ -141,8 +141,10 @@ MonoBehaviour:
     m_Address: Assets/Project/Prefabs/ProgressBar.prefab
     m_ReadOnly: 0
     m_SerializedLabels: []
-    m_MainAsset: {fileID: 0}
-    m_TargetAsset: {fileID: 0}
+    m_MainAsset: {fileID: 8871262989416576049, guid: c992eb222563c460d84bff90f23a0b42,
+      type: 3}
+    m_TargetAsset: {fileID: 8871262989416576049, guid: c992eb222563c460d84bff90f23a0b42,
+      type: 3}
   - m_GUID: cc35221e1f2c54ae8ba023299eb797d3
     m_Address: StaticDummyBottlePrefab
     m_ReadOnly: 0

--- a/Assets/AddressableAssetsData/AssetGroups/Stages.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Stages.asset
@@ -143,6 +143,13 @@ MonoBehaviour:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 1d155e30b0ef04023bdd2068ebf80cfe, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 1d155e30b0ef04023bdd2068ebf80cfe, type: 2}
+  - m_GUID: 22620e28274b34eb5a6adee4ad8d978f
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Spring_2/8.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 22620e28274b34eb5a6adee4ad8d978f, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 22620e28274b34eb5a6adee4ad8d978f, type: 2}
   - m_GUID: 22f7806eb7ae946fbafa303cabb4c9d6
     m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/9.asset
     m_ReadOnly: 0
@@ -164,6 +171,13 @@ MonoBehaviour:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 2745de03d7ff643ee95a086856467d66, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 2745de03d7ff643ee95a086856467d66, type: 2}
+  - m_GUID: 2b0f0ed5e8f584538a96202e6c80c1dd
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Spring_2/6.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 2b0f0ed5e8f584538a96202e6c80c1dd, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 2b0f0ed5e8f584538a96202e6c80c1dd, type: 2}
   - m_GUID: 2b6133b0009a74657b01d3d67d3eba5a
     m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/6.asset
     m_ReadOnly: 0
@@ -206,6 +220,13 @@ MonoBehaviour:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 37d4ea8bb421849a08aa1a0100c209ab, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 37d4ea8bb421849a08aa1a0100c209ab, type: 2}
+  - m_GUID: 39c057e840ea0430694ebaaaed8181eb
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Spring_2/10.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 39c057e840ea0430694ebaaaed8181eb, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 39c057e840ea0430694ebaaaed8181eb, type: 2}
   - m_GUID: 3da906b1e1316489b82a2a3627e6b8fd
     m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/7.asset
     m_ReadOnly: 0
@@ -556,6 +577,13 @@ MonoBehaviour:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: a21354950a4994e52b7d942f44b3d68f, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: a21354950a4994e52b7d942f44b3d68f, type: 2}
+  - m_GUID: a35f83a63b9b9421f9d8f009d61c07ba
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Spring_2/9.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: a35f83a63b9b9421f9d8f009d61c07ba, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: a35f83a63b9b9421f9d8f009d61c07ba, type: 2}
   - m_GUID: a4c285a06fb704ddcb1661f4622c9e4c
     m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/3.asset
     m_ReadOnly: 0
@@ -794,6 +822,13 @@ MonoBehaviour:
     - Stage
     m_MainAsset: {fileID: 0}
     m_TargetAsset: {fileID: 0}
+  - m_GUID: f34525bb49daa4dbe8120f5c7c7bb4fe
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Spring_2/7.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: f34525bb49daa4dbe8120f5c7c7bb4fe, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: f34525bb49daa4dbe8120f5c7c7bb4fe, type: 2}
   - m_GUID: f4eafd6ad27cc4199927a936493093d5
     m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/9.asset
     m_ReadOnly: 0

--- a/Assets/AddressableAssetsData/AssetGroups/Stages.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Stages.asset
@@ -24,13 +24,48 @@ MonoBehaviour:
     - Stage
     m_MainAsset: {fileID: 0}
     m_TargetAsset: {fileID: 0}
+  - m_GUID: 01f93f152261349ae881c2ca6a33b25e
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/6.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 01f93f152261349ae881c2ca6a33b25e, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 01f93f152261349ae881c2ca6a33b25e, type: 2}
+  - m_GUID: 02de8ace75fcc4965890ae9f94f3a684
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/3.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 02de8ace75fcc4965890ae9f94f3a684, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 02de8ace75fcc4965890ae9f94f3a684, type: 2}
   - m_GUID: 037fdc96989f249339fc86425cee7575
     m_Address: Assets/Project/Resources_moved/GameDatas/Stages/Spring_2/3.asset
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
-    m_MainAsset: {fileID: 11400000, guid: 037fdc96989f249339fc86425cee7575, type: 2}
-    m_TargetAsset: {fileID: 11400000, guid: 037fdc96989f249339fc86425cee7575, type: 2}
+    m_MainAsset: {fileID: 0}
+    m_TargetAsset: {fileID: 0}
+  - m_GUID: 0803662de3aa547e18c189c71cf1bfb4
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/4.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 0803662de3aa547e18c189c71cf1bfb4, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 0803662de3aa547e18c189c71cf1bfb4, type: 2}
+  - m_GUID: 0bc92b8a7da1e45efbf4679a09dc061c
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/5.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 0bc92b8a7da1e45efbf4679a09dc061c, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 0bc92b8a7da1e45efbf4679a09dc061c, type: 2}
+  - m_GUID: 0bd474522d9ca4d1db47f29462e3b38e
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/9.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 0bd474522d9ca4d1db47f29462e3b38e, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 0bd474522d9ca4d1db47f29462e3b38e, type: 2}
   - m_GUID: 0d4ae34c0c5f94dd18575192c4afb966
     m_Address: Assets/Project/Resources_moved/GameDatas/Stages/Spring_2/5.asset
     m_ReadOnly: 0
@@ -38,6 +73,111 @@ MonoBehaviour:
     - Stage
     m_MainAsset: {fileID: 0}
     m_TargetAsset: {fileID: 0}
+  - m_GUID: 0de39bb1cabf246aab07596b1072bf21
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/1.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 0de39bb1cabf246aab07596b1072bf21, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 0de39bb1cabf246aab07596b1072bf21, type: 2}
+  - m_GUID: 0e581ecef079943e18b670c5764dec27
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/6.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 0e581ecef079943e18b670c5764dec27, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 0e581ecef079943e18b670c5764dec27, type: 2}
+  - m_GUID: 0f32f060f67b642cd9faa81cbbcd9b44
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/3.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 0f32f060f67b642cd9faa81cbbcd9b44, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 0f32f060f67b642cd9faa81cbbcd9b44, type: 2}
+  - m_GUID: 107509ec6a7aa488ab7c029317f1aa49
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/2.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 107509ec6a7aa488ab7c029317f1aa49, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 107509ec6a7aa488ab7c029317f1aa49, type: 2}
+  - m_GUID: 10c44a0932bf9425eae65ee4e416f8e4
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/5.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 10c44a0932bf9425eae65ee4e416f8e4, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 10c44a0932bf9425eae65ee4e416f8e4, type: 2}
+  - m_GUID: 15f93d76cf77b43c08372ec474a2b09c
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/6.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 15f93d76cf77b43c08372ec474a2b09c, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 15f93d76cf77b43c08372ec474a2b09c, type: 2}
+  - m_GUID: 1635a896ae6c24e4c8dd4bb047ed1a07
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/1.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 1635a896ae6c24e4c8dd4bb047ed1a07, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 1635a896ae6c24e4c8dd4bb047ed1a07, type: 2}
+  - m_GUID: 1a71fda93879742fd80ac2996775f5f6
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/2.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 1a71fda93879742fd80ac2996775f5f6, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 1a71fda93879742fd80ac2996775f5f6, type: 2}
+  - m_GUID: 1b5e2d1cda1e24f7f854f687e3e9ed21
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/4.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 1b5e2d1cda1e24f7f854f687e3e9ed21, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 1b5e2d1cda1e24f7f854f687e3e9ed21, type: 2}
+  - m_GUID: 1d155e30b0ef04023bdd2068ebf80cfe
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/2.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 1d155e30b0ef04023bdd2068ebf80cfe, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 1d155e30b0ef04023bdd2068ebf80cfe, type: 2}
+  - m_GUID: 22f7806eb7ae946fbafa303cabb4c9d6
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/9.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 22f7806eb7ae946fbafa303cabb4c9d6, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 22f7806eb7ae946fbafa303cabb4c9d6, type: 2}
+  - m_GUID: 255877b8fcb134e278a0ce9db6790033
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/5.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 255877b8fcb134e278a0ce9db6790033, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 255877b8fcb134e278a0ce9db6790033, type: 2}
+  - m_GUID: 2745de03d7ff643ee95a086856467d66
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/8.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 2745de03d7ff643ee95a086856467d66, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 2745de03d7ff643ee95a086856467d66, type: 2}
+  - m_GUID: 2b6133b0009a74657b01d3d67d3eba5a
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/6.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 2b6133b0009a74657b01d3d67d3eba5a, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 2b6133b0009a74657b01d3d67d3eba5a, type: 2}
+  - m_GUID: 2c2a97f3c0270410a9637014bec103a1
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/8.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 2c2a97f3c0270410a9637014bec103a1, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 2c2a97f3c0270410a9637014bec103a1, type: 2}
   - m_GUID: 2f545b4136ab948c4afda14881b0af7a
     m_Address: Assets/Project/Resources_moved/GameDatas/Stages/Spring_1/10.asset
     m_ReadOnly: 0
@@ -52,6 +192,41 @@ MonoBehaviour:
     - Stage
     m_MainAsset: {fileID: 0}
     m_TargetAsset: {fileID: 0}
+  - m_GUID: 37514a6ee75ca4331bdd27786759857c
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/8.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 37514a6ee75ca4331bdd27786759857c, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 37514a6ee75ca4331bdd27786759857c, type: 2}
+  - m_GUID: 37d4ea8bb421849a08aa1a0100c209ab
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/2.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 37d4ea8bb421849a08aa1a0100c209ab, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 37d4ea8bb421849a08aa1a0100c209ab, type: 2}
+  - m_GUID: 3da906b1e1316489b82a2a3627e6b8fd
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/7.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 3da906b1e1316489b82a2a3627e6b8fd, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 3da906b1e1316489b82a2a3627e6b8fd, type: 2}
+  - m_GUID: 3fdcf0ca585b4447c9174093d38d2b9e
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/7.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 3fdcf0ca585b4447c9174093d38d2b9e, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 3fdcf0ca585b4447c9174093d38d2b9e, type: 2}
+  - m_GUID: 3ff1c067532fd47d8ba97dc8f33db3fb
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/2.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 3ff1c067532fd47d8ba97dc8f33db3fb, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 3ff1c067532fd47d8ba97dc8f33db3fb, type: 2}
   - m_GUID: 40c99fbdab68644d1a2d673f6b8b6ff3
     m_Address: Assets/Project/Resources_moved/GameDatas/Stages/Spring_1/8.asset
     m_ReadOnly: 0
@@ -66,6 +241,55 @@ MonoBehaviour:
     - Stage
     m_MainAsset: {fileID: 0}
     m_TargetAsset: {fileID: 0}
+  - m_GUID: 42be2fc124fca48bc92f392791afd6b6
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/7.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 42be2fc124fca48bc92f392791afd6b6, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 42be2fc124fca48bc92f392791afd6b6, type: 2}
+  - m_GUID: 44671f370928842fd911445471f8fdd9
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/10.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 44671f370928842fd911445471f8fdd9, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 44671f370928842fd911445471f8fdd9, type: 2}
+  - m_GUID: 46cb4002c76c746a1a9c146866fd5fac
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/1.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 46cb4002c76c746a1a9c146866fd5fac, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 46cb4002c76c746a1a9c146866fd5fac, type: 2}
+  - m_GUID: 47e8649d5d99c4c3db9095c7ad35d33e
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/1.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 47e8649d5d99c4c3db9095c7ad35d33e, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 47e8649d5d99c4c3db9095c7ad35d33e, type: 2}
+  - m_GUID: 4cebcc594ae334ca1ac94f3718723332
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/9.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 4cebcc594ae334ca1ac94f3718723332, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 4cebcc594ae334ca1ac94f3718723332, type: 2}
+  - m_GUID: 4d5678a326a7c47eaaf1f6759ac5dcb2
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/8.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 4d5678a326a7c47eaaf1f6759ac5dcb2, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 4d5678a326a7c47eaaf1f6759ac5dcb2, type: 2}
+  - m_GUID: 4df4aa6dd529b48039a1eb1231d3f654
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/6.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 4df4aa6dd529b48039a1eb1231d3f654, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 4df4aa6dd529b48039a1eb1231d3f654, type: 2}
   - m_GUID: 4e0e93b0cd7a24564a088dea7f86125e
     m_Address: Assets/Project/Resources_moved/GameDatas/Stages/Spring_1/5.asset
     m_ReadOnly: 0
@@ -73,6 +297,153 @@ MonoBehaviour:
     - Stage
     m_MainAsset: {fileID: 0}
     m_TargetAsset: {fileID: 0}
+  - m_GUID: 519a9319c35b74864b1760b7faabc2eb
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/5.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 519a9319c35b74864b1760b7faabc2eb, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 519a9319c35b74864b1760b7faabc2eb, type: 2}
+  - m_GUID: 54f8e229f3ff541b8a4b2d0d3f0a32e0
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/7.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 54f8e229f3ff541b8a4b2d0d3f0a32e0, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 54f8e229f3ff541b8a4b2d0d3f0a32e0, type: 2}
+  - m_GUID: 593284e23d93347f3bbc345c2031f39c
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/4.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 593284e23d93347f3bbc345c2031f39c, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 593284e23d93347f3bbc345c2031f39c, type: 2}
+  - m_GUID: 5954053c1dee24736ac5d1261fe66c8c
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/5.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 5954053c1dee24736ac5d1261fe66c8c, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 5954053c1dee24736ac5d1261fe66c8c, type: 2}
+  - m_GUID: 5c646d14ee06b4f689b0767b774e8b23
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/8.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 5c646d14ee06b4f689b0767b774e8b23, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 5c646d14ee06b4f689b0767b774e8b23, type: 2}
+  - m_GUID: 5c896da2728f24608a7e3b408609203d
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/3.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 5c896da2728f24608a7e3b408609203d, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 5c896da2728f24608a7e3b408609203d, type: 2}
+  - m_GUID: 5dee2bf1b62de46c399d5c540a0d8f2c
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/6.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 5dee2bf1b62de46c399d5c540a0d8f2c, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 5dee2bf1b62de46c399d5c540a0d8f2c, type: 2}
+  - m_GUID: 638f993409edd4f18a269ff1c961a453
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/6.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 638f993409edd4f18a269ff1c961a453, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 638f993409edd4f18a269ff1c961a453, type: 2}
+  - m_GUID: 64e87db2e3e4f49069576bdaabb32f8c
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/7.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 64e87db2e3e4f49069576bdaabb32f8c, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 64e87db2e3e4f49069576bdaabb32f8c, type: 2}
+  - m_GUID: 66c5cfbb0b8a54b47b288282e5d43e38
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/5.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 66c5cfbb0b8a54b47b288282e5d43e38, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 66c5cfbb0b8a54b47b288282e5d43e38, type: 2}
+  - m_GUID: 66d0b097da911496e98faded93097c3b
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/6.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 66d0b097da911496e98faded93097c3b, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 66d0b097da911496e98faded93097c3b, type: 2}
+  - m_GUID: 67444d8f28a8b436c9d544498b78c664
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/2.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 67444d8f28a8b436c9d544498b78c664, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 67444d8f28a8b436c9d544498b78c664, type: 2}
+  - m_GUID: 6767feede47fa447895f936387c733b2
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/3.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 6767feede47fa447895f936387c733b2, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 6767feede47fa447895f936387c733b2, type: 2}
+  - m_GUID: 6a99dfe5f28cf4380a4a312c37164512
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/4.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 6a99dfe5f28cf4380a4a312c37164512, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 6a99dfe5f28cf4380a4a312c37164512, type: 2}
+  - m_GUID: 6dd5c24d546c3489e906302864d84759
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/9.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 6dd5c24d546c3489e906302864d84759, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 6dd5c24d546c3489e906302864d84759, type: 2}
+  - m_GUID: 6dd5cfe9944624b678fb99c7380b524a
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/1.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 6dd5cfe9944624b678fb99c7380b524a, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 6dd5cfe9944624b678fb99c7380b524a, type: 2}
+  - m_GUID: 70a133ec213be46db9f7e3a2ec81ec09
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/1.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 70a133ec213be46db9f7e3a2ec81ec09, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 70a133ec213be46db9f7e3a2ec81ec09, type: 2}
+  - m_GUID: 73c6d2cc828044739965edb261ec08a6
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/9.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 73c6d2cc828044739965edb261ec08a6, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 73c6d2cc828044739965edb261ec08a6, type: 2}
+  - m_GUID: 75470e5c8713f440392214dfd5422ac0
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/4.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 75470e5c8713f440392214dfd5422ac0, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 75470e5c8713f440392214dfd5422ac0, type: 2}
+  - m_GUID: 7b63ba282b68f4977bef8087a803b813
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/8.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 7b63ba282b68f4977bef8087a803b813, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 7b63ba282b68f4977bef8087a803b813, type: 2}
+  - m_GUID: 80dc1685ee6b842a6a716ce2b54627d7
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/9.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 80dc1685ee6b842a6a716ce2b54627d7, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 80dc1685ee6b842a6a716ce2b54627d7, type: 2}
   - m_GUID: 80f965afa4a944ee99d79343061962bc
     m_Address: Assets/Project/Resources_moved/GameDatas/Stages/Spring_2/4.asset
     m_ReadOnly: 0
@@ -87,6 +458,174 @@ MonoBehaviour:
     - Stage
     m_MainAsset: {fileID: 0}
     m_TargetAsset: {fileID: 0}
+  - m_GUID: 846fed9e6cebf49db83b42158bda1051
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/10.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 846fed9e6cebf49db83b42158bda1051, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 846fed9e6cebf49db83b42158bda1051, type: 2}
+  - m_GUID: 8537a36ba6cc74b45b6909bb2479c1f2
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/3.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 8537a36ba6cc74b45b6909bb2479c1f2, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 8537a36ba6cc74b45b6909bb2479c1f2, type: 2}
+  - m_GUID: 860af3096abcb42edad422e0edf79846
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/7.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 860af3096abcb42edad422e0edf79846, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 860af3096abcb42edad422e0edf79846, type: 2}
+  - m_GUID: 865c2189a27be4db9956bed81b53922f
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/8.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 865c2189a27be4db9956bed81b53922f, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 865c2189a27be4db9956bed81b53922f, type: 2}
+  - m_GUID: 87080ce8bc261462aa473fe21edf9672
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/4.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 87080ce8bc261462aa473fe21edf9672, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 87080ce8bc261462aa473fe21edf9672, type: 2}
+  - m_GUID: 8be6cd1b7bede413fb81c03c009e3c92
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/9.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 8be6cd1b7bede413fb81c03c009e3c92, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 8be6cd1b7bede413fb81c03c009e3c92, type: 2}
+  - m_GUID: 8e69704b96440464fb5c027b168f300b
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/2.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 8e69704b96440464fb5c027b168f300b, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 8e69704b96440464fb5c027b168f300b, type: 2}
+  - m_GUID: 94b1083c8238c4064ba0c1202108a94c
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/10.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 94b1083c8238c4064ba0c1202108a94c, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 94b1083c8238c4064ba0c1202108a94c, type: 2}
+  - m_GUID: 985ec3dab43e94dbea1689fe49f66600
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/6.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 985ec3dab43e94dbea1689fe49f66600, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 985ec3dab43e94dbea1689fe49f66600, type: 2}
+  - m_GUID: 9c088d6b675084fbfb88981ed18708fd
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/5.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 9c088d6b675084fbfb88981ed18708fd, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 9c088d6b675084fbfb88981ed18708fd, type: 2}
+  - m_GUID: 9d6ae666156454c6a976f9feaa8f200f
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/5.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 9d6ae666156454c6a976f9feaa8f200f, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 9d6ae666156454c6a976f9feaa8f200f, type: 2}
+  - m_GUID: 9edf445148c0c43c5b2785031f734e68
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/1.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 9edf445148c0c43c5b2785031f734e68, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 9edf445148c0c43c5b2785031f734e68, type: 2}
+  - m_GUID: 9f2e7496db24c4fa1954e0c1276aa7aa
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/1.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: 9f2e7496db24c4fa1954e0c1276aa7aa, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 9f2e7496db24c4fa1954e0c1276aa7aa, type: 2}
+  - m_GUID: a21354950a4994e52b7d942f44b3d68f
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/10.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: a21354950a4994e52b7d942f44b3d68f, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: a21354950a4994e52b7d942f44b3d68f, type: 2}
+  - m_GUID: a4c285a06fb704ddcb1661f4622c9e4c
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/3.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: a4c285a06fb704ddcb1661f4622c9e4c, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: a4c285a06fb704ddcb1661f4622c9e4c, type: 2}
+  - m_GUID: a64f65de02a324d48bdbc19a57c0ea4f
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/4.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: a64f65de02a324d48bdbc19a57c0ea4f, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: a64f65de02a324d48bdbc19a57c0ea4f, type: 2}
+  - m_GUID: a7a6a41bb079542d4a0791b36fefc6de
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/5.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: a7a6a41bb079542d4a0791b36fefc6de, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: a7a6a41bb079542d4a0791b36fefc6de, type: 2}
+  - m_GUID: a913b10988de840918ce0995b119516e
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/10.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: a913b10988de840918ce0995b119516e, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: a913b10988de840918ce0995b119516e, type: 2}
+  - m_GUID: ac7221acbe82e485d8193755ce2f090f
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/10.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: ac7221acbe82e485d8193755ce2f090f, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: ac7221acbe82e485d8193755ce2f090f, type: 2}
+  - m_GUID: acee77a57f90c4fa4bc17feeb3d06408
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/3.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: acee77a57f90c4fa4bc17feeb3d06408, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: acee77a57f90c4fa4bc17feeb3d06408, type: 2}
+  - m_GUID: ad926578eea2f483a8da483c1d64d635
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/5.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: ad926578eea2f483a8da483c1d64d635, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: ad926578eea2f483a8da483c1d64d635, type: 2}
+  - m_GUID: af9f42a0ed4534934aaa351a44ee0df5
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/8.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: af9f42a0ed4534934aaa351a44ee0df5, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: af9f42a0ed4534934aaa351a44ee0df5, type: 2}
+  - m_GUID: b0347b35cd68b4a7e8705fb8719fd404
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/10.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: b0347b35cd68b4a7e8705fb8719fd404, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: b0347b35cd68b4a7e8705fb8719fd404, type: 2}
+  - m_GUID: b148658ecfcfb438796a1246dee965b5
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/6.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: b148658ecfcfb438796a1246dee965b5, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: b148658ecfcfb438796a1246dee965b5, type: 2}
   - m_GUID: b6d22d1ea2625477291111bc178a1657
     m_Address: Assets/Project/Resources_moved/GameDatas/Stages/Spring_1/3.asset
     m_ReadOnly: 0
@@ -94,6 +633,104 @@ MonoBehaviour:
     - Stage
     m_MainAsset: {fileID: 0}
     m_TargetAsset: {fileID: 0}
+  - m_GUID: bf003bc8360714572bbdab850fcad22e
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/4.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: bf003bc8360714572bbdab850fcad22e, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: bf003bc8360714572bbdab850fcad22e, type: 2}
+  - m_GUID: bf32fc30ea73b4e44a79608b59e34e63
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/9.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: bf32fc30ea73b4e44a79608b59e34e63, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: bf32fc30ea73b4e44a79608b59e34e63, type: 2}
+  - m_GUID: c191ae0a9719a45d49ea772613c36572
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/1.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: c191ae0a9719a45d49ea772613c36572, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: c191ae0a9719a45d49ea772613c36572, type: 2}
+  - m_GUID: c2363a3eb41fa4088a49c7b73fc91206
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/2.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: c2363a3eb41fa4088a49c7b73fc91206, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: c2363a3eb41fa4088a49c7b73fc91206, type: 2}
+  - m_GUID: c627d08c8667f4028b4d10424305b2a4
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/7.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: c627d08c8667f4028b4d10424305b2a4, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: c627d08c8667f4028b4d10424305b2a4, type: 2}
+  - m_GUID: c9952998f0e0541418a2664f0b1308f1
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/7.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: c9952998f0e0541418a2664f0b1308f1, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: c9952998f0e0541418a2664f0b1308f1, type: 2}
+  - m_GUID: cb13d7c03238440d1b9f4e8e485c4340
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/4.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: cb13d7c03238440d1b9f4e8e485c4340, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: cb13d7c03238440d1b9f4e8e485c4340, type: 2}
+  - m_GUID: cfe7580bcfa1348879c13bdc01392681
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/3.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: cfe7580bcfa1348879c13bdc01392681, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: cfe7580bcfa1348879c13bdc01392681, type: 2}
+  - m_GUID: d284cbb70be204acf9acc5d0041dff80
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/8.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: d284cbb70be204acf9acc5d0041dff80, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: d284cbb70be204acf9acc5d0041dff80, type: 2}
+  - m_GUID: d30bd3747984042a5933df5a0c60a883
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/7.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: d30bd3747984042a5933df5a0c60a883, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: d30bd3747984042a5933df5a0c60a883, type: 2}
+  - m_GUID: d94bba782b00848c48b6d1f04bc3718a
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/8.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: d94bba782b00848c48b6d1f04bc3718a, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: d94bba782b00848c48b6d1f04bc3718a, type: 2}
+  - m_GUID: dbebf5f2a97f24a66892f38c1c6dcd54
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/1.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: dbebf5f2a97f24a66892f38c1c6dcd54, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: dbebf5f2a97f24a66892f38c1c6dcd54, type: 2}
+  - m_GUID: e46985f3520824d2eaad1ed05e41d722
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/7.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: e46985f3520824d2eaad1ed05e41d722, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: e46985f3520824d2eaad1ed05e41d722, type: 2}
+  - m_GUID: e5202320c685048f78a2c19cc66fa5ee
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/2.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: e5202320c685048f78a2c19cc66fa5ee, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: e5202320c685048f78a2c19cc66fa5ee, type: 2}
   - m_GUID: e7adfa3f7376c4acba0e84d33dbff57c
     m_Address: Assets/Project/Resources_moved/GameDatas/Stages/Spring_1/4.asset
     m_ReadOnly: 0
@@ -101,6 +738,13 @@ MonoBehaviour:
     - Stage
     m_MainAsset: {fileID: 0}
     m_TargetAsset: {fileID: 0}
+  - m_GUID: e82174cd0ea9a44d09a9ee3bdcc3bd6d
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/10.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: e82174cd0ea9a44d09a9ee3bdcc3bd6d, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: e82174cd0ea9a44d09a9ee3bdcc3bd6d, type: 2}
   - m_GUID: e9e66da04ddfa4b8ab048dbb6ec0a7f9
     m_Address: Assets/Project/Resources_moved/GameDatas/Stages/Spring_2/1.asset
     m_ReadOnly: 0
@@ -115,6 +759,34 @@ MonoBehaviour:
     - Stage
     m_MainAsset: {fileID: 0}
     m_TargetAsset: {fileID: 0}
+  - m_GUID: eac00d282222242b68e4a7cdfde4465d
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/9.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: eac00d282222242b68e4a7cdfde4465d, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: eac00d282222242b68e4a7cdfde4465d, type: 2}
+  - m_GUID: ec16ecf08577f41b8bd1acbbb8191cd6
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/4.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: ec16ecf08577f41b8bd1acbbb8191cd6, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: ec16ecf08577f41b8bd1acbbb8191cd6, type: 2}
+  - m_GUID: ef2a4b639786f44a69226527362b3bf6
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/2.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: ef2a4b639786f44a69226527362b3bf6, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: ef2a4b639786f44a69226527362b3bf6, type: 2}
+  - m_GUID: eff3398753b0d4b7481fd4404f4fafbf
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/3.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: eff3398753b0d4b7481fd4404f4fafbf, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: eff3398753b0d4b7481fd4404f4fafbf, type: 2}
   - m_GUID: f1f274f7d95914fb3837ed486594f6dd
     m_Address: Assets/Project/Resources_moved/GameDatas/Stages/Spring_1/9.asset
     m_ReadOnly: 0
@@ -122,6 +794,34 @@ MonoBehaviour:
     - Stage
     m_MainAsset: {fileID: 0}
     m_TargetAsset: {fileID: 0}
+  - m_GUID: f4eafd6ad27cc4199927a936493093d5
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/9.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: f4eafd6ad27cc4199927a936493093d5, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: f4eafd6ad27cc4199927a936493093d5, type: 2}
+  - m_GUID: f592616422c624095be2fb3a061e50eb
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/3.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: f592616422c624095be2fb3a061e50eb, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: f592616422c624095be2fb3a061e50eb, type: 2}
+  - m_GUID: faf473801664d49a5b4b9389a413566b
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/10.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: faf473801664d49a5b4b9389a413566b, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: faf473801664d49a5b4b9389a413566b, type: 2}
+  - m_GUID: fc2bcd08488d24d90ad4e760226867e3
+    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/10.asset
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Stage
+    m_MainAsset: {fileID: 11400000, guid: fc2bcd08488d24d90ad4e760226867e3, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: fc2bcd08488d24d90ad4e760226867e3, type: 2}
   m_ReadOnly: 0
   m_Settings: {fileID: 11400000, guid: 86a9d3876e9534cd69e69f31dd11bb5f, type: 2}
   m_SchemaSet:

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: aae07535d46a34af4a346b06faf0a712
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/1.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/1.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 1
+  m_EditorClassIdentifier: 
+  treeId: 2001
+  stageNumber: 1
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/1.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/1.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1635a896ae6c24e4c8dd4bb047ed1a07
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/10.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/10.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 10
+  m_EditorClassIdentifier: 
+  treeId: 2001
+  stageNumber: 10
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/10.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/10.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a21354950a4994e52b7d942f44b3d68f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/2.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/2.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 2
+  m_EditorClassIdentifier: 
+  treeId: 2001
+  stageNumber: 2
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/2.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/2.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1d155e30b0ef04023bdd2068ebf80cfe
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/3.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/3.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 3
+  m_EditorClassIdentifier: 
+  treeId: 2001
+  stageNumber: 3
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/3.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/3.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: eff3398753b0d4b7481fd4404f4fafbf
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/4.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/4.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 4
+  m_EditorClassIdentifier: 
+  treeId: 2001
+  stageNumber: 4
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/4.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/4.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ec16ecf08577f41b8bd1acbbb8191cd6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/5.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/5.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 5
+  m_EditorClassIdentifier: 
+  treeId: 2001
+  stageNumber: 5
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/5.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/5.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ad926578eea2f483a8da483c1d64d635
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/6.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/6.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 6
+  m_EditorClassIdentifier: 
+  treeId: 2001
+  stageNumber: 6
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/6.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/6.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4df4aa6dd529b48039a1eb1231d3f654
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/7.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/7.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 7
+  m_EditorClassIdentifier: 
+  treeId: 2001
+  stageNumber: 7
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/7.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/7.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c9952998f0e0541418a2664f0b1308f1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/8.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/8.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 8
+  m_EditorClassIdentifier: 
+  treeId: 2001
+  stageNumber: 8
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/8.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/8.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2745de03d7ff643ee95a086856467d66
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/9.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/9.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 9
+  m_EditorClassIdentifier: 
+  treeId: 2001
+  stageNumber: 9
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/9.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/9.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6dd5c24d546c3489e906302864d84759
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 80414de4735d34bbabaadf452e307d1f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/1.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/1.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 1
+  m_EditorClassIdentifier: 
+  treeId: 2002
+  stageNumber: 1
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/1.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/1.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 47e8649d5d99c4c3db9095c7ad35d33e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/10.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/10.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 10
+  m_EditorClassIdentifier: 
+  treeId: 2002
+  stageNumber: 10
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/10.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/10.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a913b10988de840918ce0995b119516e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/2.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/2.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 2
+  m_EditorClassIdentifier: 
+  treeId: 2002
+  stageNumber: 2
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/2.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/2.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 107509ec6a7aa488ab7c029317f1aa49
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/3.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/3.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 3
+  m_EditorClassIdentifier: 
+  treeId: 2002
+  stageNumber: 3
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/3.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/3.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0f32f060f67b642cd9faa81cbbcd9b44
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/4.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/4.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 4
+  m_EditorClassIdentifier: 
+  treeId: 2002
+  stageNumber: 4
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/4.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/4.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cb13d7c03238440d1b9f4e8e485c4340
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/5.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/5.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 5
+  m_EditorClassIdentifier: 
+  treeId: 2002
+  stageNumber: 5
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/5.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/5.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0bc92b8a7da1e45efbf4679a09dc061c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/6.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/6.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 6
+  m_EditorClassIdentifier: 
+  treeId: 2002
+  stageNumber: 6
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/6.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/6.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 01f93f152261349ae881c2ca6a33b25e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/7.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/7.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 7
+  m_EditorClassIdentifier: 
+  treeId: 2002
+  stageNumber: 7
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/7.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/7.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 860af3096abcb42edad422e0edf79846
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/8.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/8.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 8
+  m_EditorClassIdentifier: 
+  treeId: 2002
+  stageNumber: 8
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/8.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/8.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5c646d14ee06b4f689b0767b774e8b23
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/9.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/9.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 9
+  m_EditorClassIdentifier: 
+  treeId: 2002
+  stageNumber: 9
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/9.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/9.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0bd474522d9ca4d1db47f29462e3b38e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 073cffc8c90fd4e1a8f1e3534a04fd21
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/1.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/1.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 1
+  m_EditorClassIdentifier: 
+  treeId: 2003
+  stageNumber: 1
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/1.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/1.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c191ae0a9719a45d49ea772613c36572
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/10.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/10.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 10
+  m_EditorClassIdentifier: 
+  treeId: 2003
+  stageNumber: 10
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/10.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/10.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fc2bcd08488d24d90ad4e760226867e3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/2.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/2.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 2
+  m_EditorClassIdentifier: 
+  treeId: 2003
+  stageNumber: 2
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/2.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/2.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 67444d8f28a8b436c9d544498b78c664
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/3.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/3.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 3
+  m_EditorClassIdentifier: 
+  treeId: 2003
+  stageNumber: 3
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/3.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/3.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f592616422c624095be2fb3a061e50eb
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/4.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/4.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 4
+  m_EditorClassIdentifier: 
+  treeId: 2003
+  stageNumber: 4
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/4.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/4.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 75470e5c8713f440392214dfd5422ac0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/5.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/5.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 5
+  m_EditorClassIdentifier: 
+  treeId: 2003
+  stageNumber: 5
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/5.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/5.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9d6ae666156454c6a976f9feaa8f200f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/6.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/6.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 6
+  m_EditorClassIdentifier: 
+  treeId: 2003
+  stageNumber: 6
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/6.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/6.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 638f993409edd4f18a269ff1c961a453
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/7.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/7.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 7
+  m_EditorClassIdentifier: 
+  treeId: 2003
+  stageNumber: 7
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/7.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/7.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3fdcf0ca585b4447c9174093d38d2b9e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/8.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/8.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 8
+  m_EditorClassIdentifier: 
+  treeId: 2003
+  stageNumber: 8
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/8.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/8.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d94bba782b00848c48b6d1f04bc3718a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/9.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/9.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 9
+  m_EditorClassIdentifier: 
+  treeId: 2003
+  stageNumber: 9
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/9.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/9.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8be6cd1b7bede413fb81c03c009e3c92
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Spring_2/10.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Spring_2/10.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 10
+  m_EditorClassIdentifier: 
+  treeId: 2
+  stageNumber: 10
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Spring_2/10.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Spring_2/10.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 39c057e840ea0430694ebaaaed8181eb
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Spring_2/6.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Spring_2/6.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 6
+  m_EditorClassIdentifier: 
+  treeId: 2
+  stageNumber: 6
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Spring_2/6.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Spring_2/6.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2b0f0ed5e8f584538a96202e6c80c1dd
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Spring_2/7.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Spring_2/7.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 7
+  m_EditorClassIdentifier: 
+  treeId: 2
+  stageNumber: 7
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Spring_2/7.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Spring_2/7.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f34525bb49daa4dbe8120f5c7c7bb4fe
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Spring_2/8.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Spring_2/8.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 8
+  m_EditorClassIdentifier: 
+  treeId: 2
+  stageNumber: 8
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Spring_2/8.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Spring_2/8.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 22620e28274b34eb5a6adee4ad8d978f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Spring_2/9.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Spring_2/9.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 9
+  m_EditorClassIdentifier: 
+  treeId: 2
+  stageNumber: 9
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Spring_2/9.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Spring_2/9.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a35f83a63b9b9421f9d8f009d61c07ba
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Spring_3.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Spring_3.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0701995cab95a4fd6849c6d1d901ae7a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/1.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/1.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 1
+  m_EditorClassIdentifier: 
+  treeId: 3
+  stageNumber: 1
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/1.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/1.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9f2e7496db24c4fa1954e0c1276aa7aa
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/10.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/10.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 10
+  m_EditorClassIdentifier: 
+  treeId: 3
+  stageNumber: 10
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/10.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/10.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ac7221acbe82e485d8193755ce2f090f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/2.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/2.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 2
+  m_EditorClassIdentifier: 
+  treeId: 3
+  stageNumber: 2
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/2.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/2.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e5202320c685048f78a2c19cc66fa5ee
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/3.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/3.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 3
+  m_EditorClassIdentifier: 
+  treeId: 3
+  stageNumber: 3
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/3.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/3.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: acee77a57f90c4fa4bc17feeb3d06408
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/4.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/4.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 4
+  m_EditorClassIdentifier: 
+  treeId: 3
+  stageNumber: 4
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/4.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/4.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0803662de3aa547e18c189c71cf1bfb4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/5.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/5.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 5
+  m_EditorClassIdentifier: 
+  treeId: 3
+  stageNumber: 5
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/5.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/5.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5954053c1dee24736ac5d1261fe66c8c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/6.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/6.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 6
+  m_EditorClassIdentifier: 
+  treeId: 3
+  stageNumber: 6
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/6.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/6.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b148658ecfcfb438796a1246dee965b5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/7.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/7.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 7
+  m_EditorClassIdentifier: 
+  treeId: 3
+  stageNumber: 7
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/7.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/7.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e46985f3520824d2eaad1ed05e41d722
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/8.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/8.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 8
+  m_EditorClassIdentifier: 
+  treeId: 3
+  stageNumber: 8
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/8.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/8.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7b63ba282b68f4977bef8087a803b813
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/9.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/9.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 9
+  m_EditorClassIdentifier: 
+  treeId: 3
+  stageNumber: 9
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/9.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/9.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 73c6d2cc828044739965edb261ec08a6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_1.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_1.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8df924646b94b44a0ad4f35badf89616
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/1.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/1.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 1
+  m_EditorClassIdentifier: 
+  treeId: 1001
+  stageNumber: 1
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/1.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/1.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6dd5cfe9944624b678fb99c7380b524a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/10.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/10.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 10
+  m_EditorClassIdentifier: 
+  treeId: 1001
+  stageNumber: 10
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/10.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/10.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b0347b35cd68b4a7e8705fb8719fd404
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/2.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/2.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 2
+  m_EditorClassIdentifier: 
+  treeId: 1001
+  stageNumber: 2
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/2.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/2.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3ff1c067532fd47d8ba97dc8f33db3fb
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/3.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/3.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 3
+  m_EditorClassIdentifier: 
+  treeId: 1001
+  stageNumber: 3
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/3.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/3.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6767feede47fa447895f936387c733b2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/4.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/4.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 4
+  m_EditorClassIdentifier: 
+  treeId: 1001
+  stageNumber: 4
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/4.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/4.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 593284e23d93347f3bbc345c2031f39c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/5.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/5.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 5
+  m_EditorClassIdentifier: 
+  treeId: 1001
+  stageNumber: 5
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/5.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/5.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 10c44a0932bf9425eae65ee4e416f8e4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/6.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/6.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 6
+  m_EditorClassIdentifier: 
+  treeId: 1001
+  stageNumber: 6
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/6.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/6.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 66d0b097da911496e98faded93097c3b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/7.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/7.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 7
+  m_EditorClassIdentifier: 
+  treeId: 1001
+  stageNumber: 7
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/7.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/7.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d30bd3747984042a5933df5a0c60a883
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/8.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/8.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 8
+  m_EditorClassIdentifier: 
+  treeId: 1001
+  stageNumber: 8
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/8.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/8.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4d5678a326a7c47eaaf1f6759ac5dcb2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/9.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/9.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 9
+  m_EditorClassIdentifier: 
+  treeId: 1001
+  stageNumber: 9
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/9.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/9.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f4eafd6ad27cc4199927a936493093d5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_2.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_2.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dc8227124d76d4e41b83de046f1c7e4d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/1.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/1.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 1
+  m_EditorClassIdentifier: 
+  treeId: 1002
+  stageNumber: 1
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/1.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/1.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9edf445148c0c43c5b2785031f734e68
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/10.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/10.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 10
+  m_EditorClassIdentifier: 
+  treeId: 1002
+  stageNumber: 10
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/10.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/10.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 44671f370928842fd911445471f8fdd9
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/2.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/2.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 2
+  m_EditorClassIdentifier: 
+  treeId: 1002
+  stageNumber: 2
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/2.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/2.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ef2a4b639786f44a69226527362b3bf6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/3.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/3.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 3
+  m_EditorClassIdentifier: 
+  treeId: 1002
+  stageNumber: 3
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/3.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/3.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 02de8ace75fcc4965890ae9f94f3a684
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/4.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/4.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 4
+  m_EditorClassIdentifier: 
+  treeId: 1002
+  stageNumber: 4
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/4.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/4.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a64f65de02a324d48bdbc19a57c0ea4f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/5.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/5.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 5
+  m_EditorClassIdentifier: 
+  treeId: 1002
+  stageNumber: 5
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/5.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/5.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a7a6a41bb079542d4a0791b36fefc6de
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/6.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/6.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 6
+  m_EditorClassIdentifier: 
+  treeId: 1002
+  stageNumber: 6
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/6.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/6.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 15f93d76cf77b43c08372ec474a2b09c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/7.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/7.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 7
+  m_EditorClassIdentifier: 
+  treeId: 1002
+  stageNumber: 7
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/7.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/7.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3da906b1e1316489b82a2a3627e6b8fd
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/8.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/8.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 8
+  m_EditorClassIdentifier: 
+  treeId: 1002
+  stageNumber: 8
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/8.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/8.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: af9f42a0ed4534934aaa351a44ee0df5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/9.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/9.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 9
+  m_EditorClassIdentifier: 
+  treeId: 1002
+  stageNumber: 9
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/9.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/9.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4cebcc594ae334ca1ac94f3718723332
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_3.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_3.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5218ac36902504f6f83bcad23c69dacd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/1.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/1.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 1
+  m_EditorClassIdentifier: 
+  treeId: 1003
+  stageNumber: 1
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/1.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/1.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 46cb4002c76c746a1a9c146866fd5fac
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/10.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/10.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 10
+  m_EditorClassIdentifier: 
+  treeId: 1003
+  stageNumber: 10
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/10.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/10.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 94b1083c8238c4064ba0c1202108a94c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/2.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/2.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 2
+  m_EditorClassIdentifier: 
+  treeId: 1003
+  stageNumber: 2
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/2.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/2.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1a71fda93879742fd80ac2996775f5f6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/3.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/3.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 3
+  m_EditorClassIdentifier: 
+  treeId: 1003
+  stageNumber: 3
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/3.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/3.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a4c285a06fb704ddcb1661f4622c9e4c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/4.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/4.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 4
+  m_EditorClassIdentifier: 
+  treeId: 1003
+  stageNumber: 4
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/4.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/4.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1b5e2d1cda1e24f7f854f687e3e9ed21
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/5.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/5.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 5
+  m_EditorClassIdentifier: 
+  treeId: 1003
+  stageNumber: 5
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/5.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/5.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9c088d6b675084fbfb88981ed18708fd
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/6.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/6.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 6
+  m_EditorClassIdentifier: 
+  treeId: 1003
+  stageNumber: 6
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/6.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/6.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2b6133b0009a74657b01d3d67d3eba5a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/7.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/7.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 7
+  m_EditorClassIdentifier: 
+  treeId: 1003
+  stageNumber: 7
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/7.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/7.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c627d08c8667f4028b4d10424305b2a4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/8.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/8.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 8
+  m_EditorClassIdentifier: 
+  treeId: 1003
+  stageNumber: 8
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/8.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/8.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 865c2189a27be4db9956bed81b53922f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/9.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/9.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 9
+  m_EditorClassIdentifier: 
+  treeId: 1003
+  stageNumber: 9
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/9.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/9.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 22f7806eb7ae946fbafa303cabb4c9d6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_1.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_1.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 28b82e50d580540b0a1969493ea65a3a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/1.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/1.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 1
+  m_EditorClassIdentifier: 
+  treeId: 3001
+  stageNumber: 1
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/1.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/1.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dbebf5f2a97f24a66892f38c1c6dcd54
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/10.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/10.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 10
+  m_EditorClassIdentifier: 
+  treeId: 3001
+  stageNumber: 10
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/10.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/10.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e82174cd0ea9a44d09a9ee3bdcc3bd6d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/2.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/2.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 2
+  m_EditorClassIdentifier: 
+  treeId: 3001
+  stageNumber: 2
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/2.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/2.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8e69704b96440464fb5c027b168f300b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/3.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/3.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 3
+  m_EditorClassIdentifier: 
+  treeId: 3001
+  stageNumber: 3
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/3.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/3.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8537a36ba6cc74b45b6909bb2479c1f2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/4.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/4.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 4
+  m_EditorClassIdentifier: 
+  treeId: 3001
+  stageNumber: 4
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/4.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/4.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6a99dfe5f28cf4380a4a312c37164512
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/5.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/5.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 5
+  m_EditorClassIdentifier: 
+  treeId: 3001
+  stageNumber: 5
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/5.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/5.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 255877b8fcb134e278a0ce9db6790033
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/6.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/6.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 6
+  m_EditorClassIdentifier: 
+  treeId: 3001
+  stageNumber: 6
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/6.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/6.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5dee2bf1b62de46c399d5c540a0d8f2c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/7.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/7.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 7
+  m_EditorClassIdentifier: 
+  treeId: 3001
+  stageNumber: 7
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/7.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/7.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 64e87db2e3e4f49069576bdaabb32f8c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/8.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/8.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 8
+  m_EditorClassIdentifier: 
+  treeId: 3001
+  stageNumber: 8
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/8.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/8.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2c2a97f3c0270410a9637014bec103a1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/9.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/9.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 9
+  m_EditorClassIdentifier: 
+  treeId: 3001
+  stageNumber: 9
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/9.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/9.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: eac00d282222242b68e4a7cdfde4465d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_2.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_2.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 654de73250023456c9c971f4fac63b99
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/1.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/1.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 1
+  m_EditorClassIdentifier: 
+  treeId: 3002
+  stageNumber: 1
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/1.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/1.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 70a133ec213be46db9f7e3a2ec81ec09
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/10.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/10.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 10
+  m_EditorClassIdentifier: 
+  treeId: 3002
+  stageNumber: 10
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/10.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/10.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 846fed9e6cebf49db83b42158bda1051
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/2.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/2.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 2
+  m_EditorClassIdentifier: 
+  treeId: 3002
+  stageNumber: 2
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/2.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/2.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c2363a3eb41fa4088a49c7b73fc91206
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/3.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/3.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 3
+  m_EditorClassIdentifier: 
+  treeId: 3002
+  stageNumber: 3
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/3.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/3.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cfe7580bcfa1348879c13bdc01392681
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/4.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/4.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 4
+  m_EditorClassIdentifier: 
+  treeId: 3002
+  stageNumber: 4
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/4.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/4.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bf003bc8360714572bbdab850fcad22e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/5.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/5.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 5
+  m_EditorClassIdentifier: 
+  treeId: 3002
+  stageNumber: 5
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/5.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/5.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 66c5cfbb0b8a54b47b288282e5d43e38
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/6.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/6.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 6
+  m_EditorClassIdentifier: 
+  treeId: 3002
+  stageNumber: 6
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/6.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/6.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 985ec3dab43e94dbea1689fe49f66600
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/7.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/7.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 7
+  m_EditorClassIdentifier: 
+  treeId: 3002
+  stageNumber: 7
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/7.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/7.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 42be2fc124fca48bc92f392791afd6b6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/8.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/8.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 8
+  m_EditorClassIdentifier: 
+  treeId: 3002
+  stageNumber: 8
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/8.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/8.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 37514a6ee75ca4331bdd27786759857c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/9.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/9.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 9
+  m_EditorClassIdentifier: 
+  treeId: 3002
+  stageNumber: 9
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/9.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/9.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 80dc1685ee6b842a6a716ce2b54627d7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_3.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_3.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ab69e77d00e9b47ebbc65cafb8ced2b3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/1.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/1.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 1
+  m_EditorClassIdentifier: 
+  treeId: 3003
+  stageNumber: 1
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/1.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/1.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0de39bb1cabf246aab07596b1072bf21
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/10.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/10.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 10
+  m_EditorClassIdentifier: 
+  treeId: 3003
+  stageNumber: 10
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/10.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/10.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: faf473801664d49a5b4b9389a413566b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/2.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/2.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 2
+  m_EditorClassIdentifier: 
+  treeId: 3003
+  stageNumber: 2
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/2.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/2.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 37d4ea8bb421849a08aa1a0100c209ab
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/3.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/3.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 3
+  m_EditorClassIdentifier: 
+  treeId: 3003
+  stageNumber: 3
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/3.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/3.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5c896da2728f24608a7e3b408609203d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/4.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/4.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 4
+  m_EditorClassIdentifier: 
+  treeId: 3003
+  stageNumber: 4
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/4.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/4.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 87080ce8bc261462aa473fe21edf9672
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/5.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/5.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 5
+  m_EditorClassIdentifier: 
+  treeId: 3003
+  stageNumber: 5
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/5.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/5.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 519a9319c35b74864b1760b7faabc2eb
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/6.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/6.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 6
+  m_EditorClassIdentifier: 
+  treeId: 3003
+  stageNumber: 6
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/6.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/6.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0e581ecef079943e18b670c5764dec27
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/7.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/7.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 7
+  m_EditorClassIdentifier: 
+  treeId: 3003
+  stageNumber: 7
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/7.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/7.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 54f8e229f3ff541b8a4b2d0d3f0a32e0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/8.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/8.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 8
+  m_EditorClassIdentifier: 
+  treeId: 3003
+  stageNumber: 8
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/8.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/8.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d284cbb70be204acf9acc5d0041dff80
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/9.asset
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/9.asset
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 9
+  m_EditorClassIdentifier: 
+  treeId: 3003
+  stageNumber: 9
+  tiles: []
+  bottles:
+  - type: 0
+    initPos: 3
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  - type: 2
+    initPos: 4
+    targetPos: 4
+    bottleSprite:
+      m_AssetGUID: 8cacf29162ce544c6a91e04b672dda22
+      m_SubObjectName: 1_bgy
+    targetTileSprite:
+      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
+      m_SubObjectName: numberTile1
+    life: 0
+  - type: 2
+    initPos: 5
+    targetPos: 5
+    bottleSprite:
+      m_AssetGUID: 3ad34613c20ab4a8f9d82c5e184a0f2a
+      m_SubObjectName: 2_bvy
+    targetTileSprite:
+      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
+      m_SubObjectName: numberTile2
+    life: 0
+  - type: 2
+    initPos: 6
+    targetPos: 6
+    bottleSprite:
+      m_AssetGUID: 306499f0dbaa04cb386a1aa39a34d9e9
+      m_SubObjectName: 3_gy
+    targetTileSprite:
+      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
+      m_SubObjectName: numberTile3
+    life: 0
+  - type: 2
+    initPos: 7
+    targetPos: 7
+    bottleSprite:
+      m_AssetGUID: d4a70a4ce855e4182b6554908109825d
+      m_SubObjectName: 4_ops
+    targetTileSprite:
+      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
+      m_SubObjectName: numberTile4
+    life: 0
+  - type: 2
+    initPos: 8
+    targetPos: 8
+    bottleSprite:
+      m_AssetGUID: 043ec374bab50405dbf75005d1a106bf
+      m_SubObjectName: 5_oy
+    targetTileSprite:
+      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
+      m_SubObjectName: numberTile5
+    life: 0
+  - type: 2
+    initPos: 9
+    targetPos: 9
+    bottleSprite:
+      m_AssetGUID: 3e7b664c3229c4b66a919e9db2641a63
+      m_SubObjectName: 6_rp
+    targetTileSprite:
+      m_AssetGUID: 002d879f7321744279709540f5b88837
+      m_SubObjectName: numberTile6
+    life: 0
+  - type: 2
+    initPos: 10
+    targetPos: 10
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
+      m_SubObjectName: numberTile7
+    life: 0
+  - type: 2
+    initPos: 14
+    targetPos: 11
+    bottleSprite:
+      m_AssetGUID: 44a494e351155459dbfee62492c655bd
+      m_SubObjectName: 7_voy
+    targetTileSprite:
+      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
+      m_SubObjectName: numberTile8
+    life: 0
+  - type: 1
+    initPos: 15
+    targetPos: 0
+    bottleSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    targetTileSprite:
+      m_AssetGUID: 
+      m_SubObjectName: 
+    life: 0
+  gimmicks: []
+  overviewGimmicks: 
+  tutorial:
+    type: 0
+    image:
+      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_SubObjectName: 
+    video:
+      m_AssetGUID: 
+      m_SubObjectName: 

--- a/Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/9.asset.meta
+++ b/Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/9.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bf32fc30ea73b4e44a79608b59e34e63
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### 対象イシュー
Close #531 

### 概要
ボトルを設置したステージデータを全レベルに対して10個作成する

### 詳細

・Spring_1_1をベースとしてコピー。ギミック、タイルを削除する。
・`Addressable` をチェック入れて、ラベル、グループ分けを適切に設定。


#### 技術的な内容


### キャプチャ


### 動作確認方法
- [ ] Stage_2_6 ~ Winter_3_10の任意のステージをプレイして、画像のような配置になっていることを確認
- [ ] Addressable Groups にて設定漏れのステージデータがあるかを確認
- [ ] 新規ファイル名、フォルダ名が適切かを確認

![image](https://user-images.githubusercontent.com/17778395/91653972-1db20000-eae0-11ea-9016-d0c4f3500705.png)


### 参考 URL
