### PR TITLE
fix UIManager initialization

### DIFF
--- a/Assets/Project/Scripts/Common/Managers/UIManager.cs
+++ b/Assets/Project/Scripts/Common/Managers/UIManager.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using Cysharp.Threading.Tasks;
 using Treevel.Common.Components.UIs;
 using Treevel.Common.Entities;
@@ -44,7 +45,7 @@ namespace Treevel.Common.Managers
 
         private MessageDialog _messageDialog;
 
-        public async void Awake()
+        public async UniTask Initialize()
         {
             DontDestroyOnLoad(gameObject);
 

--- a/Assets/Project/Scripts/Modules/StartUpScene/StartUpDirector.cs
+++ b/Assets/Project/Scripts/Modules/StartUpScene/StartUpDirector.cs
@@ -1,4 +1,4 @@
-﻿using Cysharp.Threading.Tasks;
+using Cysharp.Threading.Tasks;
 using Cysharp.Threading.Tasks.Triggers;
 using Treevel.Common.Managers;
 using Treevel.Common.Utils;
@@ -20,7 +20,7 @@ namespace Treevel.Modules.StartUpScene
                 DontDestroyOnLoad(eventSystem.gameObject);
 
             // UIManager Initialize
-            await UIManager.Instance.AwakeAsync();
+            await UIManager.Instance.Initialize();
 
             // AppManager Initialize
             AppManager.OnApplicationStart();


### PR DESCRIPTION
### 対象イシュー
なし

### 概要
#648 がマージされてから `develop` でnull object reference が発生した不具合の修正

### 詳細
#### 現実装になった経緯
fbaeebc0ba444262162a06bedc55df512732c14d で `UniTask`の`AwakeAsync`機能を使用したが、
`AwakeAsync`は `await`対象の`Monobehaviour`の `Awake`が`async`の場合では動作が保証されていないことがわかりました。
したがって該当コミット内容を戻します。

#### 技術的な内容


### キャプチャ


### 動作確認方法
- [ ] ゲーム起動し、エラーが出ないことを確認

### 参考 URL
