### PR TITLE
Bottleの色とTileの色を別々に指定する

### DIFF
--- a/Assets/AddressableAssetsData/AssetGroups/Bottles.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Bottles.asset
@@ -18,7 +18,7 @@ MonoBehaviour:
   m_GUID: 4951f8159737447ba8ae521e4284726a
   m_SerializeEntries:
   - m_GUID: 141dfdffa4c9e4962ab05c138b69881c
-    m_Address: normalBottle_6
+    m_Address: normalBottle_LightBlue
     m_ReadOnly: 0
     m_SerializedLabels:
     - Bottles
@@ -26,7 +26,7 @@ MonoBehaviour:
     m_MainAsset: {fileID: 0}
     m_TargetAsset: {fileID: 0}
   - m_GUID: 2a7e69dea5902413a99deaf07342f7dc
-    m_Address: normalBottle_7
+    m_Address: normalBottle_Blue
     m_ReadOnly: 0
     m_SerializedLabels:
     - Bottles
@@ -55,7 +55,7 @@ MonoBehaviour:
     m_MainAsset: {fileID: 0}
     m_TargetAsset: {fileID: 0}
   - m_GUID: 77afffe8c8ad8478fac611078bf02cdd
-    m_Address: normalBottle_2
+    m_Address: normalBottle_Pink
     m_ReadOnly: 0
     m_SerializedLabels:
     - Bottles
@@ -70,7 +70,7 @@ MonoBehaviour:
     m_MainAsset: {fileID: 0}
     m_TargetAsset: {fileID: 0}
   - m_GUID: bc5b41ad84210436b8d054663a3f2754
-    m_Address: normalBottle_4
+    m_Address: normalBottle_Yellow
     m_ReadOnly: 0
     m_SerializedLabels:
     - Bottles
@@ -93,7 +93,7 @@ MonoBehaviour:
     m_MainAsset: {fileID: 0}
     m_TargetAsset: {fileID: 0}
   - m_GUID: c7e771d42b34e444cb9570cbace8f66b
-    m_Address: normalBottle_1
+    m_Address: normalBottle_Red
     m_ReadOnly: 0
     m_SerializedLabels:
     - Bottles
@@ -115,7 +115,7 @@ MonoBehaviour:
     m_MainAsset: {fileID: 0}
     m_TargetAsset: {fileID: 0}
   - m_GUID: dc8347884678a4c3eab9a812d91f796f
-    m_Address: normalBottle_3
+    m_Address: normalBottle_Orange
     m_ReadOnly: 0
     m_SerializedLabels:
     - Bottles
@@ -152,7 +152,7 @@ MonoBehaviour:
     m_MainAsset: {fileID: 0}
     m_TargetAsset: {fileID: 0}
   - m_GUID: fa2dda00e054449238d90541adcf68b8
-    m_Address: normalBottle_8
+    m_Address: normalBottle_Purple
     m_ReadOnly: 0
     m_SerializedLabels:
     - Bottles
@@ -160,7 +160,7 @@ MonoBehaviour:
     m_MainAsset: {fileID: 0}
     m_TargetAsset: {fileID: 0}
   - m_GUID: fad0ddda9821b4c0eae4822e28fe654b
-    m_Address: normalBottle_5
+    m_Address: normalBottle_Green
     m_ReadOnly: 0
     m_SerializedLabels:
     - Bottles

--- a/Assets/AddressableAssetsData/AssetGroups/Tiles.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Tiles.asset
@@ -22,8 +22,8 @@ MonoBehaviour:
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tile
-    m_MainAsset: {fileID: 0}
-    m_TargetAsset: {fileID: 0}
+    m_MainAsset: {fileID: 2800000, guid: 002d879f7321744279709540f5b88837, type: 3}
+    m_TargetAsset: {fileID: 2800000, guid: 002d879f7321744279709540f5b88837, type: 3}
   - m_GUID: 07e443d3f6d294a17a18de0cc2799195
     m_Address: normalTile_9
     m_ReadOnly: 0
@@ -166,6 +166,13 @@ MonoBehaviour:
     m_TargetAsset: {fileID: 0}
   - m_GUID: b9d906ecbf1694e63aa7160b78a3e0bf
     m_Address: normalTile_15
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - Tile
+    m_MainAsset: {fileID: 0}
+    m_TargetAsset: {fileID: 0}
+  - m_GUID: bf773a93995d0477695c2bb46e3c335b
+    m_Address: GoalTilePrefab
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tile

--- a/Assets/AddressableAssetsData/AssetGroups/Tiles.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Tiles.asset
@@ -18,211 +18,201 @@ MonoBehaviour:
   m_GUID: 52dde2e2b4fd843bfb781a540a37ccb8
   m_SerializeEntries:
   - m_GUID: 002d879f7321744279709540f5b88837
-    m_Address: numberTile6
+    m_Address: numberTile_LightBlue
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tile
-    m_MainAsset: {fileID: 2800000, guid: 002d879f7321744279709540f5b88837, type: 3}
-    m_TargetAsset: {fileID: 2800000, guid: 002d879f7321744279709540f5b88837, type: 3}
+    m_MainAsset: {fileID: 0}
+    m_TargetAsset: {fileID: 0}
   - m_GUID: 07e443d3f6d294a17a18de0cc2799195
     m_Address: normalTile_9
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tile
-    m_MainAsset: {fileID: 2800000, guid: 07e443d3f6d294a17a18de0cc2799195, type: 3}
-    m_TargetAsset: {fileID: 2800000, guid: 07e443d3f6d294a17a18de0cc2799195, type: 3}
+    m_MainAsset: {fileID: 0}
+    m_TargetAsset: {fileID: 0}
   - m_GUID: 10615e735d661461a88777d89755bf0e
     m_Address: NormalTilePrefab
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tile
-    m_MainAsset: {fileID: 1202584627454472, guid: 10615e735d661461a88777d89755bf0e,
-      type: 3}
-    m_TargetAsset: {fileID: 1202584627454472, guid: 10615e735d661461a88777d89755bf0e,
-      type: 3}
+    m_MainAsset: {fileID: 0}
+    m_TargetAsset: {fileID: 0}
   - m_GUID: 31793e365380e4285b274b30c991eef5
     m_Address: SpiderwebTilePrefab
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tile
-    m_MainAsset: {fileID: 5612440846642675437, guid: 31793e365380e4285b274b30c991eef5,
-      type: 3}
-    m_TargetAsset: {fileID: 5612440846642675437, guid: 31793e365380e4285b274b30c991eef5,
-      type: 3}
+    m_MainAsset: {fileID: 0}
+    m_TargetAsset: {fileID: 0}
   - m_GUID: 353351082f72147da8017017e8d6d8bb
     m_Address: normalTile_11
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tile
-    m_MainAsset: {fileID: 2800000, guid: 353351082f72147da8017017e8d6d8bb, type: 3}
-    m_TargetAsset: {fileID: 2800000, guid: 353351082f72147da8017017e8d6d8bb, type: 3}
+    m_MainAsset: {fileID: 0}
+    m_TargetAsset: {fileID: 0}
   - m_GUID: 496f422ec07e8488cbc4b8555ae8ff02
     m_Address: normalTile_4
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tile
-    m_MainAsset: {fileID: 2800000, guid: 496f422ec07e8488cbc4b8555ae8ff02, type: 3}
-    m_TargetAsset: {fileID: 2800000, guid: 496f422ec07e8488cbc4b8555ae8ff02, type: 3}
+    m_MainAsset: {fileID: 0}
+    m_TargetAsset: {fileID: 0}
   - m_GUID: 51b39f4d7523d4df3a7e291ceb9fc25e
     m_Address: normalTile_10
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tile
-    m_MainAsset: {fileID: 2800000, guid: 51b39f4d7523d4df3a7e291ceb9fc25e, type: 3}
-    m_TargetAsset: {fileID: 2800000, guid: 51b39f4d7523d4df3a7e291ceb9fc25e, type: 3}
+    m_MainAsset: {fileID: 0}
+    m_TargetAsset: {fileID: 0}
   - m_GUID: 57e95fd6c6d8e4876858772d8b00c4cf
     m_Address: IceTilePrefab
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tile
-    m_MainAsset: {fileID: 5845266341071709951, guid: 57e95fd6c6d8e4876858772d8b00c4cf,
-      type: 3}
-    m_TargetAsset: {fileID: 5845266341071709951, guid: 57e95fd6c6d8e4876858772d8b00c4cf,
-      type: 3}
+    m_MainAsset: {fileID: 0}
+    m_TargetAsset: {fileID: 0}
   - m_GUID: 5fd9bc0429bee4c5ab59b54f11aa4508
     m_Address: HolyTilePrefab
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tile
-    m_MainAsset: {fileID: 1906666572760857407, guid: 5fd9bc0429bee4c5ab59b54f11aa4508,
-      type: 3}
-    m_TargetAsset: {fileID: 1906666572760857407, guid: 5fd9bc0429bee4c5ab59b54f11aa4508,
-      type: 3}
+    m_MainAsset: {fileID: 0}
+    m_TargetAsset: {fileID: 0}
   - m_GUID: 621ad890756e54e6d93e52c8911cfcc3
-    m_Address: numberTile1
+    m_Address: numberTile_Red
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tile
-    m_MainAsset: {fileID: 2800000, guid: 621ad890756e54e6d93e52c8911cfcc3, type: 3}
-    m_TargetAsset: {fileID: 2800000, guid: 621ad890756e54e6d93e52c8911cfcc3, type: 3}
+    m_MainAsset: {fileID: 0}
+    m_TargetAsset: {fileID: 0}
   - m_GUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-    m_Address: numberTile5
+    m_Address: numberTile_Green
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tile
-    m_MainAsset: {fileID: 2800000, guid: 6b27d5e8cb48e4d3b8e9df348aa185c6, type: 3}
-    m_TargetAsset: {fileID: 2800000, guid: 6b27d5e8cb48e4d3b8e9df348aa185c6, type: 3}
+    m_MainAsset: {fileID: 0}
+    m_TargetAsset: {fileID: 0}
   - m_GUID: 6cf2e60e46bfa4964b97af696aab6d8a
     m_Address: normalTile_8
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tile
-    m_MainAsset: {fileID: 2800000, guid: 6cf2e60e46bfa4964b97af696aab6d8a, type: 3}
-    m_TargetAsset: {fileID: 2800000, guid: 6cf2e60e46bfa4964b97af696aab6d8a, type: 3}
+    m_MainAsset: {fileID: 0}
+    m_TargetAsset: {fileID: 0}
   - m_GUID: 6e504f819843b4e19b691bb6f41ae21c
     m_Address: normalTile_12
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tile
-    m_MainAsset: {fileID: 2800000, guid: 6e504f819843b4e19b691bb6f41ae21c, type: 3}
-    m_TargetAsset: {fileID: 2800000, guid: 6e504f819843b4e19b691bb6f41ae21c, type: 3}
+    m_MainAsset: {fileID: 0}
+    m_TargetAsset: {fileID: 0}
   - m_GUID: 7049c28bb2d914c02abfad034c3d08ca
-    m_Address: numberTile7
+    m_Address: numberTile_Blue
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tile
-    m_MainAsset: {fileID: 2800000, guid: 7049c28bb2d914c02abfad034c3d08ca, type: 3}
-    m_TargetAsset: {fileID: 2800000, guid: 7049c28bb2d914c02abfad034c3d08ca, type: 3}
+    m_MainAsset: {fileID: 0}
+    m_TargetAsset: {fileID: 0}
   - m_GUID: 75c32df0ab0684c329e34ac831a5c9b3
-    m_Address: numberTile4
+    m_Address: numberTile_Yellow
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tile
-    m_MainAsset: {fileID: 2800000, guid: 75c32df0ab0684c329e34ac831a5c9b3, type: 3}
-    m_TargetAsset: {fileID: 2800000, guid: 75c32df0ab0684c329e34ac831a5c9b3, type: 3}
+    m_MainAsset: {fileID: 0}
+    m_TargetAsset: {fileID: 0}
   - m_GUID: 8723518ab12fa4ff9a973c664acbdc08
     m_Address: normalTile_2
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tile
-    m_MainAsset: {fileID: 2800000, guid: 8723518ab12fa4ff9a973c664acbdc08, type: 3}
-    m_TargetAsset: {fileID: 2800000, guid: 8723518ab12fa4ff9a973c664acbdc08, type: 3}
+    m_MainAsset: {fileID: 0}
+    m_TargetAsset: {fileID: 0}
   - m_GUID: 8a0d5bd6528c44ce0a41c1950bd14250
     m_Address: normalTile_13
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tile
-    m_MainAsset: {fileID: 2800000, guid: 8a0d5bd6528c44ce0a41c1950bd14250, type: 3}
-    m_TargetAsset: {fileID: 2800000, guid: 8a0d5bd6528c44ce0a41c1950bd14250, type: 3}
+    m_MainAsset: {fileID: 0}
+    m_TargetAsset: {fileID: 0}
   - m_GUID: 8bd35c0dfc09c48479577e2b43dcac03
     m_Address: WarpTilePrefab
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tile
-    m_MainAsset: {fileID: 2281809373051226156, guid: 8bd35c0dfc09c48479577e2b43dcac03,
-      type: 3}
-    m_TargetAsset: {fileID: 2281809373051226156, guid: 8bd35c0dfc09c48479577e2b43dcac03,
-      type: 3}
+    m_MainAsset: {fileID: 0}
+    m_TargetAsset: {fileID: 0}
   - m_GUID: 9ea691163f5654eb78be7c92e8a030d6
     m_Address: normalTile_14
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tile
-    m_MainAsset: {fileID: 2800000, guid: 9ea691163f5654eb78be7c92e8a030d6, type: 3}
-    m_TargetAsset: {fileID: 2800000, guid: 9ea691163f5654eb78be7c92e8a030d6, type: 3}
+    m_MainAsset: {fileID: 0}
+    m_TargetAsset: {fileID: 0}
   - m_GUID: ac32591f4371d4d449612b92a4b54fcb
     m_Address: normalTile_7
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tile
-    m_MainAsset: {fileID: 2800000, guid: ac32591f4371d4d449612b92a4b54fcb, type: 3}
-    m_TargetAsset: {fileID: 2800000, guid: ac32591f4371d4d449612b92a4b54fcb, type: 3}
+    m_MainAsset: {fileID: 0}
+    m_TargetAsset: {fileID: 0}
   - m_GUID: b8f7dbec862e143b98cf342ad4b46952
