### PR TITLE
道の解放アニメーション途中に画面遷移した場合でも道の色を更新する

### DIFF
--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/LevelSelectDirector.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/LevelSelectDirector.cs
@@ -30,7 +30,7 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
         private void OnEnable()
         {
             _trees.ForEach(tree => tree.UpdateState());
-            _roads.ForEach(road => road.UpdateState());
+            _roads.ForEach(road => StartCoroutine(road.UpdateState()));
         }
 
         /// <summary>

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/LineController.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/LineController.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System.Collections;
+using UnityEngine;
 
 namespace Treevel.Modules.MenuSelectScene.LevelSelect
 {
@@ -73,7 +74,7 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
 
         protected abstract void SetSaveKey();
 
-        public abstract void UpdateState();
+        public abstract IEnumerator UpdateState();
 
         public abstract void SaveState();
 

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/RoadController.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/RoadController.cs
@@ -11,6 +11,22 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
     {
         private LevelTreeController _endObjectController;
 
+        /// <summary>
+        /// 道の解放アニメーションのフレーム数
+        /// </summary>
+        private const int _CLEAR_ANIMATION_FRAMES = 500;
+
+        /// <summary>
+        /// 解放時の道の色
+        /// </summary>
+        private static readonly Color _ROAD_RELEASED_COLOR = Color.white;
+
+        /// <summary>
+        /// 非解放時の道の色
+        /// </summary>
+        /// <returns></returns>
+        private static readonly Color _ROAD_UNRELEASED_COLOR = new Color(0.2f, 0.2f, 0.7f);
+
         protected override void Awake()
         {
             base.Awake();
@@ -58,8 +74,9 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
 
             if (!released) {
                 // 非解放時
-                lineRenderer.startColor = new Color(0.2f, 0.2f, 0.7f);
-                lineRenderer.endColor = new Color(0.2f, 0.2f, 0.7f);
+                lineRenderer.startColor = lineRenderer.endColor = _ROAD_UNRELEASED_COLOR;
+            } else {
+                lineRenderer.startColor = lineRenderer.endColor = _ROAD_RELEASED_COLOR;
             }
         }
 
@@ -73,9 +90,9 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
             _endObjectController.state = ETreeState.Released;
 
             // 道の更新アニメーション
-            for (var i = 0; i < 100; i++) {
-                lineRenderer.startColor = new Color((float)i / 100, (float)i / 100, (float)i / 100);
-                lineRenderer.endColor = new Color((float)i / 100, (float)i / 100, (float)i / 100);
+            for (var i = 0; i < _CLEAR_ANIMATION_FRAMES; i++) {
+                // 非解放状態から解放状態まで線形補間
+                lineRenderer.startColor = lineRenderer.endColor = Color.Lerp(_ROAD_UNRELEASED_COLOR, _ROAD_RELEASED_COLOR, (float) i / _CLEAR_ANIMATION_FRAMES);
                 yield return null;
             }
 

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/RoadController.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/RoadController.cs
@@ -14,7 +14,7 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
         /// <summary>
         /// 道の解放アニメーションのフレーム数
         /// </summary>
-        private const int _CLEAR_ANIMATION_FRAMES = 500;
+        private const int _CLEAR_ANIMATION_FRAMES = 200;
 
         /// <summary>
         /// 解放時の道の色

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/RoadController.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/RoadController.cs
@@ -52,7 +52,7 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
         /// <summary>
         /// 道の状態の更新
         /// </summary>
-        public override void UpdateState()
+        public override IEnumerator UpdateState()
         {
             released = PlayerPrefs.GetInt(saveKey, Default.ROAD_RELEASED) == 1;
 
@@ -67,7 +67,7 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
                     released = constraintObjects.All(tree => tree.GetComponent<LevelTreeController>().state >= ETreeState.Cleared);
                     if (released) {
                         // 道が非解放状態から解放状態に変わった時
-                        StartCoroutine(ReleaseEndObject());
+                        yield return StartCoroutine(ReleaseEndObject());
                     }
                 }
             }

--- a/Assets/Project/Scripts/Modules/StageSelectScene/BranchController.cs
+++ b/Assets/Project/Scripts/Modules/StageSelectScene/BranchController.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using Treevel.Common.Entities;
 using Treevel.Common.Utils;
@@ -37,7 +38,7 @@ namespace Treevel.Modules.StageSelectScene
         /// <summary>
         /// 枝の状態の更新
         /// </summary>
-        public override void UpdateState()
+        public override IEnumerator UpdateState()
         {
             if (branchStates.ContainsKey(saveKey))
                 released = branchStates[saveKey];
@@ -55,6 +56,7 @@ namespace Treevel.Modules.StageSelectScene
                     // 終点のステージの状態の更新
                     _endObjectController.ReleaseStage();
                     _endObjectController.ReflectTreeState();
+                    yield return null;
                 }
             }
 

--- a/Assets/Project/Scripts/Modules/StageSelectScene/StageSelectDirector.cs
+++ b/Assets/Project/Scripts/Modules/StageSelectScene/StageSelectDirector.cs
@@ -118,7 +118,7 @@ namespace Treevel.Modules.StageSelectScene
         /// </summary>
         private void OnEnable()
         {
-            _branches.ForEach(branch => branch.UpdateState());
+            _branches.ForEach(branch => StartCoroutine(branch.UpdateState()));
             _trees.ForEach(tree => tree.UpdateState());
         }
 


### PR DESCRIPTION
### 対象イシュー
Close #587

### 概要
道の解放アニメーション中に、`MenuSelectScene`の別画面(`RecordScene`, `SettingScene`)に遷移した際、道の色がアニメーション途中の色になってしまう問題を修正

### 詳細
- `LevelSelectScene`を開くたびに、クリア状態に応じて道の色を設定。(木と同じ処理を道にも加えた)
- 道の解放アニメーションの長さをわかりやすくするために長くした

#### 現実装になった経緯
特になし

#### 技術的な内容
- 特になし

### キャプチャ


### 動作確認方法

- [x] リセット → `Spring_1-1`をクリア → `MenuSelectScene`に戻る → 道の解放アニメーション中に`RecordScene`を開く → 道の色がクリア後の色になっていることを確認

### 参考 URL
