### PR TITLE
データタイプを編集する際データをリセットする

### DIFF
--- a/Assets/Project/Scripts/Editor/EditorExtension.cs
+++ b/Assets/Project/Scripts/Editor/EditorExtension.cs
@@ -63,8 +63,8 @@ namespace Project.Scripts.Editor
         /// </summary>
         public static IEnumerable<SerializedProperty> GetChildren(this SerializedProperty serializedProperty)
         {
-            SerializedProperty currentProperty = serializedProperty.Copy();
-            SerializedProperty nextSiblingProperty = serializedProperty.Copy();
+            var currentProperty = serializedProperty.Copy();
+            var nextSiblingProperty = serializedProperty.Copy();
             nextSiblingProperty.Next(false);
 
             if (currentProperty.Next(true)) {

--- a/Assets/Project/Scripts/Editor/EditorExtension.cs
+++ b/Assets/Project/Scripts/Editor/EditorExtension.cs
@@ -66,12 +66,12 @@ namespace Project.Scripts.Editor
             SerializedProperty currentProperty = serializedProperty.Copy();
             SerializedProperty nextSiblingProperty = serializedProperty.Copy();
             nextSiblingProperty.Next(false);
-        
+
             if (currentProperty.Next(true)) {
                 do {
                     if (SerializedProperty.EqualContents(currentProperty, nextSiblingProperty))
                         break;
-        
+
                     yield return currentProperty;
                 } while (currentProperty.Next(false));
             }

--- a/Assets/Project/Scripts/Editor/EditorExtension.cs
+++ b/Assets/Project/Scripts/Editor/EditorExtension.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
 
@@ -53,6 +54,26 @@ namespace Project.Scripts.Editor
                 } else {
                     EditorGUILayout.PropertyField(arrayElementProperty, new GUIContent(arrayElementProperty.displayName));
                 }
+            }
+        }
+
+        /// <summary>
+        /// プロパティから該当データのメンバープロパティを取得する
+        /// https://forum.unity.com/threads/loop-through-serializedproperty-children.435119/
+        /// </summary>
+        public static IEnumerable<SerializedProperty> GetChildren(this SerializedProperty serializedProperty)
+        {
+            SerializedProperty currentProperty = serializedProperty.Copy();
+            SerializedProperty nextSiblingProperty = serializedProperty.Copy();
+            nextSiblingProperty.Next(false);
+        
+            if (currentProperty.Next(true)) {
+                do {
+                    if (SerializedProperty.EqualContents(currentProperty, nextSiblingProperty))
+                        break;
+        
+                    yield return currentProperty;
+                } while (currentProperty.Next(false));
             }
         }
     }

