### PR TITLE
PlayFabログイン認証実装

### DIFF
--- a/Assets/Project/Scripts/Common/Networks/Database/PlayFabDatabaseService.cs
+++ b/Assets/Project/Scripts/Common/Networks/Database/PlayFabDatabaseService.cs
@@ -121,14 +121,14 @@ namespace Treevel.Common.Networks.Database
             // LoginResultは現状使いところがないが、念の為変数で保存しておく
             var result = await task;
 
-            var success = task.Status == UniTaskStatus.Succeeded;
+            var isSuccess = task.Status == UniTaskStatus.Succeeded;
 
             // 新規作成の場合PlayerPrefsに保存
-            if (success && createAccount) {
+            if (isSuccess && createAccount) {
                 PlayerPrefs.SetString(Constants.PlayerPrefsKeys.DATABASE_LOGIN_ID, customId);
             }
 
-            return success;
+            return isSuccess;
         }
     }
 }

--- a/Assets/Project/Scripts/Common/Networks/Database/PlayFabDatabaseService.cs
+++ b/Assets/Project/Scripts/Common/Networks/Database/PlayFabDatabaseService.cs
@@ -80,7 +80,7 @@ namespace Treevel.Common.Networks.Database
             // ログインと同時に取得したいデータを指定できます
             var infoRequestParams = new GetPlayerCombinedInfoRequestParams();
 
-            #if UNITY_IOS || UNITY_IPHONE
+            #if UNITY_IOS
             var request = new LoginWithIOSDeviceIDRequest() {
                 TitleId = PlayFabSettings.TitleId,
                 DeviceId = customId,

--- a/Assets/Project/Scripts/Common/Utils/Constants.cs
+++ b/Assets/Project/Scripts/Common/Utils/Constants.cs
@@ -19,6 +19,7 @@ namespace Treevel.Common.Utils
             public const string FAILURE_REASONS_COUNT = "FAILURE_REASONS_COUNT";
             public const string STARTUP_DAYS = "STARTUP_DAYS";
             public const string LAST_STARTUP_DATE = "LAST_STARTUP_DATE";
+            public const string DATABASE_LOGIN_ID = "DATABASE_LOGIN_ID";
         }
 
         /// <summary>


### PR DESCRIPTION
### 対象イシュー
Close #729 

### 概要

PlayFabのログイン認証周りの実装

### 詳細

#### 現実装になった経緯

Unityではデバイスの識別子として `SystemInfo.deviceUniqueIdentifier` を用意していますが、[AppleやGoogleの基準改訂によって取得する値が変化する可能性がある](https://note.dimage.co.jp/blog_008_unity-apprication.html)ため、個人識別子として、GUIDを生成することにします。


#### 技術的な内容

* `PlayerPrefs`にログインIDがあるか調べる
* あればそのIDを使ってログイン、なければ新規生成してログイン
* 新規作成の場合ログイン成功後ログインIDを`PlayerPrefs`に保存

### キャプチャ


### 動作確認方法


### 参考 URL
[GUIDの生成](https://kan-kikuchi.hatenablog.com/entry/NewGuid)
