### PR TITLE
BottleEnum変更時のResetDataの挙動修正

### DIFF
--- a/Assets/Project/GameDatas/Stages/Spring_1/10.asset
+++ b/Assets/Project/GameDatas/Stages/Spring_1/10.asset
@@ -122,26 +122,26 @@ MonoBehaviour:
     isReverse: 0
   - type: 0
     initPos: 3
-    targetPos: 11
+    targetPos: 0
     bottleSprite:
-      m_AssetGUID: 96d23fdd7f95f4c40bc0ca4786de5beb
-      m_SubObjectName: normalBottle8
+      m_AssetGUID: 
+      m_SubObjectName: 
     targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+      m_AssetGUID: 
+      m_SubObjectName: 
     life: 0
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 1
     initPos: 15
-    targetPos: 11
+    targetPos: 0
     bottleSprite:
-      m_AssetGUID: 96d23fdd7f95f4c40bc0ca4786de5beb
-      m_SubObjectName: normalBottle8
+      m_AssetGUID: 
+      m_SubObjectName: 
     targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+      m_AssetGUID: 
+      m_SubObjectName: 
     life: 0
     isSelfish: 0
     isDark: 0

--- a/Assets/Project/Scripts/Editor/StageDataEditor.cs
+++ b/Assets/Project/Scripts/Editor/StageDataEditor.cs
@@ -635,8 +635,16 @@ namespace Treevel.Editor
                     case SerializedPropertyType.Enum:
                         child.enumValueIndex = child.intValue = default;
                         break;
-                    case SerializedPropertyType.ObjectReference:
-                        child.objectReferenceValue = null;
+                    case SerializedPropertyType.Generic:
+                        var childCopy = child.Copy();
+                        var end = child.GetEndProperty(true);
+                        if (childCopy.Next(true)) {
+                            while (!SerializedProperty.EqualContents(childCopy, end)) {
+                                ResetData(childCopy);
+                                if (!childCopy.Next(false))
+                                    break;
+                            }
+                        }
                         break;
                 }
             }


### PR DESCRIPTION
### 対象イシュー
Close #640

### 概要
`StageDataEditor.cs`の`ResetData()`メソッドで`AssetReferenceSprite`が初期化されない問題の修正

### 詳細
特に無し

#### 現実装になった経緯

#### 技術的な内容
- `AssetReferenceSprite`は`SerializedPropertyType.ObjectReference`ではなく、`SerializedPropertyType.Generic`だった。
- プリミティブな`propertyType`は今までの実装で値をリセットできたが、それ以外の`propertyType`は今回のように、再帰的に行う必要がある
[参考](https://gist.github.com/n-yoda/9712492)

##### 既知の仕様について
`StageData`の画像を変更して、`StageData`を保存する前に画像以外の`property`の値を変更すると、`Bottle`の画像が変更前に戻ってしまう。
これは、このbranch前から起こっている問題であり、今回は対処していない。

### キャプチャ
<img width="214" alt="スクリーンショット 2020-12-15 19 33 41" src="https://user-images.githubusercontent.com/26213141/102203874-77fa9380-3f0c-11eb-9663-f355388b8ff1.png">

### 動作確認方法
- [ ] Spring-1-10をプレイ、DynamicDummy, StaticDummyの画像を確認

### 参考 URL
