### PR TITLE
拡大率を反映させた道の幅に修正する

### DIFF
--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/LevelSelectDirector.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/LevelSelectDirector.cs
@@ -57,7 +57,7 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
         /// <param name="scale"> 拡大率 </param>
         public void ScaleRoad(float scale)
         {
-            _roads.ForEach(road => road.ScaleWidth(scale));
+            _roads.ForEach(road => road.Scale.Value = scale);
         }
     }
 }

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/LineController.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/LineController.cs
@@ -67,8 +67,8 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
         protected virtual void Awake()
         {
             SetSaveKey();
-            Scale.Subscribe(_ => {
-                lineRenderer.startWidth = lineRenderer.endWidth = (float) Screen.width * width * Scale.Value;
+            Scale.Subscribe(scale => {
+                lineRenderer.startWidth = lineRenderer.endWidth = Screen.width * width * scale;
             }).AddTo(this);
         }
 

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/LineController.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/LineController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using UniRx;
 using UnityEngine;
 
 namespace Treevel.Modules.MenuSelectScene.LevelSelect
@@ -42,6 +43,11 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
         [SerializeField] [Range(0, 0.2f)] protected float width;
 
         /// <summary>
+        /// 拡大率
+        /// </summary>
+        public ReactiveProperty<float> Scale = new ReactiveProperty<float>(1f);
+
+        /// <summary>
         /// 道の長さ
         /// </summary>
         protected float lineLength = 0f;
@@ -61,6 +67,9 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
         protected virtual void Awake()
         {
             SetSaveKey();
+            Scale.Subscribe(_ => {
+                lineRenderer.startWidth = lineRenderer.endWidth = (float) Screen.width * width * Scale.Value;
+            }).AddTo(this);
         }
 
         protected virtual void Start()
@@ -85,7 +94,7 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
         {
             if (lineRenderer == null) return;
             lineRenderer.positionCount = _middlePointNum + 2;
-            lineRenderer.startWidth = lineRenderer.endWidth = (float)Screen.width * width;
+            lineRenderer.startWidth = lineRenderer.endWidth = Screen.width * width * Scale.Value;
 
             var startPointLocalPosition = startObject.transform.localPosition;
             var endPointLocalPosition = endObject.transform.localPosition;

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/RoadController.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/RoadController.cs
@@ -107,14 +107,5 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
         {
             PlayerPrefs.SetInt(saveKey, Convert.ToInt32(released));
         }
-
-        /// <summary>
-        /// 線の幅の変更
-        /// </summary>
-        /// <param name="scale"> 拡大率 </param>
-        public void ScaleWidth(float scale)
-        {
-            lineRenderer.startWidth = lineRenderer.endWidth = (float)Screen.width * width * scale;
-        }
     }
 }


### PR DESCRIPTION
### 対象イシュー
Close #642

### 概要
MenuSelectSceneに遷移した時に、道の幅が拡大率が反映された太さになっていなかった問題の修正

### 詳細
`Start()`のタイミングで、拡大率を反映させた幅で設定したのち、デフォルトの太さの幅に設定し直していたことが原因であった。

#### 現実装になった経緯
- デフォルトの拡大率(1f)を道の情報として保持するように変更
- UniRxを用いたリファクタリング

#### 技術的な内容
特になし

### キャプチャ
変更前 | 変更後
<img width="222" alt="スクリーンショット 2020-12-27 14 33 39" src="https://user-images.githubusercontent.com/26213141/103164572-8ae85e80-4850-11eb-8896-adae9be2fe34.png"> <img width="224" alt="スクリーンショット 2020-12-27 14 33 10" src="https://user-images.githubusercontent.com/26213141/103164573-8e7be580-4850-11eb-8c8d-5531c844b9c4.png">


### 動作確認方法

- [x] 拡大(or縮小)した状態で、MenuSelectScene→StageSelectScene→MenuSelectSceneと遷移した時に、道の幅が１回目と２回目のMenuSelectSceneで同じであることを確認する

### 参考 URL
