### PR TITLE
StageDataEditorのMeteorite, Fogのインデックス修正

### DIFF
--- a/Assets/Project/Actors/Gimmicks/Thunder/ThunderPrefab.prefab
+++ b/Assets/Project/Actors/Gimmicks/Thunder/ThunderPrefab.prefab
@@ -200,7 +200,7 @@ BoxCollider2D:
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 1.92, y: 1.92}
+    oldSize: {x: 192, y: 192}
     newSize: {x: 1.92, y: 1.92}
     adaptiveTilingThreshold: 0.5
     drawMode: 0
@@ -291,7 +291,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _warningDisplayTime: 1
-  _moveSpeed: 1.5
+  _moveSpeed: 150
   _cloud: {fileID: 1252275917}
 --- !u!82 &3899458119821525949
 AudioSource:

--- a/Assets/Project/Scripts/Editor/StageDataEditor.cs
+++ b/Assets/Project/Scripts/Editor/StageDataEditor.cs
@@ -328,7 +328,6 @@ namespace Treevel.Editor
                                         // デフォルト値設定
                                         lineElem.intValue =
                                             Mathf.Clamp(lineElem.intValue, 0, Constants.StageSize.COLUMN - 1);
-
                                         lineElem.intValue = (int)(EColumn)EditorGUILayout.EnumPopup(
                                             label: new GUIContent("Target Column"),
                                             selected: (EColumn)lineElem.intValue,
@@ -343,7 +342,6 @@ namespace Treevel.Editor
                                         // デフォルト値設定
                                         lineElem.intValue =
                                             Mathf.Clamp(lineElem.intValue, 0, Constants.StageSize.ROW - 1);
-
                                         lineElem.intValue = (int)(ERow)EditorGUILayout.EnumPopup(
                                             label: new GUIContent("Target Row"),
                                             selected: (ERow)lineElem.intValue,
@@ -427,8 +425,7 @@ namespace Treevel.Editor
                                                              new GUIContent("Random Column"));
                             }
                         } else {
-                            if (rowProp.intValue < 1 || rowProp.intValue > Constants.StageSize.ROW) rowProp.intValue = 1;
-
+                            rowProp.intValue = Mathf.Clamp(rowProp.intValue, 0, Constants.StageSize.ROW - 1);
                             rowProp.intValue = (int)(ERow)EditorGUILayout.EnumPopup(
                                 label: new GUIContent("Row"),
                                 selected: (ERow)rowProp.intValue,
@@ -437,7 +434,7 @@ namespace Treevel.Editor
                                 includeObsolete: false
                             );
 
-                            if (colProp.intValue < 1 || colProp.intValue > Constants.StageSize.COLUMN) colProp.intValue = 1;
+                            colProp.intValue = Mathf.Clamp(colProp.intValue, 0, Constants.StageSize.COLUMN - 1);
                             colProp.intValue = (int)(EColumn)EditorGUILayout.EnumPopup(
                                 label: new GUIContent("EColumn"),
                                 selected: (EColumn)colProp.intValue,
@@ -617,12 +614,12 @@ namespace Treevel.Editor
                             // 横幅、縦幅の設定
                             var widthProp = gimmickDataProp.FindPropertyRelative("width");
                             if (widthProp.intValue < 1 || widthProp.intValue >
-                                Mathf.Min(FogController.WIDTH_MAX, Constants.StageSize.COLUMN + 1 - colProp.intValue))
+                                Mathf.Min(FogController.WIDTH_MAX, Constants.StageSize.COLUMN - colProp.intValue))
                                 widthProp.intValue = 1;
                             EditorGUILayout.PropertyField(widthProp);
                             var heightProp = gimmickDataProp.FindPropertyRelative("height");
                             if (heightProp.intValue < 1 || heightProp.intValue >
-                                Mathf.Min(FogController.HEIGHT_MAX, Constants.StageSize.ROW + 1 - rowProp.intValue))
+                                Mathf.Min(FogController.HEIGHT_MAX, Constants.StageSize.ROW - rowProp.intValue))
                                 heightProp.intValue = 1;
                             EditorGUILayout.PropertyField(heightProp);
                         }

--- a/Assets/Project/Scripts/Editor/StageDataEditor.cs
+++ b/Assets/Project/Scripts/Editor/StageDataEditor.cs
@@ -495,8 +495,8 @@ namespace Treevel.Editor
                             var buffer = new int[] { xProp.intValue, yProp.intValue };
                             EditorGUI.MultiIntField(rect, subLabels, buffer);
 
-                            xProp.intValue = Mathf.Clamp(buffer[0], 1, Constants.StageSize.ROW);
-                            yProp.intValue = Mathf.Clamp(buffer[1], 1, Constants.StageSize.COLUMN);
+                            xProp.intValue = Mathf.Clamp(buffer[0], 0, Constants.StageSize.ROW - 1);
+                            yProp.intValue = Mathf.Clamp(buffer[1], 0, Constants.StageSize.COLUMN - 1);
                         });
                         break;
                     }

--- a/Assets/Project/Scripts/Editor/StageDataEditor.cs
+++ b/Assets/Project/Scripts/Editor/StageDataEditor.cs
@@ -436,7 +436,7 @@ namespace Treevel.Editor
 
                             colProp.intValue = Mathf.Clamp(colProp.intValue, 0, Constants.StageSize.COLUMN - 1);
                             colProp.intValue = (int)(EColumn)EditorGUILayout.EnumPopup(
-                                label: new GUIContent("EColumn"),
+                                label: new GUIContent("Column"),
                                 selected: (EColumn)colProp.intValue,
                                 //ランダムは選択不能にする
                                 checkEnabled: (eType) => (EColumn)eType != EColumn.Random,
@@ -604,7 +604,7 @@ namespace Treevel.Editor
 
                             colProp.intValue = Mathf.Clamp(colProp.intValue, 0, Constants.StageSize.COLUMN - 1);
                             colProp.intValue = (int)(EColumn)EditorGUILayout.EnumPopup(
-                                label: new GUIContent("EColumn"),
+                                label: new GUIContent("Column"),
                                 selected: (EColumn)colProp.intValue,
                                 //ランダムは選択不能にする
                                 checkEnabled: (eType) => (EColumn)eType != EColumn.Random,

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Gimmick/ThunderController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Gimmick/ThunderController.cs
@@ -26,7 +26,7 @@ namespace Treevel.Modules.GamePlayScene.Gimmick
         /// <summary>
         /// 移動速度
         /// </summary>
-        [SerializeField] private float _moveSpeed = 1.5f;
+        [SerializeField] private float _moveSpeed = 150f;
 
         /// <summary>
         /// 目標タイル


### PR DESCRIPTION
### 対象イシュー
Close #711

### 概要
タイトルまま

### 詳細
ERow, EColumnのenumの初期値を`1`から`0`に変更するissue(#615)の際の変更漏れ

#### 現実装になった経緯


#### 技術的な内容


### キャプチャ


### 動作確認方法

- [x] StageDataEditorでMeteorite Gimmickを選択し、Rowに"First"を選択できる
- [x] StageDataEditorでMeteorite Gimmickを選択し、Columnに"Left"を選択できる
- [x] StageDataEditorでFog Gimmickを選択し、Rowに"Fifth"を選択した状態で"Height"に2以上を入力すると1になる(他のRowでは2を入力できる)
- [x] StageDataEditorでFog Gimmickを選択し、Columnに"Right"を選択した状態で"Width"に2以上を入力すると1になる(他のColumnでは2を入力できる)

### 参考 URL
