### PR TITLE
個別記録画面を Model と Director に分ける

### DIFF
--- a/Assets/Project/Scripts/Modules/MenuSelectScene/Record/IndividualRecordDirector.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/Record/IndividualRecordDirector.cs
@@ -95,7 +95,7 @@ namespace Treevel.Modules.MenuSelectScene.Record
                     _clearStageNum.GetComponent<ClearStageNumController>()
                         .SetUp(clearStageNum, totalStageNum, _model.currentSeason.Value.GetColor());
 
-                    SetupBarGraph(stageStatusList);
+                    SetupBarGraph();
                 }).AddTo(this);
 
             /*
@@ -171,9 +171,9 @@ namespace Treevel.Modules.MenuSelectScene.Record
             _dropdown.RefreshShownValue();
         }
 
-        private void SetupBarGraph(IReadOnlyCollection<StageStatus> stageStatusList)
+        private void SetupBarGraph()
         {
-            var challengeNumMax = (float)stageStatusList
+            var challengeNumMax = (float)_model.stageStatusArray.Value
                 .Select(stageStatus => stageStatus.challengeNum).Max();
 
             // 1~30 は 30、31~60 は 60 にするために Ceiling を使用
@@ -187,7 +187,7 @@ namespace Treevel.Modules.MenuSelectScene.Record
                 ? maxAxisLabelNum.ToString()
                 : maxAxisLabelNum + "+";
 
-            stageStatusList
+            _model.stageStatusArray.Value
                 .Select((stageStatus, index) => (_graphBars[index], stageStatus.successNum, stageStatus.challengeNum))
                 .ToList()
                 .ForEach(args => {

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/Record/IndividualRecordDirector.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/Record/IndividualRecordDirector.cs
@@ -1,11 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Cysharp.Threading.Tasks;
 using Treevel.Common.Entities;
 using Treevel.Common.Managers;
-using Treevel.Common.Networks;
-using Treevel.Common.Networks.Requests;
 using Treevel.Modules.StageSelectScene;
 using UniRx;
 using UniRx.Triggers;

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/Record/IndividualRecordDirector.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/Record/IndividualRecordDirector.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Cysharp.Threading.Tasks;
 using Treevel.Common.Entities;
@@ -16,33 +17,46 @@ namespace Treevel.Modules.MenuSelectScene.Record
     public class IndividualRecordDirector : MonoBehaviour
     {
         /// <summary>
-        /// [UI] グラフのポップアップ
+        /// Model
+        /// </summary>
+        private IndividualRecordModel _model;
+
+        /// <summary>
+        /// [View] グラフのポップアップ
         /// </summary>
         [SerializeField] private GameObject _graphPopup;
 
         /// <summary>
-        /// [UI] "ステージクリア数" の prefab
+        /// [View] "ステージクリア数" の prefab
         /// </summary>
         [SerializeField] private GameObject _clearStageNum;
 
         /// <summary>
-        /// [UI] 棒グラフの prefab
+        /// [View] 棒グラフの prefab
         /// 現状，グラフの数は 10 で決めうち
         /// </summary>
         [SerializeField] private GameObject[] _graphBars = new GameObject[10];
 
         /// <summary>
-        /// [UI] 棒グラフの y 軸ラベルの text
+        /// [View] 棒グラフの y 軸ラベルの text
         /// 一番下のラベルは 0 で確定なので 3 つを考慮
         /// </summary>
         [SerializeField] private Text[] _graphAxisLabels = new Text[3];
 
         /// <summary>
-        /// [UI] "ステージ一覧へ"
+        /// [View] "ステージ一覧へ"
         /// </summary>
         [SerializeField] private Button _toStageSelectSceneButton;
 
-        private StageStatus[] _stageStatuses;
+        /// <summary>
+        /// [View] ドロップダウン
+        /// </summary>
+        [SerializeField] private Dropdown _dropdown;
+
+        /// <summary>
+        /// [View] ドロップダウンテンプレート
+        /// </summary>
+        [SerializeField] private GameObject _dropdownTemplate;
 
         /// <summary>
         /// y 軸ラベルの最小値
@@ -59,60 +73,58 @@ namespace Treevel.Modules.MenuSelectScene.Record
         /// </summary>
         private const int _AXIS_LABEL_MARGIN = 30;
 
-        [SerializeField] private Dropdown _dropdown;
-
-        [SerializeField] private GameObject _dropdownTemplate;
-
-        /// <summary>
-        /// 現在表示している季節
-        /// </summary>
-        private readonly ReactiveProperty<ESeasonId> _currentSeason = new ReactiveProperty<ESeasonId>(ESeasonId.Spring);
-
-        /// <summary>
-        /// 現在表示している木
-        /// </summary>
-        private readonly ReactiveProperty<ETreeId> _currentTree = new ReactiveProperty<ETreeId>();
-
         private void Awake()
         {
-            _currentTree.Value = _currentSeason.Value.GetFirstTree();
+            _model = new IndividualRecordModel();
 
-            // 季節変更時の処理
-            _currentSeason.Subscribe(season => {
+            /*
+             * Input From Model
+             */
+
+            _model.currentSeason.Subscribe(season => {
                 _graphPopup.SetActive(false);
                 SetDropdownOptions(season);
-                _currentTree.Value = season.GetFirstTree();
             }).AddTo(this);
 
