### PR TITLE
【GamePlayScene】ゲーム開始時特殊タイルを削除する

### DIFF
--- a/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
+++ b/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
@@ -15,6 +15,7 @@ using Project.Scripts.GameDatas;
 using UnityEngine.Video;
 using Project.Scripts.Utils.Attributes;
 using Project.Scripts.GamePlayScene.Gimmick;
+using Project.Scripts.GamePlayScene.Tile;
 
 namespace Project.Scripts.GamePlayScene
 {
@@ -244,6 +245,12 @@ namespace Project.Scripts.GamePlayScene
             foreach (var gimmick in gimmicks) {
                 // 銃弾の削除
                 DestroyImmediate(gimmick);
+            }
+
+            // ノーマルタイル以外のタイルを削除
+            var specialTiles = FindObjectsOfType<AbstractTileController>().Where(t => !(t is NormalTileController));
+            foreach (var tile in specialTiles) {
+                DestroyImmediate(tile.gameObject);
             }
         }
 


### PR DESCRIPTION
### 対象イシュー
Close #468 

### 概要
ゲーム失敗してリトライする際、特殊タイルが削除されてないままシーンに残ってたのは良くなかったので削除する

### 詳細

#### 現実装になった経緯


#### 技術的な内容
NormalTileController以外のAbstractTileControllerを探して削除するようにしました。

### キャプチャ


### 動作確認方法
- [ ] Spring_1_1で失敗してリトライする際、WarpTileが削除されることを確認する

修正前：
![CA5FE7D4-8B9E-462E-BEAD-E921DABEF676](https://user-images.githubusercontent.com/17778395/92713368-de17cd80-f395-11ea-98a6-e96ec32a265e.png)

修正後：
![01C03A23-5B4C-479A-8606-FDFC9B5937FE](https://user-images.githubusercontent.com/17778395/92713400-e3751800-f395-11ea-803f-65dbf434c475.png)

### 参考 URL
