### PR TITLE
BGM フェードイン・フェードアウト

### DIFF
--- a/Assets/Project/Scripts/Common/Managers/SoundManager.cs
+++ b/Assets/Project/Scripts/Common/Managers/SoundManager.cs
@@ -194,11 +194,13 @@ namespace Treevel.Common.Managers
         /// <summary>
         /// BGMの音量をフェイドさせる
         /// </summary>
-        /// <param name="from">初期値</param>
-        /// <param name="to">終値</param>
-        /// <param name="time">変化する時間</param>
+        /// <param name="from">初期値(0.0 to 1.0)</param>
+        /// <param name="to">終値(0.0 to 1.0)</param>
+        /// <param name="time">変化する時間(>0)</param>
         private async UniTask FadeBGMVolume(float from, float to, float time)
         {
+            Debug.Assert(time > 0);
+
             var elapsed = 0f;
             while (elapsed < time) {
                 _bgmPlayer.volume = Mathf.Lerp(from, to, elapsed / time);

--- a/Assets/Project/Scripts/Common/Managers/SoundManager.cs
+++ b/Assets/Project/Scripts/Common/Managers/SoundManager.cs
@@ -175,7 +175,7 @@ namespace Treevel.Common.Managers
             if (_bgmPlayer.isPlaying) _bgmPlayer.Stop();
 
             // フェイド中などで音量が変わった場合があるので一度リセットする
-            ResetVolume();
+            ResetBGMVolume();
 
             _bgmPlayer.clip = clip;
             _bgmPlayer.time = playback;
@@ -230,7 +230,7 @@ namespace Treevel.Common.Managers
         {
             FadeBGMVolume(_bgmPlayer.volume, 0, fadeOutTime).ContinueWith(() => {
                 _bgmPlayer.Stop();
-                ResetVolume();
+                ResetBGMVolume();
             });
         }
 
@@ -262,12 +262,22 @@ namespace Treevel.Common.Managers
             }
         }
 
-        public void ResetVolume()
+        private void ResetBGMVolume()
         {
             _bgmPlayer.volume = _INITIAL_BGM_VOLUME * UserSettings.BGMVolume.Value;
+        }
+
+        private void ResetSEVolume()
+        {
             foreach (var sePlayer in _sePlayers) {
                 sePlayer.volume = _INITIAL_SE_VOLUME * UserSettings.SEVolume.Value;
             }
+        }
+
+        public void ResetVolume()
+        {
+            ResetBGMVolume();
+            ResetSEVolume();
         }
 
         /// <summary>

--- a/Assets/Project/Scripts/Common/Managers/SoundManager.cs
+++ b/Assets/Project/Scripts/Common/Managers/SoundManager.cs
@@ -182,13 +182,15 @@ namespace Treevel.Common.Managers
             _bgmPlayer.Play();
             FadeBGMVolume(0, _bgmPlayer.volume, fadeInTime);
 
-            // ループ終わるところでフェイドアウトフェイドインするようにタイマーを設置する
-            var clipLength = clip.length;
-            _loopVolumeController = Observable.Timer(TimeSpan.FromSeconds(clipLength - _BGM_LOOP_FADE_TIME), TimeSpan.FromSeconds(clipLength)).Subscribe(_ => {
-                Debug.Log("Start FadeIn/FadeOut");
-                var initVolume = _bgmPlayer.volume;
-                FadeBGMVolume(_bgmPlayer.volume, 0, _BGM_LOOP_FADE_TIME).ContinueWith(() => FadeBGMVolume(0, initVolume, _BGM_LOOP_FADE_TIME));
-            }).AddTo(this);
+            if (_bgmPlayer.loop) {
+                // ループ終わるところでフェイドアウトフェイドインするようにタイマーを設置する
+                var clipLength = clip.length;
+                _loopVolumeController = Observable.Timer(TimeSpan.FromSeconds(clipLength - _BGM_LOOP_FADE_TIME), TimeSpan.FromSeconds(clipLength)).Subscribe(_ => {
+                    Debug.Log("Start FadeIn/FadeOut");
+                    var initVolume = _bgmPlayer.volume;
+                    FadeBGMVolume(_bgmPlayer.volume, 0, _BGM_LOOP_FADE_TIME).ContinueWith(() => FadeBGMVolume(0, initVolume, _BGM_LOOP_FADE_TIME));
+                }).AddTo(this);
+            }
         }
 
         /// <summary>

--- a/Assets/Project/Scripts/Common/Managers/SoundManager.cs
+++ b/Assets/Project/Scripts/Common/Managers/SoundManager.cs
@@ -209,6 +209,8 @@ namespace Treevel.Common.Managers
                 await UniTask.WaitForEndOfFrame();
                 elapsed += Time.deltaTime;
             }
+
+            _bgmPlayer.volume = to;
         }
 
         /// <summary>

--- a/Assets/Project/Scripts/Modules/GamePlayScene/GamePlayDirector.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/GamePlayDirector.cs
@@ -353,9 +353,6 @@ namespace Treevel.Modules.GamePlayScene
 
                 // ギミックの発火
                 GimmickGenerator.Instance.FireGimmick();
-
-                // BGMの再生
-                SoundManager.Instance.PlayBGM(EBGMKey.GamePlay_Spring, 2.0f);
             }
 
             /// <summary>


### PR DESCRIPTION
### 対象イシュー
Close #747 

### 概要

タイトルの機能の実装

### 詳細

#### 技術的な内容
* Fade in/out 

```csharp:SoundManager.cs
private async UniTask FadeBGMVolume(float from, float to, float time)
{
    var elapsed = 0f;
    while (elapsed < time) {
        _bgmPlayer.volume = Mathf.Lerp(from, to, elapsed / time);
        await UniTask.WaitForEndOfFrame();
        elapsed += Time.deltaTime;
    }
}
```

* BGMループの先頭と末端でフェイド：`Observable.Timer`を利用する
```csharp
// ループ終わるところでフェイドアウトフェイドインするようにタイマーを設置する
var clipLength = clip.length;
_loopVolumeController = Observable.Timer(TimeSpan.FromSeconds(clipLength - _BGM_LOOP_FADE_TIME), TimeSpan.FromSeconds(clipLength)).Subscribe(_ => {
    Debug.Log("Start FadeIn/FadeOut");
    var initVolume = _bgmPlayer.volume;
    FadeBGMVolume(_bgmPlayer.volume, 0, _BGM_LOOP_FADE_TIME).ContinueWith(() => FadeBGMVolume(0, initVolume, _BGM_LOOP_FADE_TIME));
}).AddTo(this);
```

### 動作確認方法

- [x] プレイしてシーン切り替わった際、BGMがフェイドインしていることを確認
- [x] 同じシーンでBGM再生終了するところでフェイドアウト、フェイドインされること（MenuSelectSceneだと158くらい待つ必要ある）


※現状シーン切り替わった後すぐに新しいBGM再生しているため、フェイドアウトが効かない。