-    m_Address: numberTile8
+    m_Address: numberTile_Purple
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tile
-    m_MainAsset: {fileID: 2800000, guid: b8f7dbec862e143b98cf342ad4b46952, type: 3}
-    m_TargetAsset: {fileID: 2800000, guid: b8f7dbec862e143b98cf342ad4b46952, type: 3}
+    m_MainAsset: {fileID: 0}
+    m_TargetAsset: {fileID: 0}
   - m_GUID: b9d906ecbf1694e63aa7160b78a3e0bf
     m_Address: normalTile_15
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tile
-    m_MainAsset: {fileID: 2800000, guid: b9d906ecbf1694e63aa7160b78a3e0bf, type: 3}
-    m_TargetAsset: {fileID: 2800000, guid: b9d906ecbf1694e63aa7160b78a3e0bf, type: 3}
+    m_MainAsset: {fileID: 0}
+    m_TargetAsset: {fileID: 0}
   - m_GUID: c9a3fc44eeb594f8dacee529949d6a51
-    m_Address: numberTile2
+    m_Address: numberTile_Pink
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tile
-    m_MainAsset: {fileID: 2800000, guid: c9a3fc44eeb594f8dacee529949d6a51, type: 3}
-    m_TargetAsset: {fileID: 2800000, guid: c9a3fc44eeb594f8dacee529949d6a51, type: 3}
+    m_MainAsset: {fileID: 0}
+    m_TargetAsset: {fileID: 0}
   - m_GUID: cdd3b2ecd95fd43a494aefcbe1cb66e6
     m_Address: normalTile_1
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tile
-    m_MainAsset: {fileID: 2800000, guid: cdd3b2ecd95fd43a494aefcbe1cb66e6, type: 3}
-    m_TargetAsset: {fileID: 2800000, guid: cdd3b2ecd95fd43a494aefcbe1cb66e6, type: 3}
+    m_MainAsset: {fileID: 0}
+    m_TargetAsset: {fileID: 0}
   - m_GUID: e104cc7fc139d423fa1bf074ecfcb842
     m_Address: normalTile_3
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tile
-    m_MainAsset: {fileID: 2800000, guid: e104cc7fc139d423fa1bf074ecfcb842, type: 3}
-    m_TargetAsset: {fileID: 2800000, guid: e104cc7fc139d423fa1bf074ecfcb842, type: 3}
+    m_MainAsset: {fileID: 0}
+    m_TargetAsset: {fileID: 0}
   - m_GUID: f3cb79b18e6fa4e548c931f68d35a3e8
-    m_Address: numberTile3
+    m_Address: numberTile_Orange
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tile
-    m_MainAsset: {fileID: 2800000, guid: f3cb79b18e6fa4e548c931f68d35a3e8, type: 3}
-    m_TargetAsset: {fileID: 2800000, guid: f3cb79b18e6fa4e548c931f68d35a3e8, type: 3}
+    m_MainAsset: {fileID: 0}
+    m_TargetAsset: {fileID: 0}
   - m_GUID: f9de4f74096404b6f8f21c34a2d39bdd
     m_Address: normalTile_6
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tile
-    m_MainAsset: {fileID: 2800000, guid: f9de4f74096404b6f8f21c34a2d39bdd, type: 3}
-    m_TargetAsset: {fileID: 2800000, guid: f9de4f74096404b6f8f21c34a2d39bdd, type: 3}
+    m_MainAsset: {fileID: 0}
+    m_TargetAsset: {fileID: 0}
   - m_GUID: fcb0abb225f41426bac72da393f6a241
     m_Address: normalTile_5
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tile
-    m_MainAsset: {fileID: 2800000, guid: fcb0abb225f41426bac72da393f6a241, type: 3}
-    m_TargetAsset: {fileID: 2800000, guid: fcb0abb225f41426bac72da393f6a241, type: 3}
+    m_MainAsset: {fileID: 0}
+    m_TargetAsset: {fileID: 0}
   m_ReadOnly: 0
   m_Settings: {fileID: 11400000, guid: 86a9d3876e9534cd69e69f31dd11bb5f, type: 2}
   m_SchemaSet:

--- a/Assets/Project/Actors/Bottles/Normal/NormalBottlePrefab.prefab
+++ b/Assets/Project/Actors/Bottles/Normal/NormalBottlePrefab.prefab
@@ -87,7 +87,7 @@ SpriteRenderer:
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
-  m_Size: {x: 2, y: 2}
+  m_Size: {x: 240, y: 264}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
@@ -110,8 +110,8 @@ BoxCollider2D:
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 200, y: 200}
-    newSize: {x: 2, y: 2}
+    oldSize: {x: 240, y: 264}
+    newSize: {x: 240, y: 264}
     adaptiveTilingThreshold: 0.5
     drawMode: 0
     adaptiveTiling: 0
@@ -163,10 +163,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 95e84251c113f49baab52aa39ff49b5b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Invincible: 0
+  isInvincible:
+    value: 0
   pressGesture: {fileID: 0}
   releaseGesture: {fileID: 0}
   IsMovable: 1
+  flickNum: 0
   longPressGesture: {fileID: 0}
 --- !u!222 &3899271857394035245
 CanvasRenderer:

--- a/Assets/Project/Actors/Tiles/Goal.meta
+++ b/Assets/Project/Actors/Tiles/Goal.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4f43525764a474df7a2125e0c6b9505c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/Actors/Tiles/Goal/GoalTilePrefab.prefab
+++ b/Assets/Project/Actors/Tiles/Goal/GoalTilePrefab.prefab
@@ -1,0 +1,112 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1257685958931130615
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1260897590933529755}
+  - component: {fileID: 1406191318001078179}
+  - component: {fileID: 4104404946434494885}
+  - component: {fileID: -9055332818116020086}
+  m_Layer: 12
+  m_Name: GoalTilePrefab
+  m_TagString: Tile
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1260897590933529755
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1257685958931130615}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &1406191318001078179
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1257685958931130615}
+  m_Enabled: 0
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 4294967295
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 1928078809
+  m_SortingLayer: 3
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 2, y: 2}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 0
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &4104404946434494885
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1257685958931130615}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c0c48ee6b0648441da1a1c58aef83f5b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  RatioToWindowWidth: 0.22
+  ImageRatio: 1
+--- !u!114 &-9055332818116020086
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1257685958931130615}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 393cce43e6e284d2191013e94345e789, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Project/Actors/Tiles/Goal/GoalTilePrefab.prefab.meta
+++ b/Assets/Project/Actors/Tiles/Goal/GoalTilePrefab.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: bf773a93995d0477695c2bb46e3c335b
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/GameDatas/Stages/Autumn_1/1.asset
+++ b/Assets/Project/GameDatas/Stages/Autumn_1/1.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 2001
   stageNumber: 1
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Autumn_1/10.asset
+++ b/Assets/Project/GameDatas/Stages/Autumn_1/10.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 2001
   stageNumber: 10
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Autumn_1/2.asset
+++ b/Assets/Project/GameDatas/Stages/Autumn_1/2.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 2001
   stageNumber: 2
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Autumn_1/3.asset
+++ b/Assets/Project/GameDatas/Stages/Autumn_1/3.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 2001
   stageNumber: 3
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Autumn_1/4.asset
+++ b/Assets/Project/GameDatas/Stages/Autumn_1/4.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 2001
   stageNumber: 4
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Autumn_1/5.asset
+++ b/Assets/Project/GameDatas/Stages/Autumn_1/5.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 2001
   stageNumber: 5
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Autumn_1/6.asset
+++ b/Assets/Project/GameDatas/Stages/Autumn_1/6.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 2001
   stageNumber: 6
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Autumn_1/7.asset
+++ b/Assets/Project/GameDatas/Stages/Autumn_1/7.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 2001
   stageNumber: 7
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Autumn_1/8.asset
+++ b/Assets/Project/GameDatas/Stages/Autumn_1/8.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 2001
   stageNumber: 8
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Autumn_1/9.asset
+++ b/Assets/Project/GameDatas/Stages/Autumn_1/9.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 2001
   stageNumber: 9
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Autumn_2/1.asset
+++ b/Assets/Project/GameDatas/Stages/Autumn_2/1.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 2002
   stageNumber: 1
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Autumn_2/10.asset
+++ b/Assets/Project/GameDatas/Stages/Autumn_2/10.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 2002
   stageNumber: 10
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Autumn_2/2.asset
+++ b/Assets/Project/GameDatas/Stages/Autumn_2/2.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 2002
   stageNumber: 2
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Autumn_2/3.asset
+++ b/Assets/Project/GameDatas/Stages/Autumn_2/3.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 2002
   stageNumber: 3
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Autumn_2/4.asset
+++ b/Assets/Project/GameDatas/Stages/Autumn_2/4.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 2002
   stageNumber: 4
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Autumn_2/5.asset
+++ b/Assets/Project/GameDatas/Stages/Autumn_2/5.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 2002
   stageNumber: 5
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Autumn_2/6.asset
+++ b/Assets/Project/GameDatas/Stages/Autumn_2/6.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 2002
   stageNumber: 6
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Autumn_2/7.asset
+++ b/Assets/Project/GameDatas/Stages/Autumn_2/7.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 2002
   stageNumber: 7
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Autumn_2/8.asset
+++ b/Assets/Project/GameDatas/Stages/Autumn_2/8.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 2002
   stageNumber: 8
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Autumn_2/9.asset
+++ b/Assets/Project/GameDatas/Stages/Autumn_2/9.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 2002
   stageNumber: 9
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Autumn_3/1.asset
+++ b/Assets/Project/GameDatas/Stages/Autumn_3/1.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 2003
   stageNumber: 1
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Autumn_3/10.asset
+++ b/Assets/Project/GameDatas/Stages/Autumn_3/10.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 2003
   stageNumber: 10
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Autumn_3/2.asset
+++ b/Assets/Project/GameDatas/Stages/Autumn_3/2.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 2003
   stageNumber: 2
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Autumn_3/3.asset
+++ b/Assets/Project/GameDatas/Stages/Autumn_3/3.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 2003
   stageNumber: 3
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Autumn_3/4.asset
+++ b/Assets/Project/GameDatas/Stages/Autumn_3/4.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 2003
   stageNumber: 4
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Autumn_3/5.asset
+++ b/Assets/Project/GameDatas/Stages/Autumn_3/5.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 2003
   stageNumber: 5
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Autumn_3/6.asset
+++ b/Assets/Project/GameDatas/Stages/Autumn_3/6.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 2003
   stageNumber: 6
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Autumn_3/7.asset
+++ b/Assets/Project/GameDatas/Stages/Autumn_3/7.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 2003
   stageNumber: 7
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Autumn_3/8.asset
+++ b/Assets/Project/GameDatas/Stages/Autumn_3/8.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 2003
   stageNumber: 8
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Autumn_3/9.asset
+++ b/Assets/Project/GameDatas/Stages/Autumn_3/9.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 2003
   stageNumber: 9
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Spring_1/1.asset
+++ b/Assets/Project/GameDatas/Stages/Spring_1/1.asset
@@ -15,36 +15,36 @@ MonoBehaviour:
   treeId: 1
   stageNumber: 1
   tiles:
-  - type: 0
+  - type: 1
     goalColor: 1
     number: 4
     pairNumber: 0
-  - type: 0
-    goalColor: 2
+  - type: 1
+    goalColor: 1
     number: 5
     pairNumber: 0
-  - type: 0
-    goalColor: 3
+  - type: 1
+    goalColor: 1
     number: 6
     pairNumber: 0
-  - type: 0
-    goalColor: 4
+  - type: 1
+    goalColor: 1
     number: 7
     pairNumber: 0
-  - type: 0
-    goalColor: 5
+  - type: 1
+    goalColor: 7
     number: 8
     pairNumber: 0
-  - type: 0
-    goalColor: 6
+  - type: 1
+    goalColor: 1
     number: 9
     pairNumber: 0
-  - type: 0
-    goalColor: 7
+  - type: 1
+    goalColor: 1
     number: 10
     pairNumber: 0
-  - type: 0
-    goalColor: 8
+  - type: 1
+    goalColor: 1
     number: 11
     pairNumber: 0
   bottles:
@@ -64,57 +64,50 @@ MonoBehaviour:
     isReverse: 0
   - type: 2
     initPos: 5
-    goalColor: 2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    goalColor: 3
+    goalColor: 1
     life: 1
     isSelfish: 1
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    goalColor: 4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    goalColor: 5
+    goalColor: 7
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    goalColor: 6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    goalColor: 7
+    goalColor: 1
     life: 3
     isSelfish: 0
-    isDark: 1
+    isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    goalColor: 8
+    goalColor: 1
     life: 5
-    isSelfish: 1
-    isDark: 1
-    isReverse: 0
-  - type: 1
-    initPos: 15
-    goalColor: 0
-    life: 0
     isSelfish: 0
     isDark: 0
     isReverse: 0

--- a/Assets/Project/GameDatas/Stages/Spring_1/1.asset
+++ b/Assets/Project/GameDatas/Stages/Spring_1/1.asset
@@ -15,206 +15,110 @@ MonoBehaviour:
   treeId: 1
   stageNumber: 1
   tiles:
-  - type: 1
-    number: 1
-    pairNumber: 2
+  - type: 0
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 0
+    goalColor: 2
+    number: 5
+    pairNumber: 0
+  - type: 0
+    goalColor: 3
+    number: 6
+    pairNumber: 0
+  - type: 0
+    goalColor: 4
+    number: 7
+    pairNumber: 0
+  - type: 0
+    goalColor: 5
+    number: 8
+    pairNumber: 0
+  - type: 0
+    goalColor: 6
+    number: 9
+    pairNumber: 0
+  - type: 0
+    goalColor: 7
+    number: 10
+    pairNumber: 0
+  - type: 0
+    goalColor: 8
+    number: 11
+    pairNumber: 0
   bottles:
   - type: 0
     initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
+    goalColor: 0
     life: 3
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 2
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 3
     life: 1
     isSelfish: 1
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 4
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 5
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 6
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 7
     life: 3
     isSelfish: 0
     isDark: 1
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 8
     life: 5
     isSelfish: 1
     isDark: 1
     isReverse: 0
   - type: 1
     initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
+    goalColor: 0
     life: 0
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  gimmicks:
-  - loop: 0
-    appearTime: 1
-    interval: 5
-    type: 4
-    targetDirections: 00000000
-    targetLines: 00000000
-    randomDirection: 
-    randomRow: 
-    randomColumn: 
-    targetRow: 0
-    targetColumn: 2
-    targetBottle: 0
-    randomAttackableBottles: 
-    isRandom: 0
-    targets:
-    - {x: 1, y: 1}
-    - {x: 2, y: 3}
-    - {x: 3, y: 3}
-    targetDirection: 0
-    attackTimes: 2
-    duration: 0
-    width: 0
-    height: 0
-  - loop: 1
-    appearTime: 3
-    interval: 5
-    type: 0
-    targetDirections: 00000000
-    targetLines: 03000000
-    randomDirection: 
-    randomRow: 
-    randomColumn: 
-    targetRow: 3
-    targetColumn: -1
-    targetBottle: 0
-    randomAttackableBottles: 
-    isRandom: 0
-    targets:
-    - {x: 1, y: 1}
-    targetDirection: 0
-    attackTimes: 1
-    duration: 0
-    width: 0
-    height: 0
-  - loop: 0
-    appearTime: 3
-    interval: 5
-    type: 0
-    targetDirections: 02000000
-    targetLines: 00000000
-    randomDirection: 
-    randomRow: 
-    randomColumn: 
-    targetRow: 3
-    targetColumn: -1
-    targetBottle: 0
-    randomAttackableBottles: 
-    isRandom: 0
-    targets:
-    - {x: 1, y: 1}
-    targetDirection: 0
-    attackTimes: 1
-    duration: 0
-    width: 0
-    height: 0
+  gimmicks: []
   overviewGimmicks: 
   tutorial:
     type: 1

