### PR TITLE
Fix "Not all code paths return  value"

### DIFF
--- a/Assets/Project/Scripts/Common/Entities/BottleType.cs
+++ b/Assets/Project/Scripts/Common/Entities/BottleType.cs
@@ -18,6 +18,8 @@
                 case EBottleType.Normal:
                 case EBottleType.AttackableDummy:
                     return true;
+                default:
+                    throw new System.NotImplementedException();
             }
         }
     }


### PR DESCRIPTION
### 概要
switch文でenumを使うときにdefaultが必要らしい

### 参考 URL
非常にスカッとした参考URLに出会った。
https://stackoverflow.com/questions/2071345/why-do-not-all-code-paths-return-a-value-with-a-switch-statement-and-an-enum