### PR TITLE
【ステージ概要】機能実装

### DIFF
--- a/Assets/Project/Resources/GameDatas/translation.csv
+++ b/Assets/Project/Resources/GameDatas/translation.csv
@@ -16,7 +16,7 @@ LanguageJapanese,日本語,日本語
 LanguageEnglish,English,English
 StageSelectOverviewStartGame,すすむ,START
 StageSelectOverviewCloseWindow,とじる,CLOSE
-StageSelectOverviewSuccessPercentage,前ユーザ成功割合,DUMMY
+StageSelectOverviewSuccessPercentage,全ユーザ成功割合,DUMMY
 StageSelectOverviewShortestClearTime,最速クリアタイム,DUMMY
 StageSelectOverviewAppearGimmick,登場ギミック,DUMMY
 CommonUnitSecond,秒,sec.

--- a/Assets/Project/Scripts/Common/Entities/GameDatas/StageData.cs
+++ b/Assets/Project/Scripts/Common/Entities/GameDatas/StageData.cs
@@ -38,7 +38,7 @@ namespace Treevel.Common.Entities.GameDatas
         /// <returns> StageKey(= treeId_stageNumber) </returns>
         public static string EncodeStageIdKey(ETreeId treeId, int stageNumber)
         {
-            return $"{treeId}{Constants.PlayerPrefsKeys.KEY_CONNECT_CHAR}{stageNumber}";
+            return $"{treeId.GetTreeIdAsKey()}{Constants.PlayerPrefsKeys.KEY_CONNECT_CHAR}{stageNumber}";
         }
 
         /// <summary>

--- a/Assets/Project/Scripts/Common/Entities/TreeId.cs
+++ b/Assets/Project/Scripts/Common/Entities/TreeId.cs
@@ -22,6 +22,14 @@ namespace Treevel.Common.Entities
         Winter_3 = 3003,
     }
 