-            // 木変更時の処理
-            _currentTree.Subscribe(tree => {
+            _model.currentTree.Subscribe(tree => {
                 _graphPopup.SetActive(false);
-                SetStageStatuses();
-                SetupBarGraph();
             }).AddTo(this);
 
-            // 木UI制御
-            _dropdown.onValueChanged.AsObservable()
-                .Subscribe(selected => {
-                    _currentTree.Value = (ETreeId)Enum.Parse(typeof(ETreeId), _dropdown.options[selected].text);
+            _model.stageStatusArray
+                .Subscribe(stageStatusList => {
+                    var clearStageNum = stageStatusList.Count(stageStatus => stageStatus.successNum > 0);
+                    var totalStageNum = stageStatusList.Length;
+
+                    _clearStageNum.GetComponent<ClearStageNumController>()
+                        .SetUp(clearStageNum, totalStageNum, _model.currentSeason.Value.GetColor());
+
+                    SetupBarGraph(stageStatusList);
                 }).AddTo(this);
 
-            // 季節制御
-            var seasonToggles = FindObjectsOfType<SeasonSelectButton>();
-            foreach (var seasonToggle in seasonToggles) {
+            /*
+             * Input From View
+             */
+
+            _dropdown.onValueChanged.AsObservable()
+                .Subscribe(selected => {
+                    _model.currentTree.Value = (ETreeId)Enum.Parse(typeof(ETreeId), _dropdown.options[selected].text);
+                }).AddTo(this);
+
+            foreach (var seasonToggle in FindObjectsOfType<SeasonSelectButton>()) {
                 var toggle = seasonToggle.GetComponent<Toggle>();
                 toggle.OnValueChangedAsObservable()
                     .Where(isOn => isOn)
-                    .Subscribe(isOn => {
-                        _currentSeason.Value = seasonToggle.SeasonId;
+                    .Subscribe(_ => {
+                        _model.currentSeason.Value = seasonToggle.SeasonId;
                     }).AddTo(this);
             }
 
             _toStageSelectSceneButton.onClick.AsObservable()
                 .Subscribe(_ => {
-                    StageSelectDirector.seasonId = _currentSeason.Value;
-                    StageSelectDirector.treeId = _currentTree.Value;
-                    AddressableAssetManager.LoadScene(_currentSeason.Value.GetSceneName());
+                    StageSelectDirector.seasonId = _model.currentSeason.Value;
+                    StageSelectDirector.treeId = _model.currentTree.Value;
+
+                    AddressableAssetManager.LoadScene(_model.currentSeason.Value.GetSceneName());
                 }).AddTo(this);
 
             _graphBars
@@ -131,11 +143,21 @@ namespace Treevel.Modules.MenuSelectScene.Record
                             } else {
                                 var graphPosition = _graphBars[stageNumber - 1].GetComponent<RectTransform>().position;
                                 _graphPopup.SetActive(true);
-                                graphPopupController.Initialize(_currentSeason.Value.GetColor(), _currentTree.Value, stageNumber, graphPosition);
+                                graphPopupController.Initialize(_model.currentSeason.Value.GetColor(), _model.currentTree.Value, stageNumber, graphPosition);
                             }
                         })
                         .AddTo(this);
                 });
+        }
+
+        private void OnEnable()
+        {
+            _model.FetchStageStatusList();
+        }
+
+        private void OnDestroy()
+        {
+            _model.Dispose();
         }
 
         private void SetDropdownOptions(ESeasonId seasonId)
@@ -152,28 +174,10 @@ namespace Treevel.Modules.MenuSelectScene.Record
             _dropdown.RefreshShownValue();
         }
 