--- a/Assets/Project/GameDatas/Stages/Spring_1/10.asset
+++ b/Assets/Project/GameDatas/Stages/Spring_1/10.asset
@@ -14,220 +14,98 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 1
   stageNumber: 10
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
-  gimmicks:
-  - loop: 1
-    appearTime: 1
-    interval: 5
-    type: 0
-    targetDirections: 00000000
-    targetLines: ffffffff
-    randomDirection: 0a0000000a0000000a0000000a000000
-    randomRow: 0a0000000a0000000a0000000a0000000a000000
-    randomColumn: 0a0000000a0000000a000000
-    targetRow: 0
-    targetColumn: 0
-    targetBottle: 0
-    randomAttackableBottles: 
-    isRandom: 1
-    targets: []
-    targetDirection: 0
-    attackTimes: 0
-    duration: 0
-    width: 0
-    height: 0
-  - loop: 1
-    appearTime: 1
-    interval: 5
-    type: 0
-    targetDirections: 0000000000000000
-    targetLines: ffffffffffffffff
-    randomDirection: 0a0000000a0000000a0000000a000000
-    randomRow: 0a0000000a0000000a0000000a0000000a000000
-    randomColumn: 0a0000000a0000000a000000
-    targetRow: 0
-    targetColumn: 0
-    targetBottle: 0
-    randomAttackableBottles: 
-    isRandom: 1
-    targets: []
-    targetDirection: 0
-    attackTimes: 0
-    duration: 0
-    width: 0
-    height: 0
-  - loop: 1
-    appearTime: 1
-    interval: 5
-    type: 1
-    targetDirections: 0000000000000000
-    targetLines: ffffffffffffffff
-    randomDirection: 0a0000000a0000000a0000000a000000
-    randomRow: 0a0000000a0000000a0000000a0000000a000000
-    randomColumn: 0a0000000a0000000a000000
-    targetRow: -1
-    targetColumn: -1
-    targetBottle: 0
-    randomAttackableBottles: 
-    isRandom: 1
-    targets: []
-    targetDirection: 0
-    attackTimes: 0
-    duration: 0
-    width: 0
-    height: 0
-  - loop: 1
-    appearTime: 1
-    interval: 5
-    type: 2
-    targetDirections: 0000000000000000
-    targetLines: ffffffffffffffff
-    randomDirection: 0a0000000a0000000a0000000a000000
-    randomRow: 0a0000000a0000000a0000000a0000000a000000
-    randomColumn: 0a0000000a0000000a000000
-    targetRow: 0
-    targetColumn: 0
-    targetBottle: 4
-    randomAttackableBottles: 0a0000000a0000000a0000000a0000000a0000000a0000000a0000000a000000
-    isRandom: 1
-    targets: []
-    targetDirection: 0
-    attackTimes: 0
-    duration: 0
-    width: 0
-    height: 0
-  overviewGimmicks: 
+  gimmicks: []
+  overviewGimmicks:
   tutorial:
     type: 0
     image:

--- a/Assets/Project/GameDatas/Stages/Spring_1/2.asset
+++ b/Assets/Project/GameDatas/Stages/Spring_1/2.asset
@@ -15,136 +15,97 @@ MonoBehaviour:
   treeId: 1
   stageNumber: 2
   tiles:
-  - type: 4
-    number: 14
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
     pairNumber: 0
   bottles:
   - type: 2
-    initPos: 1
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
-    life: 3
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
-  - type: 2
-    initPos: 3
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
-    life: 4
+    initPos: 4
+    goalColor: 1
+    life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
+    life: 1
+    isSelfish: 0
+    isDark: 0
+    isReverse: 0
+  - type: 2
+    initPos: 7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
-    initPos: 11
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    initPos: 9
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
-    initPos: 13
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    initPos: 10
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
-    initPos: 15
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    initPos: 14
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  gimmicks:
-  - loop: 1
-    appearTime: 3
-    interval: 5
-    type: 0
-    targetDirections: 0000000003000000010000000200000000000000
-    targetLines: 0200000000000000030000000200000000000000
-    randomDirection: 320000001e0000001400000050000000
-    randomRow: 1e0000001e0000000a0000000000000000000000
-    randomColumn: 320000001e00000000000000
-    targetRow: 0
-    targetColumn: 0
-    targetBottle: 0
-    randomAttackableBottles: 
-    isRandom: 0
-    targets: []
-    targetDirection: 0
-    attackTimes: 0
-    duration: 0
-    width: 0
-    height: 0
-  overviewGimmicks: 00000000
+  gimmicks: []
+  overviewGimmicks:
   tutorial:
     type: 2
     image:

--- a/Assets/Project/GameDatas/Stages/Spring_1/3.asset
+++ b/Assets/Project/GameDatas/Stages/Spring_1/3.asset
@@ -15,149 +15,97 @@ MonoBehaviour:
   treeId: 1
   stageNumber: 3
   tiles:
-  - type: 2
-    number: 1
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
     pairNumber: 0
   bottles:
   - type: 2
+    initPos: 4
+    goalColor: 1
+    life: 1
+    isSelfish: 0
+    isDark: 0
+    isReverse: 0
+  - type: 2
+    initPos: 5
+    goalColor: 1
+    life: 1
+    isSelfish: 0
+    isDark: 0
+    isReverse: 0
+  - type: 2
+    initPos: 6
+    goalColor: 1
+    life: 1
+    isSelfish: 0
+    isDark: 0
+    isReverse: 0
+  - type: 2
     initPos: 7
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
-    life: 1
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
-  - type: 2
-    initPos: 11
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
-    life: 1
-    isSelfish: 0
-    isDark: 1
-    isReverse: 0
-  - type: 2
-    initPos: 12
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
-    life: 1
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
-  - type: 2
-    initPos: 13
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 2
-    initPos: 1
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
-    life: 3
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
-  gimmicks:
-  - loop: 1
-    appearTime: 1
-    interval: 5
-    type: 0
-    targetDirections: 0000000003000000010000000200000000000000
-    targetLines: 0000000000000000010000000200000000000000
-    randomDirection: 
-    randomRow: 
-    randomColumn: 
-    targetRow: 0
-    targetColumn: 0
-    targetBottle: 0
-    randomAttackableBottles: 
-    isRandom: 0
-    targets: []
-    targetDirection: 0
-    attackTimes: 0
-    duration: 0
-    width: 0
-    height: 0
-  overviewGimmicks: 01000000
+  gimmicks: []
+  overviewGimmicks: 
   tutorial:
     type: 0
     image:

--- a/Assets/Project/GameDatas/Stages/Spring_1/4.asset
+++ b/Assets/Project/GameDatas/Stages/Spring_1/4.asset
@@ -15,136 +15,97 @@ MonoBehaviour:
   treeId: 1
   stageNumber: 4
   tiles:
-  - type: 3
-    number: 2
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
     pairNumber: 0
   bottles:
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  gimmicks:
-  - loop: 1
-    appearTime: 1
-    interval: 5
-    type: 1
-    targetDirections: 00000000
-    targetLines: 00000000
-    randomDirection: 
-    randomRow: 
-    randomColumn: 
-    targetRow: 1
-    targetColumn: 1
-    targetBottle: 0
-    randomAttackableBottles: 
-    isRandom: 0
-    targets: []
-    targetDirection: 0
-    attackTimes: 0
-    duration: 0
-    width: 0
-    height: 0
-  overviewGimmicks: 
+  gimmicks: []
+  overviewGimmicks:
   tutorial:
     type: 0
     image:

--- a/Assets/Project/GameDatas/Stages/Spring_1/5.asset
+++ b/Assets/Project/GameDatas/Stages/Spring_1/5.asset
@@ -14,154 +14,98 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 1
   stageNumber: 5
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 12
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  gimmicks:
-  - loop: 1
-    appearTime: 1
-    interval: 10
-    type: 2
-    targetDirections: 00000000
-    targetLines: 00000000
-    randomDirection: 
-    randomRow: 
-    randomColumn: 
-    targetRow: 0
-    targetColumn: 0
-    targetBottle: 4
-    randomAttackableBottles: 
-    isRandom: 0
-    targets: []
-    targetDirection: 0
-    attackTimes: 0
-    duration: 0
-    width: 0
-    height: 0
-  - loop: 1
-    appearTime: 6
-    interval: 10
-    type: 2
-    targetDirections: 00000000
-    targetLines: 00000000
-    randomDirection: 
-    randomRow: 
-    randomColumn: 
-    targetRow: 0
-    targetColumn: 0
-    targetBottle: 5
-    randomAttackableBottles: 
-    isRandom: 0
-    targets: []
-    targetDirection: 0
-    attackTimes: 0
-    duration: 0
-    width: 0
-    height: 0
-  overviewGimmicks: 
+  gimmicks: []
+  overviewGimmicks:
   tutorial:
     type: 0
     image:

--- a/Assets/Project/GameDatas/Stages/Spring_1/6.asset
+++ b/Assets/Project/GameDatas/Stages/Spring_1/6.asset
@@ -14,134 +14,98 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 1
   stageNumber: 6
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  gimmicks:
-  - loop: 1
-    appearTime: 1
-    interval: 5
-    type: 0
-    targetDirections: 00000000
-    targetLines: ffffffff
-    randomDirection: c80000000a000000640000000a000000
-    randomRow: 6400000005000000050000000500000064000000
-    randomColumn: 640000000a00000000000000
-    targetRow: 0
-    targetColumn: 0
-    targetBottle: 0
-    randomAttackableBottles: 
-    isRandom: 1
-    targets: []
-    targetDirection: 0
-    attackTimes: 0
-    duration: 0
-    width: 0
-    height: 0
-  overviewGimmicks: 
+  gimmicks: []
+  overviewGimmicks:
   tutorial:
     type: 0
     image:

--- a/Assets/Project/GameDatas/Stages/Spring_1/7.asset
+++ b/Assets/Project/GameDatas/Stages/Spring_1/7.asset
@@ -14,134 +14,98 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 1
   stageNumber: 7
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  gimmicks:
-  - loop: 1
-    appearTime: 1
-    interval: 5
-    type: 0
-    targetDirections: 0000000000000000
-    targetLines: ffffffffffffffff
-    randomDirection: 01000000010000000100000001000000
-    randomRow: 0100000000000000000000000000000000000000
-    randomColumn: 000000000a0000000a000000
-    targetRow: 0
-    targetColumn: 0
-    targetBottle: 0
-    randomAttackableBottles: 
-    isRandom: 1
-    targets: []
-    targetDirection: 0
-    attackTimes: 0
-    duration: 0
-    width: 0
-    height: 0
-  overviewGimmicks: 
+  gimmicks: []
+  overviewGimmicks:
   tutorial:
     type: 0
     image:

--- a/Assets/Project/GameDatas/Stages/Spring_1/8.asset
+++ b/Assets/Project/GameDatas/Stages/Spring_1/8.asset
@@ -14,134 +14,98 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 1
   stageNumber: 8
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  gimmicks:
-  - loop: 1
-    appearTime: 1
-    interval: 5
-    type: 1
-    targetDirections: 00000000
-    targetLines: 00000000
-    randomDirection: 
-    randomRow: 6400000014000000140000001400000064000000
-    randomColumn: 1e000000640000001e000000
-    targetRow: -1
-    targetColumn: -1
-    targetBottle: 0
-    randomAttackableBottles: 
-    isRandom: 1
-    targets: []
-    targetDirection: 0
-    attackTimes: 0
-    duration: 0
-    width: 0
-    height: 0
-  overviewGimmicks: 
+  gimmicks: []
+  overviewGimmicks:
   tutorial:
     type: 0
     image:

--- a/Assets/Project/GameDatas/Stages/Spring_1/9.asset
+++ b/Assets/Project/GameDatas/Stages/Spring_1/9.asset
@@ -14,134 +14,98 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 1
   stageNumber: 9
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  gimmicks:
-  - loop: 1
-    appearTime: 1
-    interval: 5
-    type: 2
-    targetDirections: 00000000
-    targetLines: 00000000
-    randomDirection: 
-    randomRow: 
-    randomColumn: 
-    targetRow: 0
-    targetColumn: 0
-    targetBottle: 4
-    randomAttackableBottles: 0a000000000000000a000000000000000a000000000000000a0000000a000000
-    isRandom: 1
-    targets: []
-    targetDirection: 0
-    attackTimes: 0
-    duration: 0
-    width: 0
-    height: 0
-  overviewGimmicks: 
+  gimmicks: []
+  overviewGimmicks:
   tutorial:
     type: 0
     image:

--- a/Assets/Project/GameDatas/Stages/Spring_2/1.asset
+++ b/Assets/Project/GameDatas/Stages/Spring_2/1.asset
@@ -14,214 +14,98 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 2
   stageNumber: 1
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
-    life: 2
-    isSelfish: 1
+    goalColor: 1
+    life: 1
+    isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  gimmicks:
-  - loop: 0
-    appearTime: 1
-    interval: 0
-    type: 6
-    targetDirections: 
-    targetLines: 
-    randomDirection: 
-    randomRow: 
-    randomColumn: 
-    targetRow: 0
-    targetColumn: 0
-    targetBottle: 0
-    randomAttackableBottles: 
-    isRandom: 0
-    targets: []
-    targetDirection: 0
-    attackTimes: 0
-    duration: 1000
-    width: 1
-    height: 1
-  - loop: 0
-    appearTime: 1
-    interval: 0
-    type: 6
-    targetDirections: 
-    targetLines: 
-    randomDirection: 
-    randomRow: 
-    randomColumn: 
-    targetRow: 0
-    targetColumn: 1
-    targetBottle: 0
-    randomAttackableBottles: 
-    isRandom: 0
-    targets: []
-    targetDirection: 0
-    attackTimes: 0
-    duration: 1000
-    width: 2
-    height: 1
-  - loop: 1
-    appearTime: 1
-    interval: 2
-    type: 1
-    targetDirections: 
-    targetLines: 
-    randomDirection: 
-    randomRow: 
-    randomColumn: 
-    targetRow: 1
-    targetColumn: 2
-    targetBottle: 0
-    randomAttackableBottles: 
-    isRandom: 0
-    targets: []
-    targetDirection: 0
-    attackTimes: 0
-    duration: 0
-    width: 0
-    height: 0
-  - loop: 0
-    appearTime: 1
-    interval: 0
-    type: 6
-    targetDirections: 
-    targetLines: 
-    randomDirection: 
-    randomRow: 
-    randomColumn: 
-    targetRow: 3
-    targetColumn: 0
-    targetBottle: 0
-    randomAttackableBottles: 
-    isRandom: 0
-    targets: []
-    targetDirection: 0
-    attackTimes: 0
-    duration: 1000
-    width: 1
-    height: 2
-  - loop: 1
-    appearTime: 2
-    interval: 1
-    type: 6
-    targetDirections: 
-    targetLines: 
-    randomDirection: 
-    randomRow: 0a0000000a0000000a0000000a000000
-    randomColumn: 0a0000000a000000
-    targetRow: -1
-    targetColumn: -1
-    targetBottle: 0
-    randomAttackableBottles: 
-    isRandom: 1
-    targets: []
-    targetDirection: 0
-    attackTimes: 0
-    duration: 1
-    width: 2
-    height: 2
-  overviewGimmicks: 
+  gimmicks: []
+  overviewGimmicks:
   tutorial:
     type: 0
     image:

