### PR TITLE
HolyTile上に初期位置を持つBottleが無敵にならないバグの修正

### DIFF
--- a/Assets/Project/Scripts/Modules/GamePlayScene/BoardManager.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/BoardManager.cs
@@ -42,6 +42,15 @@ namespace Treevel.Modules.GamePlayScene
                     _squares[col, row] = new Square(x, y);
                 }
             }
+
+            GamePlayDirector.Instance.GameStart
+                .Subscribe(_ => {
+                    foreach (var square in _squares) {
+                        if (square.bottle == null) return;
+                        square.bottle.OnEnterTile(square.tile.gameObject);
+                        if (square.tile.RunOnBottleEnterAtInit) square.tile.OnBottleEnter(square.bottle.gameObject, null);
+                    }
+                }).AddTo(this);
         }
 
         public void Initialize()
@@ -326,12 +335,6 @@ namespace Treevel.Modules.GamePlayScene
 
                 // 適切な場所に設置
                 targetSquare.bottle.transform.position = targetSquare.worldPosition;
-
-                // ボトルがタイルに配置された場合の処理を行う
-                targetSquare.bottle.OnEnterTile(targetSquare.tile.gameObject);
-                if (targetSquare.tile.RunOnBottleEnterAtInit) {
-                    targetSquare.tile.OnBottleEnter(targetSquare.bottle.gameObject, null);
-                }
             }
         }
 


### PR DESCRIPTION
### 対象イシュー
Close #676

### 概要
タイトルまま

### 詳細

#### 現実装になった経緯
- Game開始時のイベントを #660 にて作成したので、それを使って、Bottle→TileおよびTile→Bottleの処理を発火させるようにした
- Bottleが乗っているTile、Tileに乗っているBottleを取得する手間を考えると、Bottle、Tileそれぞれのクラスで購読するよりも、`Square`を管理する`BoardManager`が行うのが楽だと思いました。

#### 技術的な内容
特になし

### キャプチャ


### 動作確認方法
以下のバグ再現手順を行ってもバグが発生しないことを確認する
[準備]あらかじめステージ詳細表示をOFFにする

実行する
Spring-1-1を1フリックでクリアする
Spring-1-3をプレイして放置する
HolyTile上のBottleにTornadoが当たると衝突する

### 参考 URL