+    public static class TreeIdExtension
+    {
+        public static string GetTreeIdAsKey(this ETreeId treeId)
+        {
+            return treeId.ToString().Replace("_", "-");
+        }
+    }
+
     public static class TreeInfo
     {
         /// <summary>

--- a/Assets/Project/Scripts/Common/Networks/IServerRequest.cs
+++ b/Assets/Project/Scripts/Common/Networks/IServerRequest.cs
@@ -36,21 +36,14 @@ namespace Treevel.Common.Networks
 
         public async Task<object> GetData()
         {
-            if (Application.internetReachability == NetworkReachability.NotReachable) {
-                return GetData_Local();
-            } else {
-                return await GetData_Remote();
-            }
-        }
-
-        private async Task<object> GetData_Remote()
-        {
-            if (ServerRequest == null)
-                return null;
+            Debug.Assert(ServerRequest != null, "ServerRequest not implemented.");
 
             // TODO Show Progress bar
             await ServerRequest.SendWebRequest();
 
+            if (!IsRemoteDataValid()) {
+                return GetData_Local();
+            }
             // TODO check need to update cache
 
             return DeserializeResponse();

--- a/Assets/Project/Scripts/Common/Networks/Objects.meta
+++ b/Assets/Project/Scripts/Common/Networks/Objects.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 69027b3a590cc47c6aa0f5e54ecfac0c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/Scripts/Common/Networks/Objects/StageStats.cs
+++ b/Assets/Project/Scripts/Common/Networks/Objects/StageStats.cs
@@ -1,0 +1,9 @@
+﻿namespace Treevel.Common.Networks.Objects
+{
+    [System.Serializable]
+    public struct StageStats {
+        public float clear_rate;
+        public float min_clear_time;
+        public string stage_id;
+    }
+}

--- a/Assets/Project/Scripts/Common/Networks/Objects/StageStats.cs
+++ b/Assets/Project/Scripts/Common/Networks/Objects/StageStats.cs
@@ -1,9 +1,15 @@
-﻿namespace Treevel.Common.Networks.Objects
+﻿using UnityEngine;
+
+namespace Treevel.Common.Networks.Objects
 {
     [System.Serializable]
     public struct StageStats {
-        public float clear_rate;
-        public float min_clear_time;
-        public string stage_id;
+        public float clearRate => clear_rate;
+        public float minClearTime => min_clear_time;
+        public string stageId => stage_id;
+
+        [SerializeField] float clear_rate;
+        [SerializeField] float min_clear_time;
+        [SerializeField] string stage_id;
     }
 }

--- a/Assets/Project/Scripts/Common/Networks/Objects/StageStats.cs.meta
+++ b/Assets/Project/Scripts/Common/Networks/Objects/StageStats.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bccf20cd2532b42908b3460511b98a73
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/Scripts/Common/Networks/Requests/GetStageStatsRequest.cs
+++ b/Assets/Project/Scripts/Common/Networks/Requests/GetStageStatsRequest.cs
@@ -1,0 +1,29 @@
+﻿using Treevel.Common.Networks.Objects;
+using UnityEngine;
+using UnityEngine.Networking;
+
+namespace Treevel.Common.Networks.Requests
+{
+    public class GetStageStatsRequest : GetServerRequest
+    {
+        public GetStageStatsRequest(string stageId)
+        {
+            ServerRequest = UnityWebRequest.Get(NetworkService.HOST + "/record/stats/stages/" + stageId);
+        }
+
+        public override void SetCache()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        protected override object DeserializeResponse()
+        {
+            return JsonUtility.FromJson<StageStats>(ServerRequest.downloadHandler.text);
+        }
+
+        protected override object GetData_Local()
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/Assets/Project/Scripts/Common/Networks/Requests/GetStageStatsRequest.cs.meta
+++ b/Assets/Project/Scripts/Common/Networks/Requests/GetStageStatsRequest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8a59f88f0d1a448898b6df10eeffa26d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/Scripts/Modules/StageSelectScene/OverviewPopup.cs
+++ b/Assets/Project/Scripts/Modules/StageSelectScene/OverviewPopup.cs
@@ -34,7 +34,7 @@ namespace Treevel.Modules.StageSelectScene
 
             // クリア割合
             var clearPercentageText = transform.Find("PanelBackground/StatusPanel/SuccessPercentage/Data").GetComponent<Text>();
-            clearPercentageText.text = string.Format("{0:n2}%", stats.clear_rate * 100f);
+            clearPercentageText.text = $"{stats.clear_rate * 100f:n2}%";
 
             // 最速クリアタイム
             var minClearTimeText = transform.Find("PanelBackground/StatusPanel/ShortestClearTime/Data").GetComponent<Text>();

--- a/Assets/Project/Scripts/Modules/StageSelectScene/OverviewPopup.cs
+++ b/Assets/Project/Scripts/Modules/StageSelectScene/OverviewPopup.cs
@@ -38,7 +38,7 @@ namespace Treevel.Modules.StageSelectScene
 
             // 最速クリアタイム
             var minClearTimeText = transform.Find("PanelBackground/StatusPanel/ShortestClearTime/Data").GetComponent<Text>();
-            TimeSpan time = TimeSpan.FromSeconds(stats.min_clear_time);
+            var time = TimeSpan.FromSeconds(stats.min_clear_time);
             minClearTimeText.text = $"{time.Minutes}:{time.Seconds}'{time.Milliseconds}";
 
             // 登場ギミック

--- a/Assets/Project/Scripts/Modules/StageSelectScene/OverviewPopup.cs
+++ b/Assets/Project/Scripts/Modules/StageSelectScene/OverviewPopup.cs
@@ -59,7 +59,7 @@ namespace Treevel.Modules.StageSelectScene
             goToGameButton.onClick.AddListener(() => StageSelectDirector.Instance.GoToGame(treeId, stageNumber));
         }
 
-        void OnDisable()
+        private void OnDisable()
         {
             goToGameButton.onClick.RemoveAllListeners();
         }

--- a/Assets/Project/Scripts/Modules/StageSelectScene/OverviewPopup.cs
+++ b/Assets/Project/Scripts/Modules/StageSelectScene/OverviewPopup.cs
@@ -46,12 +46,12 @@ namespace Treevel.Modules.StageSelectScene
             var overviewGimmicks = stageData.OverviewGimmicks;
             var appearingGimmicks = transform.Find("PanelBackground/AppearingGimmicks").gameObject;
             for (var i = 1 ; i <= 3 ; ++i) {
-                var gimmickOverviewBottle = appearingGimmicks.transform.Find($"GimmickOverview{i}");
+                var newFeatureOverview = appearingGimmicks.transform.Find($"GimmickOverview{i}");
                 if (overviewGimmicks.Count >= i) {
-                    gimmickOverviewBottle.GetComponentInChildren<Text>().text = overviewGimmicks[i - 1].ToString();
-                    gimmickOverviewBottle.gameObject.SetActive(true);
+                    newFeatureOverview.GetComponentInChildren<Text>().text = overviewGimmicks[i - 1].ToString();
+                    newFeatureOverview.gameObject.SetActive(true);
                 } else {
-                    gimmickOverviewBottle.gameObject.SetActive(false);
+                    newFeatureOverview.gameObject.SetActive(false);
                 }
             }
 

--- a/Assets/Project/Scripts/Modules/StageSelectScene/OverviewPopup.cs
+++ b/Assets/Project/Scripts/Modules/StageSelectScene/OverviewPopup.cs
@@ -19,6 +19,7 @@ namespace Treevel.Modules.StageSelectScene
         /// </summary>
         /// <param name="treeId"> 木のID </param>
         /// <param name="stageNumber"> ステージ番号 </param>
+        /// <param name="stats"> サーバからもらったステージスタッツデータ </param>
         public void Initialize(ETreeId treeId, int stageNumber, StageStats stats)
         {
             var stageData = GameDataManager.GetStage(treeId, stageNumber);

--- a/Assets/Project/Scripts/Modules/StageSelectScene/OverviewPopup.cs
+++ b/Assets/Project/Scripts/Modules/StageSelectScene/OverviewPopup.cs
@@ -44,7 +44,7 @@ namespace Treevel.Modules.StageSelectScene
             // 登場ギミック
             var overviewGimmicks = stageData.OverviewGimmicks;
             var appearingGimmicks = transform.Find("PanelBackground/AppearingGimmicks").gameObject;
-            for (int i = 1 ; i <= 3 ; ++i) {
+            for (var i = 1 ; i <= 3 ; ++i) {
                 var gimmickOverviewBottle = appearingGimmicks.transform.Find($"GimmickOverview{i}");
                 if (overviewGimmicks.Count >= i) {
                     gimmickOverviewBottle.GetComponentInChildren<Text>().text = overviewGimmicks[i - 1].ToString();

--- a/Assets/Project/Scripts/Modules/StageSelectScene/OverviewPopup.cs
+++ b/Assets/Project/Scripts/Modules/StageSelectScene/OverviewPopup.cs
@@ -1,5 +1,6 @@
 ﻿using Treevel.Common.Entities;
 using Treevel.Common.Managers;
+using Treevel.Common.Networks.Objects;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -31,10 +32,12 @@ namespace Treevel.Modules.StageSelectScene
 
         private int _stageNumber;
 
+        private StageStats _stageStats;
+
         private void Awake()
         {
             _stageNumberText = transform.Find("PanelBackground/StageNumIconBase/StageNumText").GetComponent<Text>();
-            _clearPercentageText = transform.Find("PanelBackground/StatusPanel/SuccessPercentage/Title").GetComponent<Text>();
+            _clearPercentageText = transform.Find("PanelBackground/StatusPanel/SuccessPercentage/Data").GetComponent<Text>();
             _appearingGimmicks = transform.Find("PanelBackground/AppearingGimmicks").gameObject;
             goToGame = transform.Find("PanelBackground/GoToGame").gameObject;
 
@@ -47,10 +50,11 @@ namespace Treevel.Modules.StageSelectScene
         /// </summary>
         /// <param name="treeId"> 木のID </param>
         /// <param name="stageNumber"> ステージ番号 </param>
-        public void SetStageId(ETreeId treeId, int stageNumber)
+        public void Initialize(ETreeId treeId, int stageNumber, StageStats stats)
         {
             _treeId = treeId;
             _stageNumber = stageNumber;
+            _stageStats = stats;
         }
 
         void OnEnable()
@@ -65,8 +69,7 @@ namespace Treevel.Modules.StageSelectScene
 
             // _stageDifficultyText.GetComponent<Text>().text = _treeId.ToString();
 
-            // TODO:サーバで全ユーザのデータを持ったら実装
-            // _clearPercentage.GetComponent<Text>().text = ...
+            _clearPercentageText.text = string.Format("{0:n2}%", _stageStats.clear_rate * 100f);
 
             var overviewGimmicks = stageData.OverviewGimmicks;
             for (int i = 1 ; i <= 3 ; ++i) {

--- a/Assets/Project/Scripts/Modules/StageSelectScene/OverviewPopup.cs
+++ b/Assets/Project/Scripts/Modules/StageSelectScene/OverviewPopup.cs
@@ -39,7 +39,7 @@ namespace Treevel.Modules.StageSelectScene
             // 最速クリアタイム
             var minClearTimeText = transform.Find("PanelBackground/StatusPanel/ShortestClearTime/Data").GetComponent<Text>();
             TimeSpan time = TimeSpan.FromSeconds(stats.min_clear_time);
-            minClearTimeText.text = string.Format("{0}:{1}'{2}", time.Minutes, time.Seconds, time.Milliseconds);
+            minClearTimeText.text = $"{time.Minutes}:{time.Seconds}'{time.Milliseconds}";
 
             // 登場ギミック
             var overviewGimmicks = stageData.OverviewGimmicks;

--- a/Assets/Project/Scripts/Modules/StageSelectScene/OverviewPopup.cs
+++ b/Assets/Project/Scripts/Modules/StageSelectScene/OverviewPopup.cs
@@ -34,11 +34,11 @@ namespace Treevel.Modules.StageSelectScene
 
             // クリア割合
             var clearPercentageText = transform.Find("PanelBackground/StatusPanel/SuccessPercentage/Data").GetComponent<Text>();
-            clearPercentageText.text = $"{stats.clear_rate * 100f:n2}%";
+            clearPercentageText.text = $"{stats.clearRate * 100f:n2}%";
 
             // 最速クリアタイム
             var minClearTimeText = transform.Find("PanelBackground/StatusPanel/ShortestClearTime/Data").GetComponent<Text>();
-            var time = TimeSpan.FromSeconds(stats.min_clear_time);
+            var time = TimeSpan.FromSeconds(stats.minClearTime);
             minClearTimeText.text = $"{time.Minutes}:{time.Seconds}'{time.Milliseconds}";
 
             // 登場ギミック

--- a/Assets/Project/Scripts/Modules/StageSelectScene/StageSelectDirector.cs
+++ b/Assets/Project/Scripts/Modules/StageSelectScene/StageSelectDirector.cs
@@ -2,7 +2,11 @@
 using System.Linq;
 using SnapScroll;
 using Treevel.Common.Entities;
+using Treevel.Common.Entities.GameDatas;
 using Treevel.Common.Managers;
+using Treevel.Common.Networks;
+using Treevel.Common.Networks.Objects;
+using Treevel.Common.Networks.Requests;
 using Treevel.Common.Patterns.Singleton;
 using Treevel.Common.Utils;
 using Treevel.Modules.GamePlayScene;
@@ -152,10 +156,12 @@ namespace Treevel.Modules.StageSelectScene
 
         public void ShowOverPopup(ETreeId treeId, int stageNumber)
         {
-            // ポップアップを初期化する
-            _overviewPopup.GetComponent<OverviewPopup>().SetStageId(treeId, stageNumber);
-            // ポップアップを表示する
-            _overviewPopup.gameObject.SetActive(true);
+            NetworkService.Execute(new GetStageStatsRequest(StageData.EncodeStageIdKey(treeId, stageNumber)), (data) => {
+                // ポップアップを初期化する
+                _overviewPopup.GetComponent<OverviewPopup>().Initialize(treeId, stageNumber, (StageStats)data);
+                // ポップアップを表示する
+                _overviewPopup.gameObject.SetActive(true);
+            });
         }
 
         /// <summary>


### PR DESCRIPTION
### 対象イシュー
Close #569 

### 概要
#551 で作成したステージ概要ポップアップの機能実装

### 詳細
#### 現実装になった経緯


a0b8e18 : `Application.internetReachability` が `NotReachable`しか返ってこれなくなったため、サーバリクエスト飛ばしてレスポンスが返ってくるかどうかでローカルデータ使用するかどうかを判断するようにした。

279e656 : `ETreeId`から `-`つなぎのキーを返す拡張メソッド

daa5a9e : API飛ばす処理、テキスト置き換え処理

14a17e4 : `OverviewPopup.cs`を大掃除

#### 技術的な内容


### キャプチャ


### 動作確認方法
- [ ] `Spring-1-1`のステージ概要での表示と`curl localhost:8080/records/stats/stages/Spring-1-1`から得られたレスポンスの結果が同じであることを確認する


### 参考 URL
[`Application.internetReachability`が使えないについて](https://stackoverflow.com/questions/57929106/how-to-properly-check-for-internet-connection-in-unity/57931517#57931517)