--- a/Assets/Project/GameDatas/Stages/Spring_2/10.asset
+++ b/Assets/Project/GameDatas/Stages/Spring_2/10.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 2
   stageNumber: 10
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Spring_2/2.asset
+++ b/Assets/Project/GameDatas/Stages/Spring_2/2.asset
@@ -15,165 +15,97 @@ MonoBehaviour:
   treeId: 2
   stageNumber: 2
   tiles:
-  - type: 2
-    number: 1
+  - type: 1
+    goalColor: 1
+    number: 4
     pairNumber: 0
-  - type: 2
-    number: 2
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
     pairNumber: 0
   bottles:
   - type: 2
-    initPos: 1
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
-    life: 3
+    initPos: 4
+    goalColor: 1
+    life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
-    life: 3
+    goalColor: 1
+    life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
-    life: 3
+    goalColor: 1
+    life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
-    life: 3
+    goalColor: 1
+    life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
-    life: 3
+    goalColor: 1
+    life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
-    life: 3
+    goalColor: 1
+    life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
-    life: 3
+    goalColor: 1
+    life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
-    life: 3
+    goalColor: 1
+    life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
-  gimmicks:
-  - loop: 0
-    appearTime: 0
-    interval: 0
-    type: 7
-    targetDirections: 
-    targetLines: 
-    randomDirection: 
-    randomRow: 
-    randomColumn: 
-    targetRow: -1
-    targetColumn: -1
-    targetBottle: 0
-    randomAttackableBottles: 
-    isRandom: 0
-    targets: []
-    targetDirection: 0
-    attackTimes: 0
-    duration: 0
-    width: 0
-    height: 0
-  overviewGimmicks: 
+  gimmicks: []
+  overviewGimmicks:
   tutorial:
     type: 0
     image:

--- a/Assets/Project/GameDatas/Stages/Spring_2/3.asset
+++ b/Assets/Project/GameDatas/Stages/Spring_2/3.asset
@@ -14,140 +14,98 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 2
   stageNumber: 3
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
-    life: 3
+    goalColor: 1
+    life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
-    life: 3
+    goalColor: 1
+    life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
-    life: 3
+    goalColor: 1
+    life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
-    life: 3
+    goalColor: 1
+    life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
-    life: 3
+    goalColor: 1
+    life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
-    life: 3
+    goalColor: 1
+    life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
-    life: 3
+    goalColor: 1
+    life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
-    life: 3
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 1
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
+    goalColor: 1
+    life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:

--- a/Assets/Project/GameDatas/Stages/Spring_2/4.asset
+++ b/Assets/Project/GameDatas/Stages/Spring_2/4.asset
@@ -14,147 +14,98 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 2
   stageNumber: 4
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
   - type: 2
+    initPos: 4
+    goalColor: 1
+    life: 1
+    isSelfish: 0
+    isDark: 0
+    isReverse: 0
+  - type: 2
+    initPos: 5
+    goalColor: 1
+    life: 1
+    isSelfish: 0
+    isDark: 0
+    isReverse: 0
+  - type: 2
+    initPos: 6
+    goalColor: 1
+    life: 1
+    isSelfish: 0
+    isDark: 0
+    isReverse: 0
+  - type: 2
     initPos: 7
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
-    life: 1
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
-  - type: 2
-    initPos: 11
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
-    life: 1
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
-  - type: 2
-    initPos: 12
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
-    life: 1
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
-  - type: 2
-    initPos: 13
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 3
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: dced690fd94db4ea6990cf6eb1e723b6
-      m_SubObjectName: attackableDummy
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
-    life: 1
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
-  gimmicks:
-  - loop: 1
-    appearTime: 1
-    interval: 5
-    type: 0
-    targetDirections: 0000000003000000000000000200000000000000
-    targetLines: 0000000002000000010000000000000000000000
-    randomDirection: 
-    randomRow: 
-    randomColumn: 
-    targetRow: 0
-    targetColumn: 0
-    targetBottle: 0
-    randomAttackableBottles: 
-    isRandom: 0
-    targets: []
-    targetDirection: 0
-    attackTimes: 0
-    duration: 0
-    width: 0
-    height: 0
-  overviewGimmicks: 
+  gimmicks: []
+  overviewGimmicks:
   tutorial:
     type: 0
     image:

--- a/Assets/Project/GameDatas/Stages/Spring_2/5.asset
+++ b/Assets/Project/GameDatas/Stages/Spring_2/5.asset
@@ -14,134 +14,98 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 2
   stageNumber: 5
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
   - type: 2
-    initPos: 7
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
-    life: 2
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
-  - type: 2
-    initPos: 8
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
-    life: 2
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
-  - type: 2
-    initPos: 9
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
-    life: 2
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
-  - type: 2
-    initPos: 10
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
-    life: 2
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
-  - type: 2
-    initPos: 11
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
-    life: 2
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
-  - type: 2
-    initPos: 12
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    initPos: 4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
-    initPos: 13
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
-    life: 2
+    initPos: 5
+    goalColor: 1
+    life: 1
+    isSelfish: 0
+    isDark: 0
+    isReverse: 0
+  - type: 2
+    initPos: 6
+    goalColor: 1
+    life: 1
+    isSelfish: 0
+    isDark: 0
+    isReverse: 0
+  - type: 2
+    initPos: 7
+    goalColor: 1
+    life: 1
+    isSelfish: 0
+    isDark: 0
+    isReverse: 0
+  - type: 2
+    initPos: 8
+    goalColor: 1
+    life: 1
+    isSelfish: 0
+    isDark: 0
+    isReverse: 0
+  - type: 2
+    initPos: 9
+    goalColor: 1
+    life: 1
+    isSelfish: 0
+    isDark: 0
+    isReverse: 0
+  - type: 2
+    initPos: 10
+    goalColor: 1
+    life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
-    life: 2
+    goalColor: 1
+    life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  gimmicks:
-  - loop: 1
-    appearTime: 1
-    interval: 5
-    type: 0
-    targetDirections: 0000000003000000000000000200000000000000
-    targetLines: 0000000002000000010000000000000000000000
-    randomDirection: 
-    randomRow: 
-    randomColumn: 
-    targetRow: 0
-    targetColumn: 0
-    targetBottle: 0
-    randomAttackableBottles: 
-    isRandom: 0
-    targets: []
-    targetDirection: 0
-    attackTimes: 0
-    duration: 0
-    width: 0
-    height: 0
-  overviewGimmicks: 
+  gimmicks: []
+  overviewGimmicks:
   tutorial:
     type: 0
     image:

--- a/Assets/Project/GameDatas/Stages/Spring_2/6.asset
+++ b/Assets/Project/GameDatas/Stages/Spring_2/6.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 2
   stageNumber: 6
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Spring_2/7.asset
+++ b/Assets/Project/GameDatas/Stages/Spring_2/7.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 2
   stageNumber: 7
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Spring_2/8.asset
+++ b/Assets/Project/GameDatas/Stages/Spring_2/8.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 2
   stageNumber: 8
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Spring_2/9.asset
+++ b/Assets/Project/GameDatas/Stages/Spring_2/9.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 2
   stageNumber: 9
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Spring_3/1.asset
+++ b/Assets/Project/GameDatas/Stages/Spring_3/1.asset
@@ -14,184 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 3
   stageNumber: 1
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
-  gimmicks:
-  - loop: 1
-    appearTime: 2
-    interval: 2
-    type: 5
-    targetDirections: 
-    targetLines: 
-    randomDirection: 
-    randomRow: 
-    randomColumn: 
-    targetRow: 2
-    targetColumn: -1
-    targetBottle: 0
-    randomAttackableBottles: 
-    isRandom: 0
-    targets: []
-    targetDirection: 0
-    attackTimes: 0
-    duration: 0
-    width: 0
-    height: 0
-  - loop: 1
-    appearTime: 2
-    interval: 2
-    type: 5
-    targetDirections: 
-    targetLines: 
-    randomDirection: 
-    randomRow: 
-    randomColumn: 
-    targetRow: 2
-    targetColumn: 1
-    targetBottle: 0
-    randomAttackableBottles: 
-    isRandom: 0
-    targets: []
-    targetDirection: 2
-    attackTimes: 0
-    duration: 0
-    width: 0
-    height: 0
-  overviewGimmicks: 
+  gimmicks: []
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Spring_3/10.asset
+++ b/Assets/Project/GameDatas/Stages/Spring_3/10.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 3
   stageNumber: 10
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Spring_3/2.asset
+++ b/Assets/Project/GameDatas/Stages/Spring_3/2.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 3
   stageNumber: 2
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Spring_3/3.asset
+++ b/Assets/Project/GameDatas/Stages/Spring_3/3.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 3
   stageNumber: 3
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Spring_3/4.asset
+++ b/Assets/Project/GameDatas/Stages/Spring_3/4.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 3
   stageNumber: 4
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Spring_3/5.asset
+++ b/Assets/Project/GameDatas/Stages/Spring_3/5.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 3
   stageNumber: 5
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Spring_3/6.asset
+++ b/Assets/Project/GameDatas/Stages/Spring_3/6.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 3
   stageNumber: 6
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Spring_3/7.asset
+++ b/Assets/Project/GameDatas/Stages/Spring_3/7.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 3
   stageNumber: 7
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Spring_3/8.asset
+++ b/Assets/Project/GameDatas/Stages/Spring_3/8.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 3
   stageNumber: 8
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Spring_3/9.asset
+++ b/Assets/Project/GameDatas/Stages/Spring_3/9.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 3
   stageNumber: 9
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Summer_1/1.asset
+++ b/Assets/Project/GameDatas/Stages/Summer_1/1.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 1001
   stageNumber: 1
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Summer_1/10.asset
+++ b/Assets/Project/GameDatas/Stages/Summer_1/10.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 1001
   stageNumber: 10
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Summer_1/2.asset
+++ b/Assets/Project/GameDatas/Stages/Summer_1/2.asset
@@ -14,224 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 1001
   stageNumber: 2
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
-  gimmicks:
-  - loop: 1
-    appearTime: 2
-    interval: 6
-    type: 5
-    targetDirections: 00000000
-    targetLines: 00000000
-    randomDirection: 
-    randomRow: 
-    randomColumn: 
-    targetRow: 0
-    targetColumn: 0
-    targetBottle: 0
-    randomAttackableBottles: 
-    isRandom: 0
-    targets: []
-    targetDirection: 1
-    attackTimes: 1
-    duration: 0
-    width: 0
-    height: 0
-  - loop: 1
-    appearTime: 3
-    interval: 6
-    type: 5
-    targetDirections: 00000000
-    targetLines: 00000000
-    randomDirection: 
-    randomRow: 
-    randomColumn: 
-    targetRow: 2
-    targetColumn: 2
-    targetBottle: 0
-    randomAttackableBottles: 
-    isRandom: 0
-    targets: []
-    targetDirection: 3
-    attackTimes: 1
-    duration: 0
-    width: 0
-    height: 0
-  - loop: 1
-    appearTime: 4
-    interval: 6
-    type: 5
-    targetDirections: 00000000
-    targetLines: 00000000
-    randomDirection: 
-    randomRow: 
-    randomColumn: 
-    targetRow: 4
-    targetColumn: 0
-    targetBottle: 0
-    randomAttackableBottles: 
-    isRandom: 0
-    targets: []
-    targetDirection: 0
-    attackTimes: 1
-    duration: 0
-    width: 0
-    height: 0
-  - loop: 1
-    appearTime: 5
-    interval: 6
-    type: 5
-    targetDirections: 00000000
-    targetLines: 00000000
-    randomDirection: 
-    randomRow: 
-    randomColumn: 
-    targetRow: 2
-    targetColumn: 0
-    targetBottle: 0
-    randomAttackableBottles: 
-    isRandom: 0
-    targets: []
-    targetDirection: 2
-    attackTimes: 1
-    duration: 0
-    width: 0
-    height: 0
-  overviewGimmicks: 
+  gimmicks: []
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Summer_1/3.asset
+++ b/Assets/Project/GameDatas/Stages/Summer_1/3.asset
@@ -14,164 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 1001
   stageNumber: 3
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
+  - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
-    life: 0
+    goalColor: 1
+    life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
-  gimmicks:
-  - loop: 1
-    appearTime: 1
-    interval: 5
-    type: 5
-    targetDirections: 00000000
-    targetLines: 00000000
-    randomDirection: 
-    randomRow: 
-    randomColumn: 
-    targetRow: 1
-    targetColumn: 1
-    targetBottle: 0
-    randomAttackableBottles: 
-    isRandom: 0
-    targets: []
-    targetDirection: 2
-    attackTimes: 0
-    duration: 0
-    width: 0
-    height: 0
-  overviewGimmicks: 
+  gimmicks: []
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Summer_1/4.asset
+++ b/Assets/Project/GameDatas/Stages/Summer_1/4.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 1001
   stageNumber: 4
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Summer_1/5.asset
+++ b/Assets/Project/GameDatas/Stages/Summer_1/5.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 1001
   stageNumber: 5
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Summer_1/6.asset
+++ b/Assets/Project/GameDatas/Stages/Summer_1/6.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 1001
   stageNumber: 6
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Summer_1/7.asset
+++ b/Assets/Project/GameDatas/Stages/Summer_1/7.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 1001
   stageNumber: 7
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Summer_1/8.asset
+++ b/Assets/Project/GameDatas/Stages/Summer_1/8.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 1001
   stageNumber: 8
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Summer_1/9.asset
+++ b/Assets/Project/GameDatas/Stages/Summer_1/9.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 1001
   stageNumber: 9
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Summer_2/1.asset
+++ b/Assets/Project/GameDatas/Stages/Summer_2/1.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 1002
   stageNumber: 1
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Summer_2/10.asset
+++ b/Assets/Project/GameDatas/Stages/Summer_2/10.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 1002
   stageNumber: 10
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Summer_2/2.asset
+++ b/Assets/Project/GameDatas/Stages/Summer_2/2.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 1002
   stageNumber: 2
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Summer_2/3.asset
+++ b/Assets/Project/GameDatas/Stages/Summer_2/3.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 1002
   stageNumber: 3
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Summer_2/4.asset
+++ b/Assets/Project/GameDatas/Stages/Summer_2/4.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 1002
   stageNumber: 4
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Summer_2/5.asset
+++ b/Assets/Project/GameDatas/Stages/Summer_2/5.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 1002
   stageNumber: 5
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Summer_2/6.asset
+++ b/Assets/Project/GameDatas/Stages/Summer_2/6.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 1002
   stageNumber: 6
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Summer_2/7.asset
+++ b/Assets/Project/GameDatas/Stages/Summer_2/7.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 1002
   stageNumber: 7
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Summer_2/8.asset
+++ b/Assets/Project/GameDatas/Stages/Summer_2/8.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 1002
   stageNumber: 8
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Summer_2/9.asset
+++ b/Assets/Project/GameDatas/Stages/Summer_2/9.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 1002
   stageNumber: 9
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Summer_3/1.asset
+++ b/Assets/Project/GameDatas/Stages/Summer_3/1.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 1003
   stageNumber: 1
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Summer_3/10.asset
+++ b/Assets/Project/GameDatas/Stages/Summer_3/10.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 1003
   stageNumber: 10
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Summer_3/2.asset
+++ b/Assets/Project/GameDatas/Stages/Summer_3/2.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 1003
   stageNumber: 2
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Summer_3/3.asset
+++ b/Assets/Project/GameDatas/Stages/Summer_3/3.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 1003
   stageNumber: 3
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Summer_3/4.asset
+++ b/Assets/Project/GameDatas/Stages/Summer_3/4.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 1003
   stageNumber: 4
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Summer_3/5.asset
+++ b/Assets/Project/GameDatas/Stages/Summer_3/5.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 1003
   stageNumber: 5
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Summer_3/6.asset
+++ b/Assets/Project/GameDatas/Stages/Summer_3/6.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 1003
   stageNumber: 6
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Summer_3/7.asset
+++ b/Assets/Project/GameDatas/Stages/Summer_3/7.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 1003
   stageNumber: 7
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Summer_3/8.asset
+++ b/Assets/Project/GameDatas/Stages/Summer_3/8.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 1003
   stageNumber: 8
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Summer_3/9.asset
+++ b/Assets/Project/GameDatas/Stages/Summer_3/9.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 1003
   stageNumber: 9
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Winter_1/1.asset
+++ b/Assets/Project/GameDatas/Stages/Winter_1/1.asset
@@ -14,164 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 3001
   stageNumber: 1
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
-  gimmicks:
-  - loop: 0
-    appearTime: 0
-    interval: 0
-    type: 8
-    targetDirections: 
-    targetLines: 
-    randomDirection: 
-    randomRow: 
-    randomColumn: 
-    targetRow: -1
-    targetColumn: -1
-    targetBottle: 0
-    randomAttackableBottles: 
-    isRandom: 0
-    targets: []
-    targetDirection: 0
-    attackTimes: 0
-    duration: 0
-    width: 0
-    height: 0
-  overviewGimmicks: 
+  gimmicks: []
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Winter_1/10.asset
+++ b/Assets/Project/GameDatas/Stages/Winter_1/10.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 3001
   stageNumber: 10
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Winter_1/2.asset
+++ b/Assets/Project/GameDatas/Stages/Winter_1/2.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 3001
   stageNumber: 2
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Winter_1/3.asset
+++ b/Assets/Project/GameDatas/Stages/Winter_1/3.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 3001
   stageNumber: 3
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Winter_1/4.asset
+++ b/Assets/Project/GameDatas/Stages/Winter_1/4.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 3001
   stageNumber: 4
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Winter_1/5.asset
+++ b/Assets/Project/GameDatas/Stages/Winter_1/5.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 3001
   stageNumber: 5
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Winter_1/6.asset
+++ b/Assets/Project/GameDatas/Stages/Winter_1/6.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 3001
   stageNumber: 6
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Winter_1/7.asset
+++ b/Assets/Project/GameDatas/Stages/Winter_1/7.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 3001
   stageNumber: 7
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Winter_1/8.asset
+++ b/Assets/Project/GameDatas/Stages/Winter_1/8.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 3001
   stageNumber: 8
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Winter_1/9.asset
+++ b/Assets/Project/GameDatas/Stages/Winter_1/9.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 3001
   stageNumber: 9
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Winter_2/1.asset
+++ b/Assets/Project/GameDatas/Stages/Winter_2/1.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 3002
   stageNumber: 1
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Winter_2/10.asset
+++ b/Assets/Project/GameDatas/Stages/Winter_2/10.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 3002
   stageNumber: 10
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Winter_2/2.asset
+++ b/Assets/Project/GameDatas/Stages/Winter_2/2.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 3002
   stageNumber: 2
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Winter_2/3.asset
+++ b/Assets/Project/GameDatas/Stages/Winter_2/3.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 3002
   stageNumber: 3
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Winter_2/4.asset
+++ b/Assets/Project/GameDatas/Stages/Winter_2/4.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 3002
   stageNumber: 4
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Winter_2/5.asset
+++ b/Assets/Project/GameDatas/Stages/Winter_2/5.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 3002
   stageNumber: 5
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Winter_2/6.asset
+++ b/Assets/Project/GameDatas/Stages/Winter_2/6.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 3002
   stageNumber: 6
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Winter_2/7.asset
+++ b/Assets/Project/GameDatas/Stages/Winter_2/7.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 3002
   stageNumber: 7
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Winter_2/8.asset
+++ b/Assets/Project/GameDatas/Stages/Winter_2/8.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 3002
   stageNumber: 8
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Winter_2/9.asset
+++ b/Assets/Project/GameDatas/Stages/Winter_2/9.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 3002
   stageNumber: 9
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Winter_3/1.asset
+++ b/Assets/Project/GameDatas/Stages/Winter_3/1.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 3003
   stageNumber: 1
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Winter_3/10.asset
+++ b/Assets/Project/GameDatas/Stages/Winter_3/10.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 3003
   stageNumber: 10
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Winter_3/2.asset
+++ b/Assets/Project/GameDatas/Stages/Winter_3/2.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 3003
   stageNumber: 2
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Winter_3/3.asset
+++ b/Assets/Project/GameDatas/Stages/Winter_3/3.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 3003
   stageNumber: 3
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Winter_3/4.asset
+++ b/Assets/Project/GameDatas/Stages/Winter_3/4.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 3003
   stageNumber: 4
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Winter_3/5.asset
+++ b/Assets/Project/GameDatas/Stages/Winter_3/5.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 3003
   stageNumber: 5
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Winter_3/6.asset
+++ b/Assets/Project/GameDatas/Stages/Winter_3/6.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 3003
   stageNumber: 6
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Winter_3/7.asset
+++ b/Assets/Project/GameDatas/Stages/Winter_3/7.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 3003
   stageNumber: 7
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Winter_3/8.asset
+++ b/Assets/Project/GameDatas/Stages/Winter_3/8.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 3003
   stageNumber: 8
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/GameDatas/Stages/Winter_3/9.asset
+++ b/Assets/Project/GameDatas/Stages/Winter_3/9.asset
@@ -14,144 +14,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   treeId: 3003
   stageNumber: 9