--- a/Assets/Project/Scripts/Editor/StageDataEditor.cs
+++ b/Assets/Project/Scripts/Editor/StageDataEditor.cs
@@ -518,6 +518,7 @@ namespace Project.Scripts.Editor
                     continue;
 
                 if (child.isArray) {
+                    child.ClearArray();
                     child.arraySize = 0;
                 } else {
                     switch (child.propertyType) {

--- a/Assets/Project/Scripts/Editor/StageDataEditor.cs
+++ b/Assets/Project/Scripts/Editor/StageDataEditor.cs
@@ -128,7 +128,14 @@ namespace Project.Scripts.Editor
                 EditorGUILayout.PropertyField(tileDataProp.FindPropertyRelative("number"));
 
                 var tileTypeProp = tileDataProp.FindPropertyRelative("type");
-                tileTypeProp.enumValueIndex = (int)(ETileType)EditorGUILayout.EnumPopup(new GUIContent("Type"), (ETileType)tileTypeProp.enumValueIndex);
+
+                var newTileType = (int)(ETileType)EditorGUILayout.EnumPopup(new GUIContent("Type"), (ETileType)tileTypeProp.enumValueIndex);
+
+                // タイプが変わっていたらデータをリセット
+                if (newTileType != tileTypeProp.enumValueIndex) {
+                    tileTypeProp.enumValueIndex = newTileType;
+                    ResetData(tileDataProp);
+                }
 
                 switch ((ETileType)tileTypeProp.enumValueIndex) {
                     case ETileType.Normal:
@@ -160,7 +167,15 @@ namespace Project.Scripts.Editor
                 EditorGUI.indentLevel++;
 
                 var bottleTypeProp = bottleDataProp.FindPropertyRelative("type");
-                bottleTypeProp.enumValueIndex = (int)(EBottleType)EditorGUILayout.EnumPopup(new GUIContent("Type"), (EBottleType)bottleTypeProp.enumValueIndex);
+
+                var newBottleType = (int)(EBottleType)EditorGUILayout.EnumPopup(new GUIContent("Type"), (EBottleType)bottleTypeProp.enumValueIndex);
+
+                // タイプが変わっていたらデータをリセット
+                if (newBottleType != bottleTypeProp.enumValueIndex){
+                    bottleTypeProp.enumValueIndex = newBottleType;
+                    ResetData(bottleDataProp);
+                }
+
                 EditorGUILayout.PropertyField(bottleDataProp.FindPropertyRelative("initPos"));
 
                 switch ((EBottleType)bottleTypeProp.enumValueIndex) {
@@ -214,10 +229,16 @@ namespace Project.Scripts.Editor
 
                 var gimmickTypeProp = gimmickDataProp.FindPropertyRelative("type");
 
-                gimmickTypeProp.enumValueIndex = (int)(EGimmickType)EditorGUILayout.EnumPopup(
+                int newGimmickType = (int)(EGimmickType)EditorGUILayout.EnumPopup(
                         label: new GUIContent("Type"),
                         selected: (EGimmickType)gimmickTypeProp.enumValueIndex
-                    );
+                );
+
+                // タイプが変わっていたらデータをリセット
+                if (newGimmickType != gimmickTypeProp.enumValueIndex){
+                    gimmickTypeProp.enumValueIndex = newGimmickType;
+                    ResetData(gimmickDataProp);
+                }
 
                 switch ((EGimmickType)gimmickTypeProp.enumValueIndex) {
                     case EGimmickType.Tornado: {
@@ -482,6 +503,38 @@ namespace Project.Scripts.Editor
             var type = assembly.GetType("UnityEditor.LogEntries");
             var method = type.GetMethod("Clear");
             method.Invoke(new object(), null);
+        }
+
+        /// <summary>
+        /// SerializedPropertyをデフォルト値に戻す。
+        /// BottleData、TileData、GimmickDataにだけ動作を保証する
+        /// </summary>
+        /// <param name="prop"> 対象のSerializedProperty </param>
+        private void ResetData(SerializedProperty prop)
+        {
+            foreach (var child in prop.GetChildren())
+            {
+                // タイプがリセットしたら意味ない
+                if (child.name == "type")
+                    continue;
+
+                if (child.isArray) {
+                    child.arraySize = 0;
+                } else {
+                    switch (child.propertyType) {
+                        case SerializedPropertyType.Boolean:
+                            child.boolValue = false; break;
+                        case SerializedPropertyType.Integer:
+                            child.intValue = 0; break;
+                        case SerializedPropertyType.Float:
+                            child.floatValue = 0; break;
+                        case SerializedPropertyType.Enum:
+                            child.enumValueIndex = child.intValue = 0; break;
+                        case SerializedPropertyType.ObjectReference:
+                            child.objectReferenceValue = null; break;
+                    }
+                }
+            }
         }
     }
 }

--- a/Assets/Project/Scripts/Editor/StageDataEditor.cs
+++ b/Assets/Project/Scripts/Editor/StageDataEditor.cs
@@ -129,11 +129,11 @@ namespace Project.Scripts.Editor
 
                 var tileTypeProp = tileDataProp.FindPropertyRelative("type");
 
-                var newTileType = (int)(ETileType)EditorGUILayout.EnumPopup(new GUIContent("Type"), (ETileType)tileTypeProp.enumValueIndex);
+                var newEnumValueIndex = (int)(ETileType)EditorGUILayout.EnumPopup(new GUIContent("Type"), (ETileType)tileTypeProp.enumValueIndex);
 
                 // タイプが変わっていたらデータをリセット
-                if (newTileType != tileTypeProp.enumValueIndex) {
-                    tileTypeProp.enumValueIndex = newTileType;
+                if (newEnumValueIndex != tileTypeProp.enumValueIndex) {
+                    tileTypeProp.enumValueIndex = newEnumValueIndex;
                     ResetData(tileDataProp);
                 }
 
@@ -168,11 +168,11 @@ namespace Project.Scripts.Editor
 
                 var bottleTypeProp = bottleDataProp.FindPropertyRelative("type");
 
-                var newBottleType = (int)(EBottleType)EditorGUILayout.EnumPopup(new GUIContent("Type"), (EBottleType)bottleTypeProp.enumValueIndex);
+                var newEnumValueIndex = (int)(EBottleType)EditorGUILayout.EnumPopup(new GUIContent("Type"), (EBottleType)bottleTypeProp.enumValueIndex);
 
                 // タイプが変わっていたらデータをリセット
-                if (newBottleType != bottleTypeProp.enumValueIndex) {
-                    bottleTypeProp.enumValueIndex = newBottleType;
+                if (newEnumValueIndex != bottleTypeProp.enumValueIndex) {
+                    bottleTypeProp.enumValueIndex = newEnumValueIndex;
                     ResetData(bottleDataProp);
                 }
 
@@ -229,14 +229,14 @@ namespace Project.Scripts.Editor
 
                 var gimmickTypeProp = gimmickDataProp.FindPropertyRelative("type");
 
-                int newGimmickType = (int)(EGimmickType)EditorGUILayout.EnumPopup(
+                int newEnumValueIndex = (int)(EGimmickType)EditorGUILayout.EnumPopup(
                         label: new GUIContent("Type"),
                         selected: (EGimmickType)gimmickTypeProp.enumValueIndex
                     );
 
                 // タイプが変わっていたらデータをリセット
-                if (newGimmickType != gimmickTypeProp.enumValueIndex) {
-                    gimmickTypeProp.enumValueIndex = newGimmickType;
+                if (newEnumValueIndex != gimmickTypeProp.enumValueIndex) {
+                    gimmickTypeProp.enumValueIndex = newEnumValueIndex;
                     ResetData(gimmickDataProp);
                 }
 
@@ -513,7 +513,7 @@ namespace Project.Scripts.Editor
         private static void ResetData(SerializedProperty prop)
         {
             foreach (var child in prop.GetChildren()) {
-                // タイプがリセットしたら意味ない
+                // タイプをリセットしたら意味ない
                 if (child.name == "type")
                     continue;
 

--- a/Assets/Project/Scripts/Editor/StageDataEditor.cs
+++ b/Assets/Project/Scripts/Editor/StageDataEditor.cs
@@ -171,7 +171,7 @@ namespace Project.Scripts.Editor
                 var newBottleType = (int)(EBottleType)EditorGUILayout.EnumPopup(new GUIContent("Type"), (EBottleType)bottleTypeProp.enumValueIndex);
 
                 // タイプが変わっていたらデータをリセット
-                if (newBottleType != bottleTypeProp.enumValueIndex){
+                if (newBottleType != bottleTypeProp.enumValueIndex) {
                     bottleTypeProp.enumValueIndex = newBottleType;
                     ResetData(bottleDataProp);
                 }
@@ -232,10 +232,10 @@ namespace Project.Scripts.Editor
                 int newGimmickType = (int)(EGimmickType)EditorGUILayout.EnumPopup(
                         label: new GUIContent("Type"),
                         selected: (EGimmickType)gimmickTypeProp.enumValueIndex
-                );
+                    );
 
                 // タイプが変わっていたらデータをリセット
-                if (newGimmickType != gimmickTypeProp.enumValueIndex){
+                if (newGimmickType != gimmickTypeProp.enumValueIndex) {
                     gimmickTypeProp.enumValueIndex = newGimmickType;
                     ResetData(gimmickDataProp);
                 }
@@ -512,8 +512,7 @@ namespace Project.Scripts.Editor
         /// <param name="prop"> 対象のSerializedProperty </param>
         private void ResetData(SerializedProperty prop)
         {
-            foreach (var child in prop.GetChildren())
-            {
+            foreach (var child in prop.GetChildren()) {
                 // タイプがリセットしたら意味ない
                 if (child.name == "type")
                     continue;
@@ -523,15 +522,20 @@ namespace Project.Scripts.Editor
                 } else {
                     switch (child.propertyType) {
                         case SerializedPropertyType.Boolean:
-                            child.boolValue = false; break;
+                            child.boolValue = false;
+                            break;
                         case SerializedPropertyType.Integer:
-                            child.intValue = 0; break;
+                            child.intValue = 0;
+                            break;
                         case SerializedPropertyType.Float:
-                            child.floatValue = 0; break;
+                            child.floatValue = 0;
+                            break;
                         case SerializedPropertyType.Enum:
-                            child.enumValueIndex = child.intValue = 0; break;
+                            child.enumValueIndex = child.intValue = 0;
+                            break;
                         case SerializedPropertyType.ObjectReference:
-                            child.objectReferenceValue = null; break;
+                            child.objectReferenceValue = null;
+                            break;
                     }
                 }
             }

--- a/Assets/Project/Scripts/Editor/StageDataEditor.cs
+++ b/Assets/Project/Scripts/Editor/StageDataEditor.cs
@@ -510,7 +510,7 @@ namespace Project.Scripts.Editor
         /// BottleData、TileData、GimmickDataにだけ動作を保証する
         /// </summary>
         /// <param name="prop"> 対象のSerializedProperty </param>
-        private void ResetData(SerializedProperty prop)
+        private static void ResetData(SerializedProperty prop)
         {
             foreach (var child in prop.GetChildren()) {
                 // タイプがリセットしたら意味ない

--- a/Assets/Project/Scripts/Editor/StageDataEditor.cs
+++ b/Assets/Project/Scripts/Editor/StageDataEditor.cs
@@ -525,16 +525,16 @@ namespace Project.Scripts.Editor
 
                 switch (child.propertyType) {
                     case SerializedPropertyType.Boolean:
-                        child.boolValue = false;
+                        child.boolValue = default;
                         break;
                     case SerializedPropertyType.Integer:
-                        child.intValue = 0;
+                        child.intValue = default;
                         break;
                     case SerializedPropertyType.Float:
-                        child.floatValue = 0;
+                        child.floatValue = default;
                         break;
                     case SerializedPropertyType.Enum:
-                        child.enumValueIndex = child.intValue = 0;
+                        child.enumValueIndex = child.intValue = default;
                         break;
                     case SerializedPropertyType.ObjectReference:
                         child.objectReferenceValue = null;

--- a/Assets/Project/Scripts/Editor/StageDataEditor.cs
+++ b/Assets/Project/Scripts/Editor/StageDataEditor.cs
@@ -520,24 +520,25 @@ namespace Project.Scripts.Editor
                 if (child.isArray) {
                     child.ClearArray();
                     child.arraySize = 0;
-                } else {
-                    switch (child.propertyType) {
-                        case SerializedPropertyType.Boolean:
-                            child.boolValue = false;
-                            break;
-                        case SerializedPropertyType.Integer:
-                            child.intValue = 0;
-                            break;
-                        case SerializedPropertyType.Float:
-                            child.floatValue = 0;
-                            break;
-                        case SerializedPropertyType.Enum:
-                            child.enumValueIndex = child.intValue = 0;
-                            break;
-                        case SerializedPropertyType.ObjectReference:
-                            child.objectReferenceValue = null;
-                            break;
-                    }
+                    continue;
+                }
+
+                switch (child.propertyType) {
+                    case SerializedPropertyType.Boolean:
+                        child.boolValue = false;
+                        break;
+                    case SerializedPropertyType.Integer:
+                        child.intValue = 0;
+                        break;
+                    case SerializedPropertyType.Float:
+                        child.floatValue = 0;
+                        break;
+                    case SerializedPropertyType.Enum:
+                        child.enumValueIndex = child.intValue = 0;
+                        break;
+                    case SerializedPropertyType.ObjectReference:
+                        child.objectReferenceValue = null;
+                        break;
                 }
             }
         }

--- a/Assets/Project/Scripts/Editor/StageDataEditor.cs
+++ b/Assets/Project/Scripts/Editor/StageDataEditor.cs
@@ -523,6 +523,7 @@ namespace Project.Scripts.Editor
                     continue;
                 }
 
+                // 現状，リセットする必要がある型だけをリセットしている
                 switch (child.propertyType) {
                     case SerializedPropertyType.Boolean:
                         child.boolValue = default;


### PR DESCRIPTION
### 対象イシュー
Close #544 

### 概要
ステージデータ編集する際、タイプを変えた時前回編集したデータが残ることがあるので、それを回避するために対応する

### 詳細

#### 現実装になった経緯
最初は[こちらの方法](https://answers.unity.com/questions/1555254/reset-a-serializedproperty-to-its-default-value.html)を試してみたんだけど、 `GimmickData` などは `ScriptObject` ではないのでできなかった。

なので、 `SerializedProperty` から全てのデータ取り出して一つずつリセットする方法に至りました。
#### 技術的な内容


### キャプチャ


### 動作確認方法
- [x] 任意ステージデータから `BottleType` `TileType` `GimmickType` を編集してみて、データがリセットされることを確認する

### 参考 URL
[Loop through SerializedProperty children](https://forum.unity.com/threads/loop-through-serializedproperty-children.435119/)