### PR TITLE
EBottleTypeを拡張し、攻撃可能かどうかを返す

### DIFF
--- a/Assets/Project/Scripts/Common/Entities/BottleType.cs
+++ b/Assets/Project/Scripts/Common/Entities/BottleType.cs
@@ -6,4 +6,21 @@
         Normal,
         AttackableDummy,
     }
+
+    public static class BottleTypeExtension
+    {
+        public static bool IsAttackable(this EBottleType type)
+        {
+            switch (type) {
+                case EBottleType.Dynamic:
+                case EBottleType.Static:
+                    return false;
+                case EBottleType.Normal:
+                case EBottleType.AttackableDummy:
+                    return true;
+                default:
+                    throw new System.NotImplementedException();
+            }
+        }
+    }
 }

--- a/Assets/Project/Scripts/Common/Entities/BottleType.cs
+++ b/Assets/Project/Scripts/Common/Entities/BottleType.cs
@@ -18,8 +18,6 @@
                 case EBottleType.Normal:
                 case EBottleType.AttackableDummy:
                     return true;
-                default:
-                    throw new System.NotImplementedException();
             }
         }
     }

--- a/Assets/Project/Scripts/Editor/StageDataEditor.cs
+++ b/Assets/Project/Scripts/Editor/StageDataEditor.cs
@@ -564,7 +564,7 @@ namespace Treevel.Editor
 
         private IEnumerable<BottleData> GetAttackableBottles()
         {
-            return _src.BottleDatas?.Where(x => x.type == EBottleType.Normal || x.type == EBottleType.AttackableDummy);
+            return _src.BottleDatas?.Where(x => x.type.IsAttackable());
         }
 
         private static void ClearConsole()

--- a/Assets/Project/Scripts/Editor/StageDataEditor.cs
+++ b/Assets/Project/Scripts/Editor/StageDataEditor.cs
@@ -180,12 +180,14 @@ namespace Treevel.Editor
 
                 EditorGUILayout.PropertyField(bottleDataProp.FindPropertyRelative("initPos"));
 
+                if (((EBottleType)bottleTypeProp.enumValueIndex).IsAttackable()) {
+                    var lifeProp = bottleDataProp.FindPropertyRelative("life");
+                    lifeProp.intValue = Mathf.Max(1, lifeProp.intValue);
+                    EditorGUILayout.PropertyField(lifeProp);
+                }
+
                 switch ((EBottleType)bottleTypeProp.enumValueIndex) {
                     case EBottleType.Normal: {
-                            var lifeProp = bottleDataProp.FindPropertyRelative("life");
-                            if (bottleDataProp.FindPropertyRelative("life").intValue < 1)
-                                lifeProp.intValue = 1;
-                            EditorGUILayout.PropertyField(lifeProp);
                             EditorGUILayout.PropertyField(bottleDataProp.FindPropertyRelative("targetPos"));
                             EditorGUILayout.PropertyField(bottleDataProp.FindPropertyRelative("bottleSprite"));
                             EditorGUILayout.PropertyField(bottleDataProp.FindPropertyRelative("targetTileSprite"));
@@ -197,10 +199,6 @@ namespace Treevel.Editor
                         EditorGUILayout.PropertyField(bottleDataProp.FindPropertyRelative("isSelfish"));
                         break;
                     case EBottleType.AttackableDummy: {
-                            var lifeProp = bottleDataProp.FindPropertyRelative("life");
-                            if (bottleDataProp.FindPropertyRelative("life").intValue < 1)
-                                lifeProp.intValue = 1;
-                            EditorGUILayout.PropertyField(lifeProp);
                             EditorGUILayout.PropertyField(bottleDataProp.FindPropertyRelative("bottleSprite"));
                             EditorGUILayout.PropertyField(bottleDataProp.FindPropertyRelative("isSelfish"));
                         }

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Bottle/AbstractBottleController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Bottle/AbstractBottleController.cs
@@ -24,6 +24,11 @@ namespace Treevel.Modules.GamePlayScene.Bottle
         }
 
         /// <summary>
+        /// ボトルタイプ
+        /// </summary>
+        private EBottleType bottleType;
+
+        /// <summary>
         /// ギミックに攻撃されたときの挙動
         /// </summary>
         public event Action<GameObject> GetDamaged
@@ -56,7 +61,7 @@ namespace Treevel.Modules.GamePlayScene.Bottle
         /// <summary>
         /// 攻撃対象かどうか
         /// </summary>
-        public bool IsAttackable => _getDamagedInvoker != null;
+        public bool IsAttackable => bottleType.IsAttackable();
 
         /// <summary>
         /// 無敵状態かどうか
@@ -117,6 +122,7 @@ namespace Treevel.Modules.GamePlayScene.Bottle
         public virtual void Initialize(BottleData bottleData)
         {
             Id = bottleData.initPos;
+            bottleType = bottleData.type;
 
             // ボトルをボードに設定
             BoardManager.Instance.InitializeBottle(this, Id);


### PR DESCRIPTION
### 対象イシュー
Close #588 

### 概要
### 詳細

#### 現実装になった経緯
（Slackからコピー）
現状：
・`StageDataEditor.cs`でボトルに当たり判定があるかどうかを返すメソッドがある。
・`AbstractBottleController.cs`にも当たり判定があるかどうかを返すメソッドがある
・`StageDataEditor.cs`で当たり判定があるボトルだけにlifePropを表示したいがその制約がない

改善項目：
・`BottleController`が`EBottleType`のメンバ変数`bottleType`を持つようにする
・`EBottleType`を拡張して、攻撃可能かどうかのメソッド`IsAttackable()`を用意する
・`AbstractBottleController.IsAttackble()`メソッドでは`bottleType.IsAttackable()`の結果を返す
・`StageDataEditor.cs`の`GetAttackableBottle()`メソッドのWhereの中身を`EBottleType.IsAttackbale()`メソッドでき書き換える
・`StageDataEditor.cs`で、`lifeProp`は`EBottleType.IsAttackble()==true`のボトルだけに表示するようにする

#### 技術的な内容


### キャプチャ


### 動作確認方法


### 参考 URL