-  tiles: []
+  tiles:
+  - type: 1
+    goalColor: 1
+    number: 4
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 5
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 6
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 7
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 8
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 9
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 10
+    pairNumber: 0
+  - type: 1
+    goalColor: 1
+    number: 11
+    pairNumber: 0
   bottles:
-  - type: 0
-    initPos: 3
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   - type: 2
     initPos: 4
-    targetPos: 4
-    bottleSprite:
-      m_AssetGUID: c7e771d42b34e444cb9570cbace8f66b
-      m_SubObjectName: normalBottle_1
-    targetTileSprite:
-      m_AssetGUID: 621ad890756e54e6d93e52c8911cfcc3
-      m_SubObjectName: numberTile1
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 5
-    targetPos: 5
-    bottleSprite:
-      m_AssetGUID: 77afffe8c8ad8478fac611078bf02cdd
-      m_SubObjectName: normalBottle_2
-    targetTileSprite:
-      m_AssetGUID: c9a3fc44eeb594f8dacee529949d6a51
-      m_SubObjectName: numberTile2
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 6
-    targetPos: 6
-    bottleSprite:
-      m_AssetGUID: dc8347884678a4c3eab9a812d91f796f
-      m_SubObjectName: normalBottle_3
-    targetTileSprite:
-      m_AssetGUID: f3cb79b18e6fa4e548c931f68d35a3e8
-      m_SubObjectName: numberTile3
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 7
-    targetPos: 7
-    bottleSprite:
-      m_AssetGUID: bc5b41ad84210436b8d054663a3f2754
-      m_SubObjectName: normalBottle_4
-    targetTileSprite:
-      m_AssetGUID: 75c32df0ab0684c329e34ac831a5c9b3
-      m_SubObjectName: numberTile4
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 8
-    targetPos: 8
-    bottleSprite:
-      m_AssetGUID: fad0ddda9821b4c0eae4822e28fe654b
-      m_SubObjectName: normalBottle_5
-    targetTileSprite:
-      m_AssetGUID: 6b27d5e8cb48e4d3b8e9df348aa185c6
-      m_SubObjectName: numberTile5
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 9
-    targetPos: 9
-    bottleSprite:
-      m_AssetGUID: 141dfdffa4c9e4962ab05c138b69881c
-      m_SubObjectName: normalBottle_6
-    targetTileSprite:
-      m_AssetGUID: 002d879f7321744279709540f5b88837
-      m_SubObjectName: numberTile6
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 10
-    targetPos: 10
-    bottleSprite:
-      m_AssetGUID: 2a7e69dea5902413a99deaf07342f7dc
-      m_SubObjectName: normalBottle_7
-    targetTileSprite:
-      m_AssetGUID: 7049c28bb2d914c02abfad034c3d08ca
-      m_SubObjectName: numberTile7
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
   - type: 2
     initPos: 14
-    targetPos: 11
-    bottleSprite:
-      m_AssetGUID: fa2dda00e054449238d90541adcf68b8
-      m_SubObjectName: normalBottle_8
-    targetTileSprite:
-      m_AssetGUID: b8f7dbec862e143b98cf342ad4b46952
-      m_SubObjectName: numberTile8
+    goalColor: 1
     life: 1
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  - type: 1
-    initPos: 15
-    targetPos: 0
-    bottleSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    targetTileSprite:
-      m_AssetGUID: 
-      m_SubObjectName: 
-    life: 0
-    isSelfish: 0
-    isDark: 0
-    isReverse: 0
   gimmicks: []
-  overviewGimmicks: 
+  overviewGimmicks:
   tutorial:
     type: 0
     image:
-      m_AssetGUID: e6bd58f298b5d4f4491f43a49b5f2f22
+      m_AssetGUID: 
       m_SubObjectName: 
     video:
       m_AssetGUID: 

--- a/Assets/Project/Resources/GameDatas/translation.csv
+++ b/Assets/Project/Resources/GameDatas/translation.csv
@@ -36,7 +36,9 @@ ErrorUnknown,不明なエラー,Unknwon Error
 ReturnToTitle,タイトルに戻る,Return to title
 ErrorLoadDataFailed,データの読み込みが失敗しました。,Failed to load data
 StartGame,スタート！,Tap to Start
-ErrorInavlidBottleAccess,ボトルの不正アクセスが発生しました。,Invalid bottle access.
+ErrorInvalidBottleAccess,ボトルの不正アクセスが発生しました。,Invalid bottle access.
+ErrorInvalidBottleColor,ボトルの色が正しく設定されていません。,Invalid bottle color.
+ErrorInvalidTileColor,タイルの色が正しく設定されていません。,Invalid tile color.
 RecordShareButton,共有,Share
 RecordToIndividualButton,個別記録へ,Individual
 RecordToGeneralButton,総合記録へ,General

--- a/Assets/Project/Scripts/Common/Components/SpriteRendererUnifier.cs
+++ b/Assets/Project/Scripts/Common/Components/SpriteRendererUnifier.cs
@@ -40,10 +40,18 @@ namespace Treevel.Common.Components
             var heightEfficient = widthEfficient * ImageRatio;
             transform.localScale = new Vector3(widthEfficient / originalWidth, heightEfficient / originalHeight);
 
+            _renderer.enabled = true;
+
             var collider = GetComponent<BoxCollider2D>();
             if (collider == null) return;
 
             collider.size = new Vector2(originalWidth, originalHeight);
+        }
+
+        public void SetSprite(Sprite sprite)
+        {
+            _renderer.sprite = sprite;
+            Unify();
         }
     }
 }

--- a/Assets/Project/Scripts/Common/Entities/ErrorCode.cs
+++ b/Assets/Project/Scripts/Common/Entities/ErrorCode.cs
@@ -8,7 +8,9 @@
     public enum EErrorCode
     {
         UnknownError,
-        LoadDataError,   // データの読み込みに失敗
-        InvalidBottleID, // ボトルIDが不正
+        LoadDataError,      // データの読み込みに失敗
+        InvalidBottleID,    // ボトルIDが不正
+        InvalidBottleColor, // ボトルの色が不適当
+        InvalidTileColor,   // タイルの色が不適当
     }
 }