-        private void OnEnable()
+        private void SetupBarGraph(IReadOnlyCollection<StageStatus> stageStatusList)
         {
-            SetStageStatuses();
-            SetupBarGraph();
-        }
-
-        private async void SetStageStatuses()
-        {
-            var tasks = GameDataManager.GetStages(_currentTree.Value)
-                // FIXME: 呼ばれるたびに ステージ数 分リクエストしてしまうので、リクエストを減らす工夫をする
-                .Select(stage => NetworkService.Execute(new GetStageStatusRequest(stage.TreeId, stage.StageNumber)));
-            _stageStatuses = await UniTask.WhenAll(tasks);
-
-            var clearStageNum = _stageStatuses.Count(stageStatus => stageStatus.successNum > 0);
-            var totalStageNum = _stageStatuses.Length;
-            _clearStageNum.GetComponent<ClearStageNumController>()
-                .SetUp(clearStageNum, totalStageNum, _currentSeason.Value.GetColor());
-        }
-
-        private void SetupBarGraph()
-        {
-            var challengeNumMax = (float)_stageStatuses.Select(stageStatus => stageStatus.challengeNum).Max();
+            var challengeNumMax = (float)stageStatusList
+                .Select(stageStatus => stageStatus.challengeNum).Max();
 
             // 1~30 は 30、31~60 は 60 にするために Ceiling を使用
             var maxAxisLabelNum =
@@ -186,14 +190,14 @@ namespace Treevel.Modules.MenuSelectScene.Record
                 ? maxAxisLabelNum.ToString()
                 : maxAxisLabelNum + "+";
 
-            _stageStatuses
+            stageStatusList
                 .Select((stageStatus, index) => (_graphBars[index], stageStatus.successNum, stageStatus.challengeNum))
                 .ToList()
                 .ForEach(args => {
                     var (graphBar, successNum, challengeNum) = args;
 
                     graphBar.GetComponent<Image>().color =
-                        successNum > 0 ? _currentSeason.Value.GetColor() : Color.gray;
+                        successNum > 0 ? _model.currentSeason.Value.GetColor() : Color.gray;
 
                     var anchorMinY = graphBar.GetComponent<RectTransform>().anchorMin.y;
                     var anchorMaxY = Mathf.Min(anchorMinY + (1.0f - anchorMinY) * challengeNum / maxAxisLabelNum, 1.0f);

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/Record/IndividualRecordDirector.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/Record/IndividualRecordDirector.cs
@@ -75,7 +75,7 @@ namespace Treevel.Modules.MenuSelectScene.Record
             _model = new IndividualRecordModel();
 
             /*
-             * Input From Model
+             * Model -> View
              */
 
             _model.currentSeason.Subscribe(season => {
@@ -83,14 +83,14 @@ namespace Treevel.Modules.MenuSelectScene.Record
                 SetDropdownOptions(season);
             }).AddTo(this);
 
-            _model.currentTree.Subscribe(tree => {
+            _model.currentTree.Subscribe(_ => {
                 _graphPopup.SetActive(false);
             }).AddTo(this);
 
             _model.stageStatusArray
-                .Subscribe(stageStatusList => {
-                    var clearStageNum = stageStatusList.Count(stageStatus => stageStatus.successNum > 0);
-                    var totalStageNum = stageStatusList.Length;
+                .Subscribe(stageStatusArray => {
+                    var clearStageNum = stageStatusArray.Count(stageStatus => stageStatus.successNum > 0);
+                    var totalStageNum = stageStatusArray.Length;
 
                     _clearStageNum.GetComponent<ClearStageNumController>()
                         .SetUp(clearStageNum, totalStageNum, _model.currentSeason.Value.GetColor());
@@ -99,7 +99,7 @@ namespace Treevel.Modules.MenuSelectScene.Record
                 }).AddTo(this);
 
             /*
-             * Input From View
+             * View -> Model
              */
 
             _dropdown.onValueChanged.AsObservable()
@@ -149,7 +149,7 @@ namespace Treevel.Modules.MenuSelectScene.Record
 
         private void OnEnable()
         {
-            _model.FetchStageStatusList();
+            _model.FetchStageStatusArray();
         }
 
         private void OnDestroy()

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/Record/IndividualRecordModel.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/Record/IndividualRecordModel.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+using System.Linq;
+using Treevel.Common.Entities;
+using Treevel.Common.Managers;
+using UniRx;
+
+namespace Treevel.Modules.MenuSelectScene.Record
+{
+    public class IndividualRecordModel
+    {
+        private readonly CompositeDisposable _disposable = new CompositeDisposable();
+
+        /// <summary>
+        /// 現在の季節
+        /// </summary>
+        public readonly ReactiveProperty<ESeasonId> currentSeason = new ReactiveProperty<ESeasonId>(ESeasonId.Spring);
+
+        /// <summary>
+        /// 現在の木
+        /// </summary>
+        public readonly ReactiveProperty<ETreeId> currentTree = new ReactiveProperty<ETreeId>();
+
+        /// <summary>
+        /// 木に対応するステージの情報
+        /// </summary>
+        public readonly ReactiveProperty<List<StageStatus>> stageStatusList = new ReactiveProperty<List<StageStatus>>();
+
+        public IndividualRecordModel()
+        {
+            currentSeason.Subscribe(season => {
+                currentTree.Value = season.GetFirstTree();
+            }).AddTo(_disposable);
+
+            currentTree.Subscribe(tree => {
+                FetchStageStatusList();
+            }).AddTo(_disposable);
+        }
+
+        public void FetchStageStatusList()
+        {
+            stageStatusList.Value = GameDataManager.GetStages(currentTree.Value)
+                .Select(stage => StageStatus.Get(stage.TreeId, stage.StageNumber))
+                .ToList();
+        }
+
+        public void Dispose()
+        {
+            _disposable.Dispose();
+        }
+    }
+}

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/Record/IndividualRecordModel.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/Record/IndividualRecordModel.cs
@@ -33,11 +33,11 @@ namespace Treevel.Modules.MenuSelectScene.Record
             }).AddTo(_disposable);
 
             currentTree.Subscribe(tree => {
-                FetchStageStatusList();
+                FetchStageStatusArray();
             }).AddTo(_disposable);
         }
 
-        public async void FetchStageStatusList()
+        public async void FetchStageStatusArray()
         {
             var tasks = GameDataManager.GetStages(currentTree.Value)
                 .Select(stage => NetworkService.Execute(new GetStageStatusRequest(stage.TreeId, stage.StageNumber)));

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/Record/IndividualRecordModel.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/Record/IndividualRecordModel.cs
@@ -1,7 +1,8 @@
-using System.Collections.Generic;
-using System.Linq;
+using Cysharp.Threading.Tasks;
 using Treevel.Common.Entities;
 using Treevel.Common.Managers;
+using Treevel.Common.Networks;
+using Treevel.Common.Networks.Requests;
 using UniRx;
 
 namespace Treevel.Modules.MenuSelectScene.Record
@@ -23,7 +24,7 @@ namespace Treevel.Modules.MenuSelectScene.Record
         /// <summary>
         /// 木に対応するステージの情報
         /// </summary>
-        public readonly ReactiveProperty<List<StageStatus>> stageStatusList = new ReactiveProperty<List<StageStatus>>();
+        public readonly ReactiveProperty<StageStatus[]> stageStatusArray = new ReactiveProperty<StageStatus[]>();
 
         public IndividualRecordModel()
         {
@@ -36,11 +37,12 @@ namespace Treevel.Modules.MenuSelectScene.Record
             }).AddTo(_disposable);
         }
 
-        public void FetchStageStatusList()
+        public async void FetchStageStatusList()
         {
-            stageStatusList.Value = GameDataManager.GetStages(currentTree.Value)
-                .Select(stage => StageStatus.Get(stage.TreeId, stage.StageNumber))
-                .ToList();
+            var tasks = GameDataManager.GetStages(currentTree.Value)
+                .Select(stage => NetworkService.Execute(new GetStageStatusRequest(stage.TreeId, stage.StageNumber)));
+
+            stageStatusArray.Value = await UniTask.WhenAll(tasks);
         }
 
         public void Dispose()

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/Record/IndividualRecordModel.cs.meta
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/Record/IndividualRecordModel.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 8786df607a234131887766371adc7321
+timeCreated: 1614864939


### PR DESCRIPTION
### 対象イシュー
なし

### 概要
- データのみに関心を持つ Model 層と View 周りのロジックを持つ Director 層に分割した

### 詳細

#### 現実装になった経緯
- Director の責務が多すぎる
- データを管理する Model 層を持つ設計を採用
- UniRx を使っているので、`ReactiveProperty` を利用して、変更を通知する

#### 技術的な内容
- 参考リンクにあるスライドを読めば、基本は理解できる。あえてこのスライドの設計に大きく準拠した
- 現状、Director == Presenter

![PNGイメージ](https://user-images.githubusercontent.com/26104258/111064757-37091f80-84f9-11eb-998e-8de078f5f9de.png)

### レビューの観点
スライドにあるように、Director をどの粒度で作成するかが議論点。従来も今回の変更後も Scene（View の集合）に対して、1 Director になっている。この設計のメリットは
- View が増えても、ファイルが増えない
- Scene 内のどこで何をやっているかがわかる

デメリットは
- View と Director の紐付けが `[SerializeField]` を用いた GUI 操作になってしまう

1 View 1 Director にするメリットは
- `GetComponent` で View を取得できるので、`[SerializeField]` を用いた GUI 操作を必要としない
- 1 Director あたりのコード量が減るので読みやすい

デメリットは
- Director のファイル数が多くなりすぎる

個人的には、現状維持で良い。ファイルたくさん作るの面倒だし、コード量的にも読みづらいレベルではない。`[SerializeField]` を用いた GUI 操作は若干面倒だが、大した労力でもない

### 動作確認方法
- [x] 今までと動作が変わらないこと

### 参考リンク
- https://www.slideshare.net/torisoup/unirxmvrp