### PR TITLE
PowderGimmickをHolyTile上のBottleには降らせない

### DIFF
--- a/Assets/Project/GameDatas/Stages/Spring_2/2.asset
+++ b/Assets/Project/GameDatas/Stages/Spring_2/2.asset
@@ -14,10 +14,16 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 2
   stageNumber: 2
-  tiles: []
+  tiles:
+  - type: 2
+    number: 1
+    pairNumber: 0
+  - type: 2
+    number: 2
+    pairNumber: 0
   bottles:
   - type: 2
-    initPos: 4
+    initPos: 1
     targetPos: 4
     bottleSprite:
       m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Bottle/AbstractBottleController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Bottle/AbstractBottleController.cs
@@ -18,7 +18,7 @@ namespace Treevel.Modules.GamePlayScene.Bottle
         /// <summary>
         /// 無敵状態かどうか
         /// </summary>
-        public ReactiveProperty<bool> isInvincible = new ReactiveProperty<bool>(false);
+        public ReactiveProperty<bool> isInvincible = new ReactiveProperty<bool>();
 
         private readonly Subject<GameObject> _enterTileSubject = new Subject<GameObject>();
 

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Bottle/AbstractBottleController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Bottle/AbstractBottleController.cs
@@ -18,7 +18,7 @@ namespace Treevel.Modules.GamePlayScene.Bottle
         /// <summary>
         /// 無敵状態かどうか
         /// </summary>
-        public bool Invincible;
+        public ReactiveProperty<bool> isInvincible = new ReactiveProperty<bool>(false);
 
         private readonly Subject<GameObject> _enterTileSubject = new Subject<GameObject>();
 
@@ -64,7 +64,7 @@ namespace Treevel.Modules.GamePlayScene.Bottle
             this.OnTriggerEnter2DAsObservable()
                 .Where(other => other.gameObject.CompareTag(Constants.TagName.GIMMICK))
                 .Where(other => other.gameObject.transform.position.z >= 0)
-                .Where(_ => !Invincible)
+                .Where(_ => !isInvincible.Value)
                 .Subscribe(other => _getDamagedSubject.OnNext(other.gameObject)).AddTo(this);
         }
 

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Gimmick/MeteoriteController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Gimmick/MeteoriteController.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections;
+﻿using System.Collections;
 using System.Linq;
 using Treevel.Common.Entities;
 using Treevel.Common.Entities.GameDatas;
@@ -56,7 +55,7 @@ namespace Treevel.Modules.GamePlayScene.Gimmick
                 .Where(_ => transform.position.z >= 0)
                 .Subscribe(other => {
                     var bottle = other.GetComponent<AbstractBottleController>();
-                    if (bottle != null && bottle.IsAttackable && !bottle.Invincible) {
+                    if (bottle != null && bottle.IsAttackable && !bottle.isInvincible.Value) {
                         // 数字ボトルとの衝突
                         // 衝突したオブジェクトは赤色に変える
                         gameObject.GetComponent<SpriteRenderer>().color = Color.red;

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Gimmick/Powder/PiledUpPowderController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Gimmick/Powder/PiledUpPowderController.cs
@@ -47,6 +47,11 @@ namespace Treevel.Modules.GamePlayScene.Gimmick.Powder
             _bottleController.EndMove.Subscribe(_ => {
                 _animator.SetBool(_ANIMATOR_PARAM_BOOL_TRIGGER, true);
             }).AddTo(compositeDisposableOnGameEnd, this);
+            // 無敵状態の処理
+            _bottleController.isInvincible.Subscribe(value => {
+                    GetComponent<SpriteRenderer>().enabled = !value;
+                    _animator.enabled = !value;
+            }).AddTo(compositeDisposableOnGameEnd, this);
         }
 
         public override IEnumerator Trigger()

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Gimmick/Powder/PiledUpPowderController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Gimmick/Powder/PiledUpPowderController.cs
@@ -48,9 +48,9 @@ namespace Treevel.Modules.GamePlayScene.Gimmick.Powder
                 _animator.SetBool(_ANIMATOR_PARAM_BOOL_TRIGGER, true);
             }).AddTo(compositeDisposableOnGameEnd, this);
             // 無敵状態の処理
-            _bottleController.isInvincible.Subscribe(value => {
-                    GetComponent<SpriteRenderer>().enabled = !value;
-                    _animator.enabled = !value;
+            _bottleController.isInvincible.Subscribe(isInvincible => {
+                GetComponent<SpriteRenderer>().enabled = !isInvincible;
+                _animator.enabled = !isInvincible;
             }).AddTo(compositeDisposableOnGameEnd, this);
         }
 

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Gimmick/TornadoController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Gimmick/TornadoController.cs
@@ -74,7 +74,7 @@ namespace Treevel.Modules.GamePlayScene.Gimmick
                 .Select(other => other.GetComponent<AbstractBottleController>())
                 .Where(bottle => bottle != null)
                 .Where(bottle => bottle.IsAttackable)
-                .Where(bottle => !bottle.Invincible)
+                .Where(bottle => !bottle.isInvincible.Value)
                 .Subscribe(_ => {
                     // 衝突したオブジェクトは赤色に変える
                     gameObject.GetComponent<SpriteRenderer>().color = Color.red;

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Tile/HolyTileController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Tile/HolyTileController.cs
@@ -30,13 +30,13 @@ namespace Treevel.Modules.GamePlayScene.Tile
                 if (bottle.GetComponent<AbstractBottleController>() == null) return;
 
                 // 親ボトルを無敵状態にする
-                bottle.GetComponent<AbstractBottleController>().Invincible = true;
+                bottle.GetComponent<AbstractBottleController>().isInvincible.Value = true;
             }
 
             public override void OnBottleExit(GameObject bottle)
             {
                 // 親ボトルを無敵状態から元に戻す
-                bottle.GetComponent<AbstractBottleController>().Invincible = false;
+                bottle.GetComponent<AbstractBottleController>().isInvincible.Value = false;
             }
         }
     }


### PR DESCRIPTION
### 対象イシュー
Close #737

### 概要
タイトルまま

### 詳細
特になし

#### 現実装になった経緯
HolyTile上は当たり判定の起きるギミックが働かない仕様になった。

#### 技術的な内容
- Bottleの変数(`invincible`)を`ReactiveProperty`に変更
- `Bottle`を`HolyTile`に乗せると、`Bottle`の移動後に`Powder`の経過時間がリセットされる。その後、`Bottle`が無敵状態になる。という順番なので、`Powder`の経過時間がリセットされるタイミングでは`Bottle`は無敵ではない。

なので、`Bottle`が無敵になったタイミングで別処理を行うことにした。
`Animation`の速さを`0f`にすることも考えられるが、ギミック自体が働かなくなるので`Animator`を`OFF`にする方が意味的にはあっている気がする。
(`Animation`の速さを`0f`にする実装はちょくちょく存在するので、どこかのタイミングで`Animator`を`OFF`にする実装に変えたい)

### キャプチャ


### 動作確認方法

- [x] `NotHolyTile`→`HolyTile`の移動で`Powder`が積もらなくなる

- [x] `HolyTile` → `HolyTile`の移動で`Powder`が積もらない

- [x] `HolyTile` → `NotHolyTile`の移動で`Powder`が積もる

- [x] ゲーム開始時に`HolyTile`に乗っているBottleはその場では`Powder`が積もらない

### 参考 URL