--- a/Assets/Project/Scripts/Common/Entities/GameDatas/BottleData.cs
+++ b/Assets/Project/Scripts/Common/Entities/GameDatas/BottleData.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using UnityEngine;
-using UnityEngine.AddressableAssets;
-using UnityEngine.Serialization;
 
 namespace Treevel.Common.Entities.GameDatas
 {

--- a/Assets/Project/Scripts/Common/Entities/GameDatas/BottleData.cs
+++ b/Assets/Project/Scripts/Common/Entities/GameDatas/BottleData.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
+using UnityEngine.Serialization;
 
 namespace Treevel.Common.Entities.GameDatas
 {
@@ -8,10 +9,8 @@ namespace Treevel.Common.Entities.GameDatas
     public class BottleData
     {
         public EBottleType type;
-        [Range(1, 15)] public int initPos;
-        [Range(1, 15)] public short targetPos;
-        public AssetReferenceSprite bottleSprite;
-        public AssetReferenceSprite targetTileSprite;
+        [Range(1, 15)] public short initPos;
+        public EGoalColor goalColor;
         public short life;
         public bool isSelfish;
         public bool isDark;

--- a/Assets/Project/Scripts/Common/Entities/GameDatas/GimmickData.cs
+++ b/Assets/Project/Scripts/Common/Entities/GameDatas/GimmickData.cs
@@ -65,7 +65,7 @@ namespace Treevel.Common.Entities.GameDatas
         /// <summary>
         /// ＜隕石＞追従するボトル
         /// </summary>
-        public int targetBottle;
+        public short targetBottle;
 
         /// <summary>
         /// ＜隕石＞ランダムに追従するボトルの重み行列

--- a/Assets/Project/Scripts/Common/Entities/GameDatas/TileData.cs
+++ b/Assets/Project/Scripts/Common/Entities/GameDatas/TileData.cs
@@ -7,7 +7,7 @@ namespace Treevel.Common.Entities.GameDatas
     public class TileData
     {
         public ETileType type;
-        public EGoalColor color;
+        public EGoalColor goalColor;
         [Range(1, 15)] public short number;
 
         // for warp tile

--- a/Assets/Project/Scripts/Common/Entities/GameDatas/TileData.cs
+++ b/Assets/Project/Scripts/Common/Entities/GameDatas/TileData.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using UnityEngine;
-using UnityEngine.Serialization;
 
 namespace Treevel.Common.Entities.GameDatas
 {

--- a/Assets/Project/Scripts/Common/Entities/GameDatas/TileData.cs
+++ b/Assets/Project/Scripts/Common/Entities/GameDatas/TileData.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace Treevel.Common.Entities.GameDatas
 {
@@ -7,6 +8,7 @@ namespace Treevel.Common.Entities.GameDatas
     public class TileData
     {
         public ETileType type;
+        public EGoalColor goalColor;
         [Range(1, 15)] public short number;
 
         // for warp tile

--- a/Assets/Project/Scripts/Common/Entities/GameDatas/TileData.cs
+++ b/Assets/Project/Scripts/Common/Entities/GameDatas/TileData.cs
@@ -7,7 +7,7 @@ namespace Treevel.Common.Entities.GameDatas
     public class TileData
     {
         public ETileType type;
-        public EGoalColor goalColor;
+        public EGoalColor color;
         [Range(1, 15)] public short number;
 
         // for warp tile

--- a/Assets/Project/Scripts/Common/Entities/GoalColor.cs
+++ b/Assets/Project/Scripts/Common/Entities/GoalColor.cs
@@ -30,7 +30,7 @@ namespace Treevel.Common.Entities
         public static string GetTileAddress(this EGoalColor goalColor)
         {
             if (goalColor == EGoalColor.None) throw new Exception("GoalColor should not be None");
-            return Constants.Address.NUMBER_TILE_SPRITE_PREFIX + goalColor;
+            return Constants.Address.GOAL_TILE_SPRITE_PREFIX + goalColor;
         }
     }
 }

--- a/Assets/Project/Scripts/Common/Entities/GoalColor.cs
+++ b/Assets/Project/Scripts/Common/Entities/GoalColor.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using Treevel.Common.Managers;
+using Treevel.Common.Utils;
+using UnityEngine;
+
+namespace Treevel.Common.Entities
+{
+    /// <summary>
+    /// 季節一覧
+    /// </summary>
+    public enum EGoalColor
+    {
+        None,      // 指定なし
+        Red,       // 赤
+        Pink,      // ピンク
+        Orange,    // オレンジ
+        Yellow,    // 黄色
+        Green,     // 緑
+        LightBlue, // 水色
+        Blue,      // 青
+        Purple,    // 紫
+    }
+
+    public static class GoalColorExtension
+    {
+        public static string GetBottleAddress(this EGoalColor goalColor)
+        {
+            if (goalColor == EGoalColor.None) throw new Exception("GoalColor should not be None");
+            return Constants.Address.NORMAL_BOTTLE_SPRITE_PREFIX + goalColor;
+        }
+
+        public static string GetTileAddress(this EGoalColor goalColor)
+        {
+            if (goalColor == EGoalColor.None) throw new Exception("GoalColor should not be None");
+            return Constants.Address.NUMBER_TILE_SPRITE_PREFIX + goalColor;
+        }
+    }
+}

--- a/Assets/Project/Scripts/Common/Entities/GoalColor.cs
+++ b/Assets/Project/Scripts/Common/Entities/GoalColor.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using Treevel.Common.Managers;
 using Treevel.Common.Utils;
-using UnityEngine;
 
 namespace Treevel.Common.Entities
 {

--- a/Assets/Project/Scripts/Common/Entities/GoalColor.cs.meta
+++ b/Assets/Project/Scripts/Common/Entities/GoalColor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fdf5e769af17b46ed91597d21cd52b1a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/Scripts/Common/Entities/TextIndex.cs
+++ b/Assets/Project/Scripts/Common/Entities/TextIndex.cs
@@ -61,6 +61,8 @@ namespace Treevel.Common.Entities
         ErrorTextStart = 10000,          // ここからはエラーメッセージ
         ErrorUnknown = ErrorTextStart,   // 不明なエラー
         ErrorLoadDataFailed,             // データの読み込みが失敗しました
-        ErrorInavlidBottleAccess,        // ボトルの不正アクセスが発生しました。
+        ErrorInvalidBottleAccess,        // ボトルの不正アクセスが発生しました。
+        ErrorInvalidBottleColor,         // ボトルの色が正しく設定されていません。
+        ErrorInvalidTileColor,           // タイルの色が正しく設定されていません。
     }
 }

--- a/Assets/Project/Scripts/Common/Entities/TileType.cs
+++ b/Assets/Project/Scripts/Common/Entities/TileType.cs
@@ -3,6 +3,7 @@
     public enum ETileType
     {
         Normal,
+        Goal,
         Warp,
         Holy,
         Spiderweb,

--- a/Assets/Project/Scripts/Common/Managers/AddressableAssetManager.cs
+++ b/Assets/Project/Scripts/Common/Managers/AddressableAssetManager.cs
@@ -201,6 +201,9 @@ namespace Treevel.Common.Managers
                     case ETileType.Normal:
                         tasks.Add(LoadAsset<GameObject>(Constants.Address.NORMAL_TILE_PREFAB));
                         break;
+                    case ETileType.Goal:
+                        tasks.Add(LoadAsset<GameObject>(Constants.Address.GOAL_TILE_PREFAB));
+                        break;
                     case ETileType.Warp:
                         tasks.Add(LoadAsset<GameObject>(Constants.Address.WARP_TILE_PREFAB));
                         break;

--- a/Assets/Project/Scripts/Common/Managers/AddressableAssetManager.cs
+++ b/Assets/Project/Scripts/Common/Managers/AddressableAssetManager.cs
@@ -183,9 +183,11 @@ namespace Treevel.Common.Managers
                         throw new NotImplementedException();
                 }
 
-                if (bottleData.bottleSprite.RuntimeKeyIsValid()) tasks.Add(LoadAsset<Sprite>(bottleData.bottleSprite));
-                // 対応するTileのSpriteを先に読み込む
-                if (bottleData.targetTileSprite.RuntimeKeyIsValid()) tasks.Add(LoadAsset<Sprite>(bottleData.targetTileSprite));
+                // ボトルの色に対応したボトル画像、タイル画像を読み込む
+                if (bottleData.goalColor != EGoalColor.None) {
+                    tasks.Add(LoadAsset<Sprite>(bottleData.goalColor.GetBottleAddress()));
+                    tasks.Add(LoadAsset<Sprite>(bottleData.goalColor.GetTileAddress()));
+                }
             });
 
             // NormalTileのSpriteを読み込む

--- a/Assets/Project/Scripts/Common/Utils/Constants.cs
+++ b/Assets/Project/Scripts/Common/Utils/Constants.cs
@@ -133,7 +133,7 @@ namespace Treevel.Common.Utils
             public const string ATTACKABLE_DUMMY_BOTTLE_PREFAB = "AttackableDummyBottlePrefab";
             public const string DYNAMIC_DUMMY_BOTTLE_SPRITE = "dynamicDummyBottle";
             public const string STATIC_DUMMY_BOTTLE_SPRITE = "staticDummyBottle";
-            public const string NORMAL_BOTTLE_SPRITE_PREFIX = "normalBottle";
+            public const string NORMAL_BOTTLE_SPRITE_PREFIX = "normalBottle_";
 
             // ボトル関連のエフェクト
             public const string SELFISH_EFFECT_PREFAB = "SelfishEffectPrefab";
@@ -148,7 +148,7 @@ namespace Treevel.Common.Utils
             public const string HOLY_TILE_PREFAB = "HolyTilePrefab";
             public const string SPIDERWEB_TILE_PREFAB = "SpiderwebTilePrefab";
             public const string ICE_TILE_PREFAB = "IceTilePrefab";
-            public const string NUMBER_TILE_SPRITE_PREFIX = "numberTile";
+            public const string NUMBER_TILE_SPRITE_PREFIX = "numberTile_";
 
             // 銃弾関連
             public const string NORMAL_HOLE_GENERATOR_PREFAB = "NormalHoleGeneratorPrefab";

--- a/Assets/Project/Scripts/Common/Utils/Constants.cs
+++ b/Assets/Project/Scripts/Common/Utils/Constants.cs
@@ -36,6 +36,7 @@ namespace Treevel.Common.Utils
         public static class TileName
         {
             public const string NORMAL_TILE = "NormalTile";
+            public const string GOAL_TILE = "GoalTile";
             public const string WARP_TILE = "WarpTile";
             public const string HOLY_TILE = "HolyTile";
             public const string SPIDERWEB_TILE = "SpiderwebTile";

--- a/Assets/Project/Scripts/Common/Utils/Constants.cs
+++ b/Assets/Project/Scripts/Common/Utils/Constants.cs
@@ -145,6 +145,7 @@ namespace Treevel.Common.Utils
             // タイル関連
             public const string NORMAL_TILE_PREFAB = "NormalTilePrefab";
             public const string NORMAL_TILE_SPRITE_PREFIX = "normalTile_";
+            public const string GOAL_TILE_PREFAB = "GoalTilePrefab";
             public const string WARP_TILE_PREFAB = "WarpTilePrefab";
             public const string HOLY_TILE_PREFAB = "HolyTilePrefab";
             public const string SPIDERWEB_TILE_PREFAB = "SpiderwebTilePrefab";

--- a/Assets/Project/Scripts/Common/Utils/Constants.cs
+++ b/Assets/Project/Scripts/Common/Utils/Constants.cs
@@ -150,7 +150,7 @@ namespace Treevel.Common.Utils
             public const string HOLY_TILE_PREFAB = "HolyTilePrefab";
             public const string SPIDERWEB_TILE_PREFAB = "SpiderwebTilePrefab";
             public const string ICE_TILE_PREFAB = "IceTilePrefab";
-            public const string NUMBER_TILE_SPRITE_PREFIX = "numberTile_";
+            public const string GOAL_TILE_SPRITE_PREFIX = "numberTile_";
 
             // 銃弾関連
             public const string NORMAL_HOLE_GENERATOR_PREFAB = "NormalHoleGeneratorPrefab";

--- a/Assets/Project/Scripts/Editor/StageDataEditor.cs
+++ b/Assets/Project/Scripts/Editor/StageDataEditor.cs
@@ -170,10 +170,10 @@ namespace Treevel.Editor
                     case ETileType.Normal:
                         break;
                     case ETileType.Goal: {
-                        var colorElem = tileDataProp.FindPropertyRelative("color");
-                        colorElem.intValue = (int)(EGoalColor)EditorGUILayout.EnumPopup(
-                            label: new GUIContent("Color"),
-                            selected: (EGoalColor)colorElem.intValue,
+                        var goalColorElem = tileDataProp.FindPropertyRelative("goalColor");
+                        goalColorElem.intValue = (int)(EGoalColor)EditorGUILayout.EnumPopup(
+                            label: new GUIContent("GoalColor"),
+                            selected: (EGoalColor)goalColorElem.intValue,
                             // Noneは選択不能にする
                             checkEnabled: (eType) => (EGoalColor)eType != EGoalColor.None,
                             includeObsolete: false

--- a/Assets/Project/Scripts/Editor/StageDataEditor.cs
+++ b/Assets/Project/Scripts/Editor/StageDataEditor.cs
@@ -162,7 +162,16 @@ namespace Treevel.Editor
                 }
 
                 switch ((ETileType)tileTypeProp.enumValueIndex) {
-                    case ETileType.Normal:
+                    case ETileType.Normal: {
+                        var goalColorElem = tileDataProp.FindPropertyRelative("goalColor");
+                        goalColorElem.intValue = (int)(EGoalColor)EditorGUILayout.EnumPopup(
+                            label: new GUIContent("GoalColor"),
+                            selected: (EGoalColor)goalColorElem.intValue,
+                            // Noneは選択不能にする
+                            checkEnabled: (eType) => (EGoalColor)eType != EGoalColor.None,
+                            includeObsolete: false
+                        );
+                    }
                         break;
                     case ETileType.Warp: {
                         EditorGUILayout.PropertyField(tileDataProp.FindPropertyRelative("pairNumber"));
@@ -216,9 +225,14 @@ namespace Treevel.Editor
 
                 switch ((EBottleType)bottleTypeProp.enumValueIndex) {
                     case EBottleType.Normal: {
-                        EditorGUILayout.PropertyField(bottleDataProp.FindPropertyRelative("targetPos"));
-                        EditorGUILayout.PropertyField(bottleDataProp.FindPropertyRelative("bottleSprite"));
-                        EditorGUILayout.PropertyField(bottleDataProp.FindPropertyRelative("targetTileSprite"));
+                        var goalColorElem = bottleDataProp.FindPropertyRelative("goalColor");
+                        goalColorElem.intValue = (int)(EGoalColor)EditorGUILayout.EnumPopup(
+                            label: new GUIContent("GoalColor"),
+                            selected: (EGoalColor)goalColorElem.intValue,
+                            // Noneは選択不能にする
+                            checkEnabled: (eType) => (EGoalColor)eType != EGoalColor.None,
+                            includeObsolete: false
+                        );
                         EditorGUILayout.PropertyField(bottleDataProp.FindPropertyRelative("isSelfish"));
                         EditorGUILayout.PropertyField(bottleDataProp.FindPropertyRelative("isDark"));
                         EditorGUILayout.PropertyField(bottleDataProp.FindPropertyRelative("isReverse"));
@@ -229,7 +243,6 @@ namespace Treevel.Editor
                         EditorGUILayout.PropertyField(bottleDataProp.FindPropertyRelative("isReverse"));
                         break;
                     case EBottleType.AttackableDummy: {
-                        EditorGUILayout.PropertyField(bottleDataProp.FindPropertyRelative("bottleSprite"));
                         EditorGUILayout.PropertyField(bottleDataProp.FindPropertyRelative("isSelfish"));
                         EditorGUILayout.PropertyField(bottleDataProp.FindPropertyRelative("isReverse"));
                     }
@@ -460,7 +473,7 @@ namespace Treevel.Editor
                             // 現在あるボトルのIDから選択するように
                             var bottleIds = GetAttackableBottles().Select(bottle => bottle.initPos).ToList();
 
-                            var selectedIdx = bottleIds.Contains(targetBottleProp.intValue)
+                            var selectedIdx = bottleIds.Contains((short)targetBottleProp.intValue)
                                 ? bottleIds.Select((id, idx) => new {
                                     id, idx,
                                 }).First(t => t.id == targetBottleProp.intValue).idx

--- a/Assets/Project/Scripts/Editor/StageDataEditor.cs
+++ b/Assets/Project/Scripts/Editor/StageDataEditor.cs
@@ -152,8 +152,13 @@ namespace Treevel.Editor
                 var tileTypeProp = tileDataProp.FindPropertyRelative("type");
 
                 var newEnumValueIndex =
-                    (int)(ETileType)EditorGUILayout.EnumPopup(new GUIContent("Type"),
-                                                              (ETileType)tileTypeProp.enumValueIndex);
+                    (int)(ETileType)EditorGUILayout.EnumPopup(
+                        new GUIContent("Type"),
+                        (ETileType)tileTypeProp.enumValueIndex,
+                        // Normalは選択不能にする
+                        (eType) => (ETileType)eType != ETileType.Normal,
+                        false
+                        );
 
                 // タイプが変わっていたらデータをリセット
                 if (newEnumValueIndex != tileTypeProp.enumValueIndex) {
@@ -162,7 +167,9 @@ namespace Treevel.Editor
                 }
 
                 switch ((ETileType)tileTypeProp.enumValueIndex) {
-                    case ETileType.Normal: {
+                    case ETileType.Normal:
+                        break;
+                    case ETileType.Goal: {
                         var colorElem = tileDataProp.FindPropertyRelative("color");
                         colorElem.intValue = (int)(EGoalColor)EditorGUILayout.EnumPopup(
                             label: new GUIContent("Color"),

--- a/Assets/Project/Scripts/Editor/StageDataEditor.cs
+++ b/Assets/Project/Scripts/Editor/StageDataEditor.cs
@@ -163,10 +163,10 @@ namespace Treevel.Editor
 
                 switch ((ETileType)tileTypeProp.enumValueIndex) {
                     case ETileType.Normal: {
-                        var goalColorElem = tileDataProp.FindPropertyRelative("goalColor");
-                        goalColorElem.intValue = (int)(EGoalColor)EditorGUILayout.EnumPopup(
-                            label: new GUIContent("GoalColor"),
-                            selected: (EGoalColor)goalColorElem.intValue,
+                        var colorElem = tileDataProp.FindPropertyRelative("color");
+                        colorElem.intValue = (int)(EGoalColor)EditorGUILayout.EnumPopup(
+                            label: new GUIContent("Color"),
+                            selected: (EGoalColor)colorElem.intValue,
                             // Noneは選択不能にする
                             checkEnabled: (eType) => (EGoalColor)eType != EGoalColor.None,
                             includeObsolete: false

--- a/Assets/Project/Scripts/Modules/GamePlayScene/BoardManager.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/BoardManager.cs
@@ -412,13 +412,17 @@ namespace Treevel.Modules.GamePlayScene
         }
 
         /// <summary>
-        ///
+        /// タイルの色を取得する
         /// </summary>
         /// <param name="bottle"></param>
         /// <returns></returns>
         public EGoalColor GetTileColor(NormalBottleController bottle)
         {
-            return GetTile(XYToTileNum(_bottlePositions[bottle.gameObject]).Value).GetComponent<AbstractTileController>().color;
+            var tile = GetTile(GetBottlePos(bottle));
+            if (tile == null) return EGoalColor.None;
+            var tileController = tile.GetComponent<GoalTileController>();
+            if (tileController == null) return EGoalColor.None;
+            return tileController.color;
         }
 
         /// <summary>

--- a/Assets/Project/Scripts/Modules/GamePlayScene/BoardManager.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/BoardManager.cs
@@ -422,7 +422,7 @@ namespace Treevel.Modules.GamePlayScene
             if (tile == null) return EGoalColor.None;
             var tileController = tile.GetComponent<GoalTileController>();
             if (tileController == null) return EGoalColor.None;
-            return tileController.color;
+            return tileController.GoalColor;
         }
 
         /// <summary>

--- a/Assets/Project/Scripts/Modules/GamePlayScene/BoardManager.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/BoardManager.cs
@@ -418,7 +418,7 @@ namespace Treevel.Modules.GamePlayScene
         /// <returns></returns>
         public EGoalColor GetTileColor(NormalBottleController bottle)
         {
-            return GetTile(XYToTileNum(_bottlePositions[bottle.gameObject]).Value).GetComponent<AbstractTileController>().GoalColor;
+            return GetTile(XYToTileNum(_bottlePositions[bottle.gameObject]).Value).GetComponent<AbstractTileController>().color;
         }
 
         /// <summary>

--- a/Assets/Project/Scripts/Modules/GamePlayScene/BoardManager.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/BoardManager.cs
@@ -412,6 +412,16 @@ namespace Treevel.Modules.GamePlayScene
         }
 
         /// <summary>
+        ///
+        /// </summary>
+        /// <param name="bottle"></param>
+        /// <returns></returns>
+        public EGoalColor GetTileColor(NormalBottleController bottle)
+        {
+            return GetTile(XYToTileNum(_bottlePositions[bottle.gameObject]).Value).GetComponent<AbstractTileController>().GoalColor;
+        }
+
+        /// <summary>
         /// ボード上の格子単位のデータを格納するクラス
         /// </summary>
         private class Square

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Bottle/AbstractBottleController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Bottle/AbstractBottleController.cs
@@ -107,13 +107,7 @@ namespace Treevel.Modules.GamePlayScene.Bottle
             // ボトルをボードに設定
             BoardManager.Instance.InitializeBottle(this, Id);
 
-            // sprite が設定されている場合読み込む
-            if (bottleData.bottleSprite.RuntimeKeyIsValid()) {
-                await InitializeSprite(bottleData.bottleSprite);
-            } else {
-                GetComponent<SpriteRendererUnifier>().Unify();
-                GetComponent<SpriteRenderer>().enabled = true;
-            }
+            GetComponent<SpriteRendererUnifier>().Unify();
         }
 
         /// <summary>

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Bottle/NormalBottleController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Bottle/NormalBottleController.cs
@@ -50,8 +50,6 @@ namespace Treevel.Modules.GamePlayScene.Bottle
 
             // parse data
             _goalColor = bottleData.goalColor;
-            var targetTileSprite = AddressableAssetManager.GetAsset<Sprite>(bottleData.goalColor.GetTileAddress());
-
             // GoalColorがNoneではないことを保証する
             if (_goalColor == EGoalColor.None) UIManager.Instance.ShowErrorMessage(EErrorCode.InvalidBottleColor);
             

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Bottle/NormalBottleController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Bottle/NormalBottleController.cs
@@ -2,6 +2,7 @@
 using SpriteGlow;
 using TouchScript.Gestures;
 using Treevel.Common.Components;
+using Treevel.Common.Entities;
 using Treevel.Common.Entities.GameDatas;
 using Treevel.Common.Managers;
 using Treevel.Common.Utils;
@@ -20,9 +21,9 @@ namespace Treevel.Modules.GamePlayScene.Bottle
         public LongPressGesture longPressGesture;
 
         /// <summary>
-        /// 目標位置
+        /// 目標の色
         /// </summary>
-        private int _targetPos;
+        private EGoalColor _goalColor;
 
         /// <summary>
         /// 光らせるエフェクト
@@ -49,9 +50,8 @@ namespace Treevel.Modules.GamePlayScene.Bottle
             _spriteGlowEffect.enabled = false;
 
             // parse data
-            var finalPos = bottleData.targetPos;
-            _targetPos = finalPos;
-            var targetTileSprite = AddressableAssetManager.GetAsset<Sprite>(bottleData.targetTileSprite);
+            _goalColor = bottleData.goalColor;
+            var targetTileSprite = AddressableAssetManager.GetAsset<Sprite>(bottleData.goalColor.GetTileAddress());
 
             await base.Initialize(bottleData);
 
@@ -67,9 +67,8 @@ namespace Treevel.Modules.GamePlayScene.Bottle
             name = Constants.BottleName.NORMAL_BOTTLE + Id;
             #endif
 
-            // 目標とするタイルのスプライトを設定
-            var finalTile = BoardManager.Instance.GetTile(finalPos);
-            finalTile.GetComponent<NormalTileController>().SetSprite(targetTileSprite);
+            // ボトルのスプライトを設定
+            GetComponent<SpriteRendererUnifier>().SetSprite(AddressableAssetManager.GetAsset<Sprite>(bottleData.goalColor.GetBottleAddress()));
         }
 
         /// <summary>
@@ -89,7 +88,7 @@ namespace Treevel.Modules.GamePlayScene.Bottle
         /// <returns></returns>
         public bool IsSuccess()
         {
-            return _targetPos != 0 && BoardManager.Instance.GetBottlePos(this) == _targetPos;
+            return _goalColor != EGoalColor.None && BoardManager.Instance.GetTileColor(this) == _goalColor;
         }
     }
 }

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Bottle/NormalBottleController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Bottle/NormalBottleController.cs
@@ -6,7 +6,6 @@ using Treevel.Common.Entities;
 using Treevel.Common.Entities.GameDatas;
 using Treevel.Common.Managers;
 using Treevel.Common.Utils;
-using Treevel.Modules.GamePlayScene.Tile;
 using UniRx;
 using UnityEngine;
 using UnityEngine.Rendering.PostProcessing;

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Bottle/NormalBottleController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Bottle/NormalBottleController.cs
@@ -52,6 +52,9 @@ namespace Treevel.Modules.GamePlayScene.Bottle
             _goalColor = bottleData.goalColor;
             var targetTileSprite = AddressableAssetManager.GetAsset<Sprite>(bottleData.goalColor.GetTileAddress());
 
+            // GoalColorがNoneではないことを保証する
+            if (_goalColor == EGoalColor.None) UIManager.Instance.ShowErrorMessage(EErrorCode.InvalidBottleColor);
+            
             await base.Initialize(bottleData);
 
             // set handler

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Bottle/NormalBottleController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Bottle/NormalBottleController.cs
@@ -52,7 +52,7 @@ namespace Treevel.Modules.GamePlayScene.Bottle
             _goalColor = bottleData.goalColor;
             // GoalColorがNoneではないことを保証する
             if (_goalColor == EGoalColor.None) UIManager.Instance.ShowErrorMessage(EErrorCode.InvalidBottleColor);
-            
+
             await base.Initialize(bottleData);
 
             // set handler

--- a/Assets/Project/Scripts/Modules/GamePlayScene/GamePlayDirector.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/GamePlayDirector.cs
@@ -267,21 +267,20 @@ namespace Treevel.Modules.GamePlayScene
         /// </summary>
         private static void CleanObject()
         {
-            // ボトルを破壊
+            // ボトルを削除
             var bottles = FindObjectsOfType<AbstractBottleController>();
             foreach (var bottle in bottles) {
-                // ボトルの削除
                 DestroyImmediate(bottle.gameObject);
             }
 
+            // ギミックを削除
             var gimmicks = GameObject.FindGameObjectsWithTag(Constants.TagName.GIMMICK);
             foreach (var gimmick in gimmicks) {
-                // 銃弾の削除
                 DestroyImmediate(gimmick);
             }
 
-            // ノーマルタイル以外のタイルを削除
-            var specialTiles = FindObjectsOfType<AbstractTileController>().Where(t => !(t is NormalTileController));
+            // タイルを削除
+            var specialTiles = FindObjectsOfType<AbstractTileController>();
             foreach (var tile in specialTiles) {
                 DestroyImmediate(tile.gameObject);
             }

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Tile/AbstractTileController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Tile/AbstractTileController.cs
@@ -16,7 +16,7 @@ namespace Treevel.Modules.GamePlayScene.Tile
         /// <summary>
         /// タイルの色
         /// </summary>
-        public EGoalColor GoalColor { get; protected set; }
+        public EGoalColor color { get; protected set; }
 
         /// <summary>
         /// 初期配置された際に `OnBottleEnter` を実行するかどうか

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Tile/AbstractTileController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Tile/AbstractTileController.cs
@@ -14,11 +14,6 @@ namespace Treevel.Modules.GamePlayScene.Tile
         public int TileNumber { get; private set; }
 
         /// <summary>
-        /// タイルの色
-        /// </summary>
-        public EGoalColor color { get; protected set; }
-
-        /// <summary>
         /// 初期配置された際に `OnBottleEnter` を実行するかどうか
         /// </summary>
         public abstract bool RunOnBottleEnterAtInit { get; }

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Tile/AbstractTileController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Tile/AbstractTileController.cs
@@ -1,4 +1,7 @@
-﻿using UnityEngine;
+﻿using Treevel.Common.Components;
+using Treevel.Common.Entities;
+using Treevel.Common.Entities.GameDatas;
+using UnityEngine;
 
 namespace Treevel.Modules.GamePlayScene.Tile
 {
@@ -9,6 +12,11 @@ namespace Treevel.Modules.GamePlayScene.Tile
         /// タイルの番号
         /// </summary>
         public int TileNumber { get; private set; }
+
+        /// <summary>
+        /// タイルの色
+        /// </summary>
+        public EGoalColor GoalColor { get; protected set; }
 
         /// <summary>
         /// 初期配置された際に `OnBottleEnter` を実行するかどうか
@@ -23,9 +31,15 @@ namespace Treevel.Modules.GamePlayScene.Tile
         /// 初期化
         /// </summary>
         /// <param name="tileNum"> タイルの番号 </param>
+        public virtual void Initialize(TileData tileData)
+        {
+            Initialize(tileData.number);
+        }
+
         public virtual void Initialize(int tileNum)
         {
             TileNumber = tileNum;
+            GetComponent<SpriteRendererUnifier>().Unify();
         }
 
         /// <summary>

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Tile/GoalTileController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Tile/GoalTileController.cs
@@ -1,0 +1,27 @@
+﻿using Treevel.Common.Components;
+using Treevel.Common.Entities;
+using Treevel.Common.Entities.GameDatas;
+using Treevel.Common.Managers;
+using Treevel.Common.Utils;
+using UnityEngine;
+
+namespace Treevel.Modules.GamePlayScene.Tile
+{
+    public class GoalTileController : NormalTileController
+    {
+        /// <summary>
+        /// タイルの色
+        /// </summary>
+        public EGoalColor color { get; private set; }
+
+        public override void Initialize(TileData tileData)
+        {
+            base.Initialize(tileData);
+            color = tileData.color;
+            GetComponent<SpriteRendererUnifier>().SetSprite(AddressableAssetManager.GetAsset<Sprite>(tileData.color.GetTileAddress()));
+            #if UNITY_EDITOR
+            name = Constants.TileName.GOAL_TILE + tileData.number;
+            #endif
+        }
+    }
+}

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Tile/GoalTileController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Tile/GoalTileController.cs
@@ -19,7 +19,7 @@ namespace Treevel.Modules.GamePlayScene.Tile
             base.Initialize(tileData);
             GoalColor = tileData.goalColor;
             // colorがNoneではないことを保証する
-            if (GoalColor == EGoalColor.None) UIManager.Instance.ShowErrorMessage(EErrorCode.InvalidBottleColor);
+            if (GoalColor == EGoalColor.None) UIManager.Instance.ShowErrorMessage(EErrorCode.InvalidTileColor);
             GetComponent<SpriteRendererUnifier>().SetSprite(AddressableAssetManager.GetAsset<Sprite>(tileData.goalColor.GetTileAddress()));
             #if UNITY_EDITOR
             name = Constants.TileName.GOAL_TILE + tileData.number;

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Tile/GoalTileController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Tile/GoalTileController.cs
@@ -18,6 +18,8 @@ namespace Treevel.Modules.GamePlayScene.Tile
         {
             base.Initialize(tileData);
             color = tileData.color;
+            // colorがNoneではないことを保証する
+            if (color == EGoalColor.None) UIManager.Instance.ShowErrorMessage(EErrorCode.InvalidBottleColor);
             GetComponent<SpriteRendererUnifier>().SetSprite(AddressableAssetManager.GetAsset<Sprite>(tileData.color.GetTileAddress()));
             #if UNITY_EDITOR
             name = Constants.TileName.GOAL_TILE + tileData.number;

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Tile/GoalTileController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Tile/GoalTileController.cs
@@ -12,15 +12,15 @@ namespace Treevel.Modules.GamePlayScene.Tile
         /// <summary>
         /// タイルの色
         /// </summary>
-        public EGoalColor color { get; private set; }
+        public EGoalColor GoalColor { get; private set; }
 
         public override void Initialize(TileData tileData)
         {
             base.Initialize(tileData);
-            color = tileData.color;
+            GoalColor = tileData.goalColor;
             // colorがNoneではないことを保証する
-            if (color == EGoalColor.None) UIManager.Instance.ShowErrorMessage(EErrorCode.InvalidBottleColor);
-            GetComponent<SpriteRendererUnifier>().SetSprite(AddressableAssetManager.GetAsset<Sprite>(tileData.color.GetTileAddress()));
+            if (GoalColor == EGoalColor.None) UIManager.Instance.ShowErrorMessage(EErrorCode.InvalidBottleColor);
+            GetComponent<SpriteRendererUnifier>().SetSprite(AddressableAssetManager.GetAsset<Sprite>(tileData.goalColor.GetTileAddress()));
             #if UNITY_EDITOR
             name = Constants.TileName.GOAL_TILE + tileData.number;
             #endif

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Tile/GoalTileController.cs.meta
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Tile/GoalTileController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 393cce43e6e284d2191013e94345e789
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Tile/HolyTileController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Tile/HolyTileController.cs
@@ -1,4 +1,5 @@
-﻿using Treevel.Common.Utils;
+﻿using Treevel.Common.Entities.GameDatas;
+using Treevel.Common.Utils;
 using Treevel.Modules.GamePlayScene.Bottle;
 using UnityEngine;
 
@@ -14,9 +15,9 @@ namespace Treevel.Modules.GamePlayScene.Tile
             bottleHandler = new HolyTileBottleHandler();
         }
 
-        public override void Initialize(int tileNum)
+        public override void Initialize(TileData tileData)
         {
-            base.Initialize(tileNum);
+            base.Initialize(tileData);
 
             #if UNITY_EDITOR
             name = Constants.TileName.HOLY_TILE;

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Tile/IceTileController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Tile/IceTileController.cs
@@ -1,4 +1,5 @@
-﻿using Treevel.Common.Utils;
+﻿using Treevel.Common.Entities.GameDatas;
+using Treevel.Common.Utils;
 using Treevel.Modules.GamePlayScene.Bottle;
 using UnityEngine;
 
@@ -8,9 +9,9 @@ namespace Treevel.Modules.GamePlayScene.Tile
     {
         public override bool RunOnBottleEnterAtInit => false;
 
-        public override void Initialize(int tileNum)
+        public override void Initialize(TileData tileData)
         {
-            base.Initialize(tileNum);
+            base.Initialize(tileData);
 
             #if UNITY_EDITOR
             name = Constants.TileName.ICE_TILE;

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Tile/NormalTileController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Tile/NormalTileController.cs
@@ -14,8 +14,8 @@ namespace Treevel.Modules.GamePlayScene.Tile
         public override void Initialize(TileData tileData)
         {
             base.Initialize(tileData);
-            GoalColor = tileData.goalColor;
-            GetComponent<SpriteRendererUnifier>().SetSprite(AddressableAssetManager.GetAsset<Sprite>(tileData.goalColor.GetTileAddress()));
+            color = tileData.color;
+            GetComponent<SpriteRendererUnifier>().SetSprite(AddressableAssetManager.GetAsset<Sprite>(tileData.color.GetTileAddress()));
             #if UNITY_EDITOR
             name = Constants.TileName.GOAL_TILE + tileData.number;
             #endif

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Tile/NormalTileController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Tile/NormalTileController.cs
@@ -11,16 +11,6 @@ namespace Treevel.Modules.GamePlayScene.Tile
     {
         public override bool RunOnBottleEnterAtInit => false;
 
-        public override void Initialize(TileData tileData)
-        {
-            base.Initialize(tileData);
-            color = tileData.color;
-            GetComponent<SpriteRendererUnifier>().SetSprite(AddressableAssetManager.GetAsset<Sprite>(tileData.color.GetTileAddress()));
-            #if UNITY_EDITOR
-            name = Constants.TileName.GOAL_TILE + tileData.number;
-            #endif
-        }
-
         public override void Initialize(int tileNum)
         {
             base.Initialize(tileNum);

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Tile/NormalTileController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Tile/NormalTileController.cs
@@ -1,4 +1,6 @@
 ﻿using Treevel.Common.Components;
+using Treevel.Common.Entities;
+using Treevel.Common.Entities.GameDatas;
 using Treevel.Common.Managers;
 using Treevel.Common.Utils;
 using UnityEngine;
@@ -9,23 +11,23 @@ namespace Treevel.Modules.GamePlayScene.Tile
     {
         public override bool RunOnBottleEnterAtInit => false;
 
-        public override void Initialize(int tileNum)
+        public override void Initialize(TileData tileData)
         {
-            base.Initialize(tileNum);
-            SetSprite(AddressableAssetManager.GetAsset<Sprite>(Constants.Address.NORMAL_TILE_SPRITE_PREFIX + tileNum));
+            base.Initialize(tileData);
+            GoalColor = tileData.goalColor;
+            GetComponent<SpriteRendererUnifier>().SetSprite(AddressableAssetManager.GetAsset<Sprite>(tileData.goalColor.GetTileAddress()));
             #if UNITY_EDITOR
-            name = Constants.TileName.NORMAL_TILE + tileNum;
+            name = Constants.TileName.GOAL_TILE + tileData.number;
             #endif
         }
 
-        /// <summary>
-        /// タイルの画像を設定する
-        /// </summary>
-        /// <param name="sprite">タイル画像</param>
-        public void SetSprite(Sprite sprite)
+        public override void Initialize(int tileNum)
         {
-            GetComponent<SpriteRenderer>().sprite = sprite;
-            GetComponent<SpriteRendererUnifier>().Unify();
+            base.Initialize(tileNum);
+            GetComponent<SpriteRendererUnifier>().SetSprite(AddressableAssetManager.GetAsset<Sprite>(Constants.Address.NORMAL_TILE_SPRITE_PREFIX + tileNum));
+            #if UNITY_EDITOR
+            name = Constants.TileName.NORMAL_TILE + tileNum;
+            #endif
         }
     }
 }

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Tile/SpiderwebTileController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Tile/SpiderwebTileController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Treevel.Common.Entities.GameDatas;
 using Treevel.Common.Utils;
 using Treevel.Modules.GamePlayScene.Bottle;
 using UnityEngine;
@@ -20,9 +21,9 @@ namespace Treevel.Modules.GamePlayScene.Tile
             bottleHandler = new SpiderwebTileBottleHandler();
         }
 
-        public override void Initialize(int tileNum)
+        public override void Initialize(TileData tileData)
         {
-            base.Initialize(tileNum);
+            base.Initialize(tileData);
 
             #if UNITY_EDITOR
             name = Constants.TileName.SPIDERWEB_TILE;

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Tile/TileGenerator.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Tile/TileGenerator.cs
@@ -30,14 +30,14 @@ namespace Treevel.Modules.GamePlayScene.Tile
                 .Select(tileData => CreateWarpTiles(tileData.number, tileData.pairNumber))
                 .Concat(
                     // WarpTile以外の特殊Tileの生成
-                    tileDatas.Where(tileData => tileData.type != ETileType.Warp && tileData.type != ETileType.Normal)
-                        .Select(tileData => CreateTile(tileData.type, tileData.number))
+                    tileDatas.Where(tileData => tileData.type != ETileType.Warp)
+                        .Select(tileData => CreateTile(tileData))
                 )
                 .Concat(
                     // NormalTileの生成
                     Enumerable.Range(1, Constants.StageSize.ROW * Constants.StageSize.COLUMN).ToArray()
                         .Where(tileNum => !tileNumList.Contains((short)tileNum))
-                        .Select(tileNum => CreateTile(ETileType.Normal, tileNum))
+                        .Select(tileNum => CreateNormalTile(tileNum))
                 );
             return UniTask.WhenAll(tasks);
         }
@@ -56,9 +56,6 @@ namespace Treevel.Modules.GamePlayScene.Tile
                     secondTile.GetComponent<WarpTileController>().Initialize(secondTileNum, firstTile);
                     BoardManager.Instance.SetTile(firstTile.GetComponent<AbstractTileController>(), firstTileNum);
                     BoardManager.Instance.SetTile(secondTile.GetComponent<AbstractTileController>(), secondTileNum);
-
-                    firstTile.GetComponent<SpriteRenderer>().enabled = true;
-                    secondTile.GetComponent<SpriteRenderer>().enabled = true;
                 });
             });
 
@@ -66,18 +63,32 @@ namespace Treevel.Modules.GamePlayScene.Tile
         }
 
         /// <summary>
-        /// WarpTile以外を生成する
+        /// WarpTile以外の特殊Tileを生成する
         /// </summary>
         /// <param name="type"> Tileの種類 </param>
         /// <param name="tileNum"> Tileの番号 </param>
         /// <returns></returns>
-        private UniTask CreateTile(ETileType type, int tileNum)
+        private UniTask CreateTile(TileData tileData)
         {
-            return AddressableAssetManager.Instantiate(_prefabAddressableKeys[type]).ToUniTask()
+            return AddressableAssetManager.Instantiate(_prefabAddressableKeys[tileData.type]).ToUniTask()
+                .ContinueWith(tileObj => {
+                    tileObj.GetComponent<AbstractTileController>().Initialize(tileData);
+                    BoardManager.Instance.SetTile(tileObj.GetComponent<AbstractTileController>(), tileData.number);
+                });
+        }
+
+        /// <summary>
+        /// NormalTileを生成する
+        /// </summary>
+        /// <param name="type"> Tileの種類 </param>
+        /// <param name="tileNum"> Tileの番号 </param>
+        /// <returns></returns>
+        private UniTask CreateNormalTile(int tileNum)
+        {
+            return AddressableAssetManager.Instantiate(_prefabAddressableKeys[ETileType.Normal]).ToUniTask()
                 .ContinueWith(tileObj => {
                     tileObj.GetComponent<AbstractTileController>().Initialize(tileNum);
                     BoardManager.Instance.SetTile(tileObj.GetComponent<AbstractTileController>(), tileNum);
-                    tileObj.GetComponent<SpriteRenderer>().enabled = true;
                 });
         }
     }

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Tile/TileGenerator.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Tile/TileGenerator.cs
@@ -13,6 +13,7 @@ namespace Treevel.Modules.GamePlayScene.Tile
     {
         private readonly Dictionary<ETileType, string> _prefabAddressableKeys = new Dictionary<ETileType, string> {
             { ETileType.Normal, Constants.Address.NORMAL_TILE_PREFAB },
+            { ETileType.Goal, Constants.Address.GOAL_TILE_PREFAB },
             { ETileType.Warp, Constants.Address.WARP_TILE_PREFAB },
             { ETileType.Ice, Constants.Address.ICE_TILE_PREFAB },
             { ETileType.Holy, Constants.Address.HOLY_TILE_PREFAB },

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Tile/TileGenerator.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Tile/TileGenerator.cs
@@ -6,7 +6,6 @@ using Treevel.Common.Entities.GameDatas;
 using Treevel.Common.Managers;
 using Treevel.Common.Patterns.Singleton;
 using Treevel.Common.Utils;
-using UnityEngine;
 
 namespace Treevel.Modules.GamePlayScene.Tile
 {

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Tile/WarpTileController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Tile/WarpTileController.cs
@@ -48,7 +48,7 @@ namespace Treevel.Modules.GamePlayScene.Tile
         /// <param name="pairTile"> 相方の WarpTile </param>
         public void Initialize(int tileNum, GameObject pairTile)
         {
-            base.Initialize(tileNum);
+            Initialize(tileNum);
             #if UNITY_EDITOR
             name = Constants.TileName.WARP_TILE;
             #endif


### PR DESCRIPTION
### 対象イシュー
Close #757

### 概要
タイトルまま

### 詳細
傷画像を組み込む(#723)にあたり、BottleがTileの色を指定する(=Tileが自分の色をわかっていない)のは不都合があったので、BottleとTileの色を別々に指定するリファクタリングを行った

その結果、BottleとTileが1:1である保証がなくなった。(N:Nができるようになったとも言える。)
なので、StageDataEditorでBottleの色の数とTileの色の数の整合性を保証するようにした。

また、BottleとTileの画像をStageDataEditorで指定するのではなく、色だけを指定して、色から画像が一意に決まるようにした。

#### 現実装になった経緯
- `NormalBottleCOntroller.cs`の`IsSuccess()`メソッドで、引数として与えられるタイルオブジェクトから色を直接取得して成功判定を行う話が出ていたんですけど、
`GamePlayDirector.cs`や`DrakEffectController.cs`で`IsSuccess()`に引数を渡さず呼んでいる部分があったので、引数を与えることができませんでした。
(`GamePlayDirecotor`とかは`IsSuccess()`に与える引数となるタイルオブジェクトを知らないから)

そもそも`IsSuccess`を外部から呼んでいることがどうなんだ？と思ったんで直しても良かったんですけど、
スコープがずれるし、なんか単純じゃなかったので諦めました。
`Bottle`も`Tile`も相互に直接やりとりせず、`BoardManager`に任せました。

#### 技術的な内容
`TileData.cs`の`goalColor`propertyは`color`という名前でも良いんですけど,
`GoalTileController.cs`のpublic変数が`Color`になると、
`UnityEngine.Color`と被るのでやめました。

#### その他
- `GoalTile`を指定するようにしたので、`NormalTile`をStageDataEditorから指定して配置することはしないようにしました。

### キャプチャ


### 動作確認方法

- [x] Spring-1-1をプレイ。同じ色ならばどのTileでも成功判定がなされることを確認する
- [x] StageDataEditorにて、BottleのgoalColorに、Tileで指定されている色しか指定できないことを確認する
- [x] TileのgoalColorとBottleのgoalColorの個数が一致していない時にログが出ることを確認する

### 参考 URL
