### PR TITLE
`async` の使い方を見直す

### DIFF
--- a/Assets/Project/Scripts/Common/Managers/AddressableAssetManager.cs
+++ b/Assets/Project/Scripts/Common/Managers/AddressableAssetManager.cs
@@ -132,7 +132,7 @@ namespace Treevel.Common.Managers
                     // アンロード終了後、辞書から削除
                     _loadedAssets.Remove(sceneName);
                 } else {
-                    UIManager.Instance.ShowErrorMessage(EErrorCode.LoadDataError);
+                    UIManager.Instance.ShowErrorMessageAsync(EErrorCode.LoadDataError).Forget();
                 }
             };
 

--- a/Assets/Project/Scripts/Common/Managers/SoundManager.cs
+++ b/Assets/Project/Scripts/Common/Managers/SoundManager.cs
@@ -228,9 +228,9 @@ namespace Treevel.Common.Managers
         /// <summary>
         /// 再生中のBGMを停止する
         /// </summary>
-        public UniTask StopBGMAsync(float fadeOutTime = 2.0f)
+        public void StopBGMAsync(float fadeOutTime = 2.0f)
         {
-            return FadeBGMVolumeAsync(_bgmPlayer.volume, 0, fadeOutTime).ContinueWith(() => {
+            FadeBGMVolumeAsync(_bgmPlayer.volume, 0, fadeOutTime).ContinueWith(() => {
                 _bgmPlayer.Stop();
                 ResetBGMVolume();
             });

--- a/Assets/Project/Scripts/Common/Managers/SoundManager.cs
+++ b/Assets/Project/Scripts/Common/Managers/SoundManager.cs
@@ -85,7 +85,7 @@ namespace Treevel.Common.Managers
         private void Awake()
         {
             if (!gameObject) {
-                UIManager.Instance.ShowErrorMessage(EErrorCode.UnknownError);
+                UIManager.Instance.ShowErrorMessageAsync(EErrorCode.UnknownError).Forget();
                 return;
             }
 
@@ -180,7 +180,7 @@ namespace Treevel.Common.Managers
             _bgmPlayer.clip = clip;
             _bgmPlayer.time = playback;
             _bgmPlayer.Play();
-            FadeBGMVolumeAsync(0, _bgmPlayer.volume, fadeInTime);
+            FadeBGMVolumeAsync(0, _bgmPlayer.volume, fadeInTime).Forget();
 
             if (_bgmPlayer.loop) {
                 // ループ終わるところでフェイドアウトフェイドインするようにタイマーを設置する
@@ -228,9 +228,9 @@ namespace Treevel.Common.Managers
         /// <summary>
         /// 再生中のBGMを停止する
         /// </summary>
-        public void StopBGM(float fadeOutTime = 2.0f)
+        public UniTask StopBGMAsync(float fadeOutTime = 2.0f)
         {
-            FadeBGMVolumeAsync(_bgmPlayer.volume, 0, fadeOutTime).ContinueWith(() => {
+            return FadeBGMVolumeAsync(_bgmPlayer.volume, 0, fadeOutTime).ContinueWith(() => {
                 _bgmPlayer.Stop();
                 ResetBGMVolume();
             });

--- a/Assets/Project/Scripts/Common/Managers/UIManager.cs
+++ b/Assets/Project/Scripts/Common/Managers/UIManager.cs
@@ -67,10 +67,10 @@ namespace Treevel.Common.Managers
         /// エラーメッセージを表示
         /// </summary>
         /// <param name="errorCode">対応するエラーコード</param>
-        public void ShowErrorMessage(EErrorCode errorCode)
+        public UniTask ShowErrorMessageAsync(EErrorCode errorCode)
         {
             var canvas = GetComponentInChildren<Canvas>().transform;
-            _errorMessageBoxRef.InstantiateAsync(canvas)
+            return _errorMessageBoxRef.InstantiateAsync(canvas)
                 .ToUniTask()
                 .ContinueWith(obj => obj.GetComponent<ErrorMessageBox>().ErrorCode = errorCode);
         }

--- a/Assets/Project/Scripts/Modules/GamePlayScene/BoardManager.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/BoardManager.cs
@@ -149,7 +149,7 @@ namespace Treevel.Modules.GamePlayScene
             }
 
             Debug.LogError($"Cannot find bottle of ID[{bottleId}]");
-            UIManager.Instance.ShowErrorMessage(EErrorCode.InvalidBottleID);
+            UIManager.Instance.ShowErrorMessageAsync(EErrorCode.InvalidBottleID).Forget();
             return Vector2.zero;
         }
 

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Bottle/BottleControllerBase.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Bottle/BottleControllerBase.cs
@@ -75,7 +75,7 @@ namespace Treevel.Modules.GamePlayScene.Bottle
             var elapsedTime = 0f;
             while (true) {
                 if (elapsedTime >= timeOut) {
-                    UIManager.Instance.ShowErrorMessage(EErrorCode.LoadDataError);
+                    UIManager.Instance.ShowErrorMessageAsync(EErrorCode.LoadDataError).Forget();
                     throw new ArgumentNullException("ボトル画像の読み込みが失敗しました");
                 }
 

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Bottle/BottleGenerator.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Bottle/BottleGenerator.cs
@@ -18,7 +18,7 @@ namespace Treevel.Modules.GamePlayScene.Bottle
             { EBottleType.Erasable, Constants.Address.ERASABLE_BOTTLE_PREFAB }
         };
 
-        public static UniTask CreateBottles(List<BottleData> bottleDatas)
+        public static UniTask CreateBottlesAsync(List<BottleData> bottleDatas)
         {
             var tasks = bottleDatas
                 .Where(bottleData => _prefabAddressableKeys.ContainsKey(bottleData.type))

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Bottle/GoalBottleController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Bottle/GoalBottleController.cs
@@ -51,7 +51,7 @@ namespace Treevel.Modules.GamePlayScene.Bottle
             // parse data
             GoalColor = bottleData.goalColor;
             // GoalColorがNoneではないことを保証する
-            if (GoalColor == EGoalColor.None) UIManager.Instance.ShowErrorMessage(EErrorCode.InvalidBottleColor);
+            if (GoalColor == EGoalColor.None) UIManager.Instance.ShowErrorMessageAsync(EErrorCode.InvalidBottleColor).Forget();
 
             await base.InitializeAsync(bottleData);
 

--- a/Assets/Project/Scripts/Modules/GamePlayScene/GamePlayDirector.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/GamePlayDirector.cs
@@ -414,7 +414,7 @@ namespace Treevel.Modules.GamePlayScene
             private void EndProcess()
             {
                 _customTimer.StopTimer();
-                SoundManager.Instance.StopBGMAsync().Forget();
+                SoundManager.Instance.StopBGMAsync();
                 // 一時停止ボタンを非表示にする
                 Instance._pauseButton.SetActive(false);
 
@@ -588,7 +588,7 @@ namespace Treevel.Modules.GamePlayScene
                 _tutorialWindow.SetActive(false);
 
                 // OpeningState はBGMを流さないため止めとく
-                SoundManager.Instance.StopBGMAsync().Forget();
+                SoundManager.Instance.StopBGMAsync();
             }
         }
     }

--- a/Assets/Project/Scripts/Modules/GamePlayScene/GamePlayDirector.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/GamePlayDirector.cs
@@ -414,7 +414,7 @@ namespace Treevel.Modules.GamePlayScene
             private void EndProcess()
             {
                 _customTimer.StopTimer();
-                SoundManager.Instance.StopBGM();
+                SoundManager.Instance.StopBGMAsync().Forget();
                 // 一時停止ボタンを非表示にする
                 Instance._pauseButton.SetActive(false);
 
@@ -588,7 +588,7 @@ namespace Treevel.Modules.GamePlayScene
                 _tutorialWindow.SetActive(false);
 
                 // OpeningState はBGMを流さないため止めとく
-                SoundManager.Instance.StopBGM();
+                SoundManager.Instance.StopBGMAsync().Forget();
             }
         }
     }

--- a/Assets/Project/Scripts/Modules/GamePlayScene/GamePlayDirector.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/GamePlayDirector.cs
@@ -369,7 +369,7 @@ namespace Treevel.Modules.GamePlayScene
                 // BoardManagerの初期化
                 BoardManager.Instance.Initialize();
                 // 番号に合わせたステージの作成
-                StageGenerator.CreateStagesAsync(treeId, stageNumber);
+                StageGenerator.CreateStagesAsync(treeId, stageNumber).Forget();
             }
         }
 

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Gimmick/ErasableController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Gimmick/ErasableController.cs
@@ -42,11 +42,11 @@ namespace Treevel.Modules.GamePlayScene.Gimmick
                 yield return new WaitForSeconds(_GENERATING_INTERVAL);
 
                 // ErasableBottle を生成する
-                InstantiateErasableBottleAsync();
+                InstantiateErasableBottleAsync().Forget();
             }
         }
 
-        private async void InstantiateErasableBottleAsync()
+        private async UniTask InstantiateErasableBottleAsync()
         {
             var puttableTilePositions = new List<(int, int)>();
 

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Gimmick/GimmickGenerator.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Gimmick/GimmickGenerator.cs
@@ -36,7 +36,7 @@ namespace Treevel.Modules.GamePlayScene.Gimmick
                 { EGimmickType.Erasable, Constants.Address.ERASABLE_PREFAB },
             };
 
-        public UniTask Initialize(IEnumerable<GimmickData> gimmicks)
+        public UniTask InitializeAsync(IEnumerable<GimmickData> gimmicks)
         {
             _coroutines = gimmicks.Select(CreateGimmickCoroutine).ToList();
             return UniTask.CompletedTask;

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Gimmick/Powder/PowderController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Gimmick/Powder/PowderController.cs
@@ -42,7 +42,7 @@ namespace Treevel.Modules.GamePlayScene.Gimmick.Powder
             SetBackground();
 
             // 堆積Powderギミックを作成する
-            InstantiatePiledUpPowder();
+            InstantiatePiledUpPowderAsync().Forget();
         }
 
         /// <summary>
@@ -124,7 +124,7 @@ namespace Treevel.Modules.GamePlayScene.Gimmick.Powder
         /// 堆積Powderギミックを作成する
         /// </summary>
         /// <returns></returns>
-        private void InstantiatePiledUpPowder()
+        private UniTask InstantiatePiledUpPowderAsync()
         {
             string address;
             switch (GamePlayDirector.treeId.GetSeasonId()) {
@@ -142,13 +142,15 @@ namespace Treevel.Modules.GamePlayScene.Gimmick.Powder
             var bottles = FindObjectsOfType<GoalBottleController>();
             _piledUpPowders = new PiledUpPowderController[bottles.Length];
 
-            Enumerable.Range(0, bottles.Length).ToList()
-                .ForEach(i => AddressableAssetManager.Instantiate(address).ToUniTask()
+            var tasks = Enumerable.Range(0, bottles.Length).ToList()
+                .Select(i => AddressableAssetManager.Instantiate(address).ToUniTask()
                              .ContinueWith(powderObj => {
                                  var powderController = powderObj.GetComponent<PiledUpPowderController>();
                                  _piledUpPowders[i] = powderController;
                                  powderController.Initialize(bottles[i]);
                              }));
+
+            return UniTask.WhenAll(tasks);
         }
     }
 }

--- a/Assets/Project/Scripts/Modules/GamePlayScene/StageGenerator.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/StageGenerator.cs
@@ -23,7 +23,7 @@ namespace Treevel.Modules.GamePlayScene
         /// <param name="treeId"> 木のID </param>
         /// <param name="stageNumber"> ステージ番号 </param>
         /// <exception cref="NotImplementedException"> 実装されていないステージ id を指定した場合 </exception>
-        public static async void CreateStagesAsync(ETreeId treeId, int stageNumber)
+        public static async UniTask CreateStagesAsync(ETreeId treeId, int stageNumber)
         {
             CreatedFinished = false;
 

--- a/Assets/Project/Scripts/Modules/GamePlayScene/StageGenerator.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/StageGenerator.cs
@@ -31,11 +31,11 @@ namespace Treevel.Modules.GamePlayScene
             var stageData = GameDataManager.GetStage(treeId, stageNumber);
             if (stageData != null) {
                 await UniTask.WhenAll(
-                    TileGenerator.Instance.CreateTiles(stageData.TileDatas),
-                    GimmickGenerator.Instance.Initialize(stageData.GimmickDatas)
+                    TileGenerator.Instance.CreateTilesAsync(stageData.TileDatas),
+                    GimmickGenerator.Instance.InitializeAsync(stageData.GimmickDatas)
                 );
                 // Tile生成後にBottleを生成する
-                await BottleGenerator.CreateBottles(stageData.BottleDatas);
+                await BottleGenerator.CreateBottlesAsync(stageData.BottleDatas);
             } else {
                 // 存在しないステージ
                 Debug.LogError("Unable to create a stage whose stageId is " + stageNumber + ".");

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Tile/GoalTileController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Tile/GoalTileController.cs
@@ -1,4 +1,5 @@
-﻿using Cysharp.Threading.Tasks.Triggers;
+﻿using Cysharp.Threading.Tasks;
+using Cysharp.Threading.Tasks.Triggers;
 using Treevel.Common.Components;
 using Treevel.Common.Entities;
 using Treevel.Common.Entities.GameDatas;
@@ -31,7 +32,7 @@ namespace Treevel.Modules.GamePlayScene.Tile
             Initialize(tileData.number);
             GoalColor = tileData.goalColor;
             // colorがNoneではないことを保証する
-            if (GoalColor == EGoalColor.None) UIManager.Instance.ShowErrorMessage(EErrorCode.InvalidTileColor);
+            if (GoalColor == EGoalColor.None) UIManager.Instance.ShowErrorMessageAsync(EErrorCode.InvalidTileColor).Forget();
             _wound.sprite = AddressableAssetManager.GetAsset<Sprite>(tileData.goalColor.GetTileAddress());
             _wound.color = GoalColor.GetMainColor();
             _mainColorLayer.color = GoalColor.GetMainColor(_mainColorLayer.color.a);

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Tile/SpiderwebTileController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Tile/SpiderwebTileController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Cysharp.Threading.Tasks;
 using Treevel.Common.Entities.GameDatas;
 using Treevel.Common.Utils;
 using Treevel.Modules.GamePlayScene.Bottle;
@@ -40,16 +41,16 @@ namespace Treevel.Modules.GamePlayScene.Tile
             {
                 if (bottle.GetComponent<DynamicBottleController>() == null) return;
 
-                StopBottleAsync(bottle);
+                StopBottleAsync(bottle).Forget();
             }
 
-            private static async void StopBottleAsync(GameObject bottle)
+            private static async UniTask StopBottleAsync(GameObject bottle)
             {
                 Debug.Log("蜘蛛の巣タイルで拘束");
                 bottle.GetComponent<DynamicBottleController>().IsMovable = false;
 
                 // 引数は milliseconds
-                await Task.Delay(_BIND_TIME * 1000);
+                await UniTask.Delay(_BIND_TIME * 1000);
 
                 bottle.GetComponent<DynamicBottleController>().IsMovable = true;
                 Debug.Log("蜘蛛の巣タイルから解放");

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Tile/TileGenerator.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Tile/TileGenerator.cs
@@ -20,24 +20,24 @@ namespace Treevel.Modules.GamePlayScene.Tile
             { ETileType.Spiderweb, Constants.Address.SPIDERWEB_TILE_PREFAB },
         };
 
-        public UniTask CreateTiles(ICollection<TileData> tileDatas)
+        public UniTask CreateTilesAsync(ICollection<TileData> tileDatas)
         {
             // 生成する特殊Tileの番号リスト
             var tileNumList = tileDatas.Select(tileData => tileData.number).Concat(tileDatas.Select(tileData => tileData.pairNumber));
 
             var tasks = tileDatas
                 .Where(tileData => tileData.type == ETileType.Warp)
-                .Select(tileData => CreateWarpTiles(tileData.number, tileData.pairNumber))
+                .Select(tileData => CreateWarpTilesAsync(tileData.number, tileData.pairNumber))
                 .Concat(
                     // WarpTile以外の特殊Tileの生成
                     tileDatas.Where(tileData => tileData.type != ETileType.Warp)
-                        .Select(tileData => CreateTile(tileData))
+                        .Select(tileData => CreateTileAsync(tileData))
                 )
                 .Concat(
                     // NormalTileの生成
                     Enumerable.Range(1, Constants.StageSize.ROW * Constants.StageSize.COLUMN)
                         .Where(tileNum => !tileNumList.Contains((short)tileNum))
-                        .Select(tileNum => CreateNormalTile(tileNum))
+                        .Select(tileNum => CreateNormalTileAsync(tileNum))
                 );
             return UniTask.WhenAll(tasks);
         }
@@ -47,7 +47,7 @@ namespace Treevel.Modules.GamePlayScene.Tile
         /// </summary>
         /// <param name="firstTileNum"> ワープタイル1 </param>
         /// <param name="secondTileNum"> ワープタイル2 </param>
-        private static UniTask CreateWarpTiles(int firstTileNum, int secondTileNum)
+        private static UniTask CreateWarpTilesAsync(int firstTileNum, int secondTileNum)
         {
             var firstTask = AddressableAssetManager.Instantiate(Constants.Address.WARP_TILE_PREFAB).ToUniTask().ContinueWith(firstTile => {
                 var secondTask = AddressableAssetManager.Instantiate(Constants.Address.WARP_TILE_PREFAB).ToUniTask();
@@ -68,7 +68,7 @@ namespace Treevel.Modules.GamePlayScene.Tile
         /// <param name="type"> Tileの種類 </param>
         /// <param name="tileNum"> Tileの番号 </param>
         /// <returns></returns>
-        private UniTask CreateTile(TileData tileData)
+        private UniTask CreateTileAsync(TileData tileData)
         {
             return AddressableAssetManager.Instantiate(_prefabAddressableKeys[tileData.type]).ToUniTask()
                 .ContinueWith(tileObj => {
@@ -83,7 +83,7 @@ namespace Treevel.Modules.GamePlayScene.Tile
         /// <param name="type"> Tileの種類 </param>
         /// <param name="tileNum"> Tileの番号 </param>
         /// <returns></returns>
-        private UniTask CreateNormalTile(int tileNum)
+        private UniTask CreateNormalTileAsync(int tileNum)
         {
             return AddressableAssetManager.Instantiate(_prefabAddressableKeys[ETileType.Normal]).ToUniTask()
                 .ContinueWith(tileObj => {

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Tile/WarpTileController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Tile/WarpTileController.cs
@@ -49,7 +49,7 @@ namespace Treevel.Modules.GamePlayScene.Tile
                 .OnStateExitAsObservable()
                 .Where(state => state.StateInfo.shortNameHash == _ANIMATOR_NAME_HASH_BOTTLEIN)
                 .Subscribe(_ => {
-                    OnExitBottleInAnimationAsync();
+                    OnExitBottleInAnimationAsync().Forget();
                 })
                 .AddTo(this);
 
@@ -58,7 +58,7 @@ namespace Treevel.Modules.GamePlayScene.Tile
                 .OnStateExitAsObservable()
                 .Where(state => state.StateInfo.shortNameHash == _ANIMATOR_NAME_HASH_BOTTLEOUT)
                 .Subscribe(_ => {
-                    OnExitBottleOutAnimationAsync();
+                    OnExitBottleOutAnimationAsync().Forget();
                 })
                 .AddTo(this);
         }
@@ -128,7 +128,7 @@ namespace Treevel.Modules.GamePlayScene.Tile
         /// <summary>
         /// ボトルを吸い込むアニメーション完了後の処理
         /// </summary>
-        private async void OnExitBottleInAnimationAsync()
+        private async UniTask OnExitBottleInAnimationAsync()
         {
             // 呼ばれたタイミングは僅かですがまだ再生終わっていないので待つ
             await UniTask.WaitUntil(() => _animator.GetCurrentAnimatorStateInfo(0).shortNameHash != _ANIMATOR_NAME_HASH_BOTTLEIN);
@@ -154,7 +154,7 @@ namespace Treevel.Modules.GamePlayScene.Tile
         /// <summary>
         /// ボトルを放り出すアニメーション完了後の処理
         /// </summary>
-        private async void OnExitBottleOutAnimationAsync()
+        private async UniTask OnExitBottleOutAnimationAsync()
         {
             // 呼ばれたタイミングは僅かですがまだ再生終わっていない
             await UniTask.WaitUntil(() => _animator.GetCurrentAnimatorStateInfo(0).shortNameHash != _ANIMATOR_NAME_HASH_BOTTLEOUT);

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/LevelSelectDirector.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/LevelSelectDirector.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Cysharp.Threading.Tasks;
 using Treevel.Common.Patterns.Singleton;
 using Treevel.Common.Utils;
 using Treevel.Modules.MenuSelectScene.Settings;
@@ -36,8 +37,8 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
         /// </summary>
         private void OnEnable()
         {
-            _trees.ForEach(tree => tree.UpdateStateAsync());
-            _roads.ForEach(road => road.UpdateStateAsync());
+            _trees.ForEach(tree => tree.UpdateStateAsync().Forget());
+            _roads.ForEach(road => road.UpdateStateAsync().Forget());
         }
 
         /// <summary>

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/LevelTreeController.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/LevelTreeController.cs
@@ -25,7 +25,7 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
 
         [SerializeField] private Button _button;
 
-        public override async void UpdateStateAsync()
+        public override async UniTask UpdateStateAsync()
         {
             // 現在状態をPlayerPrefsから得る
             state = (ETreeState)Enum.ToObject(typeof(ETreeState),

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/LineControllerBase.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/LineControllerBase.cs
@@ -1,4 +1,5 @@
-﻿using UniRx;
+﻿using Cysharp.Threading.Tasks;
+using UniRx;
 using UnityEngine;
 
 namespace Treevel.Modules.MenuSelectScene.LevelSelect
@@ -82,7 +83,7 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
 
         protected abstract void SetSaveKey();
 
-        public abstract void UpdateStateAsync();
+        public abstract UniTask UpdateStateAsync();
 
         public abstract void SaveState();
 

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/NumClearTreeHandler.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/NumClearTreeHandler.cs
@@ -51,10 +51,10 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
             }
 
             // コンストラクタは async にできないので、関数に分離
-            InitializeAsync();
+            InitializeAsync().Forget();
         }
 
-        private async void InitializeAsync()
+        private async UniTask InitializeAsync()
         {
             // FIXME: GetTreeState の時に値が入っている保証がない
             var tasks = Enumerable.Range(1, _stageNum)

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/RoadController.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/RoadController.cs
@@ -56,7 +56,7 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
         /// <summary>
         /// 道の状態の更新
         /// </summary>
-        public override async void UpdateStateAsync()
+        public override async UniTask UpdateStateAsync()
         {
             released = PlayerPrefs.GetInt(saveKey, Default.ROAD_RELEASED) == 1;
 

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/TreeControllerBase.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/TreeControllerBase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Cysharp.Threading.Tasks;
 using Treevel.Common.Entities;
 using UnityEngine;
 
@@ -30,7 +31,7 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
         /// <summary>
         /// 木の状態の更新
         /// </summary>
-        public abstract void UpdateStateAsync();
+        public abstract UniTask UpdateStateAsync();
 
         /// <summary>
         /// 木の状態を見た目や動作に反映

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/Record/GraphPopupController.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/Record/GraphPopupController.cs
@@ -1,3 +1,4 @@
+using Cysharp.Threading.Tasks;
 using Treevel.Common.Entities;
 using Treevel.Common.Entities.GameDatas;
 using Treevel.Common.Networks;
@@ -59,7 +60,7 @@ namespace Treevel.Modules.MenuSelectScene.Record
             GetComponent<RectTransform>().sizeDelta = new Vector2(_width, _height);
         }
 
-        public async void InitializeAsync(Color seasonColor, ETreeId treeId, int stageNumber, Vector3 graphPosition)
+        public async UniTask InitializeAsync(Color seasonColor, ETreeId treeId, int stageNumber, Vector3 graphPosition)
         {
             var stageStatus = await NetworkService.Execute(new GetStageStatusRequest(treeId, stageNumber));
 

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/Record/IndividualRecordDirector.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/Record/IndividualRecordDirector.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Cysharp.Threading.Tasks;
 using Treevel.Common.Entities;
 using Treevel.Common.Managers;
 using Treevel.Modules.StageSelectScene;
@@ -140,7 +141,7 @@ namespace Treevel.Modules.MenuSelectScene.Record
                             } else {
                                 var graphPosition = _graphBars[stageNumber - 1].GetComponent<RectTransform>().position;
                                 _graphPopup.SetActive(true);
-                                graphPopupController.InitializeAsync(_model.currentSeason.Value.GetColor(), _model.currentTree.Value, stageNumber, graphPosition);
+                                graphPopupController.InitializeAsync(_model.currentSeason.Value.GetColor(), _model.currentTree.Value, stageNumber, graphPosition).Forget();
                             }
                         })
                         .AddTo(this);

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/Record/IndividualRecordModel.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/Record/IndividualRecordModel.cs
@@ -33,11 +33,11 @@ namespace Treevel.Modules.MenuSelectScene.Record
             }).AddTo(_disposable);
 
             currentTree.Subscribe(tree => {
-                FetchStageStatusArrayAsync();
+                FetchStageStatusArrayAsync().Forget();
             }).AddTo(_disposable);
         }
 
-        public async void FetchStageStatusArrayAsync()
+        public async UniTask FetchStageStatusArrayAsync()
         {
             var tasks = GameDataManager.GetStages(currentTree.Value)
                 .Select(stage => NetworkService.Execute(new GetStageStatusRequest(stage.TreeId, stage.StageNumber)));

--- a/Assets/Project/Scripts/Modules/StageSelectScene/BranchController.cs
+++ b/Assets/Project/Scripts/Modules/StageSelectScene/BranchController.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Cysharp.Threading.Tasks;
 using Treevel.Common.Entities;
 using Treevel.Common.Utils;
 using Treevel.Modules.MenuSelectScene.LevelSelect;
@@ -33,7 +34,7 @@ namespace Treevel.Modules.StageSelectScene
         /// <summary>
         /// 枝の状態の更新
         /// </summary>
-        public override void UpdateStateAsync()
+        public override UniTask UpdateStateAsync()
         {
             if (branchStates.ContainsKey(saveKey)) {
                 released = branchStates[saveKey];
@@ -62,6 +63,8 @@ namespace Treevel.Modules.StageSelectScene
                 lineRenderer.startColor = new Color(0.2f, 0.2f, 0.7f);
                 lineRenderer.endColor = new Color(0.2f, 0.2f, 0.7f);
             }
+
+            return UniTask.CompletedTask;
         }
 
         /// <summary>

--- a/Assets/Project/Scripts/Modules/StageSelectScene/OverviewPopup.cs
+++ b/Assets/Project/Scripts/Modules/StageSelectScene/OverviewPopup.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Cysharp.Threading.Tasks;
 using Treevel.Common.Entities;
 using Treevel.Common.Managers;
 using Treevel.Common.Networks.Objects;
@@ -61,7 +62,7 @@ namespace Treevel.Modules.StageSelectScene
             // ゲームを開始するボタン
             goToGameButton = transform.Find("PanelBackground/GoToGame").GetComponent<Button>();
             goToGameButton.OnClickAsObservable()
-                .Subscribe(_ => StageSelectDirector.Instance.GoToGameAsync(treeId, stageNumber))
+                .Subscribe(_ => StageSelectDirector.Instance.GoToGameAsync(treeId, stageNumber).Forget())
                 .AddTo(this);
         }
     }

--- a/Assets/Project/Scripts/Modules/StageSelectScene/OverviewPopup.cs
+++ b/Assets/Project/Scripts/Modules/StageSelectScene/OverviewPopup.cs
@@ -27,7 +27,7 @@ namespace Treevel.Modules.StageSelectScene
             var stageData = GameDataManager.GetStage(treeId, stageNumber);
 
             if (stageData == null) {
-                UIManager.Instance.ShowErrorMessage(EErrorCode.UnknownError);
+                UIManager.Instance.ShowErrorMessageAsync(EErrorCode.UnknownError).Forget();
                 return;
             }
 

--- a/Assets/Project/Scripts/Modules/StageSelectScene/StageController.cs
+++ b/Assets/Project/Scripts/Modules/StageSelectScene/StageController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Cysharp.Threading.Tasks;
 using Treevel.Common.Entities;
 using Treevel.Common.Managers;
 using Treevel.Common.Networks;
@@ -97,7 +98,7 @@ namespace Treevel.Modules.StageSelectScene
             if (UserSettings.StageDetails == 1) {
                 StageSelectDirector.Instance.ShowOverPopup(_treeId, stageNumber);
             } else {
-                StageSelectDirector.Instance.GoToGameAsync(_treeId, stageNumber);
+                StageSelectDirector.Instance.GoToGameAsync(_treeId, stageNumber).Forget();
             }
         }
     }

--- a/Assets/Project/Scripts/Modules/StageSelectScene/StageSelectDirector.cs
+++ b/Assets/Project/Scripts/Modules/StageSelectScene/StageSelectDirector.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Cysharp.Threading.Tasks;
 using SnapScroll;
 using Treevel.Common.Entities;
 using Treevel.Common.Managers;
@@ -109,8 +110,8 @@ namespace Treevel.Modules.StageSelectScene
         {
             SoundManager.Instance.PlayBGM(seasonId.GetStageSelectBGM());
 
-            _branches.ForEach(branch => branch.UpdateStateAsync());
-            _trees.ForEach(tree => tree.UpdateStateAsync());
+            _branches.ForEach(branch => branch.UpdateStateAsync().Forget());
+            _trees.ForEach(tree => tree.UpdateStateAsync().Forget());
         }
 
         /// <summary>
@@ -162,7 +163,7 @@ namespace Treevel.Modules.StageSelectScene
         /// <summary>
         /// ステージ選択画面からゲーム選択画面へ移動する
         /// </summary>
-        public async void GoToGameAsync(ETreeId treeId, int stageNumber)
+        public async UniTask GoToGameAsync(ETreeId treeId, int stageNumber)
         {
             // ステージ情報を渡す
             GamePlayDirector.seasonId = seasonId;

--- a/Assets/Project/Scripts/Modules/StageSelectScene/StageTreeController.cs
+++ b/Assets/Project/Scripts/Modules/StageSelectScene/StageTreeController.cs
@@ -42,7 +42,7 @@ namespace Treevel.Modules.StageSelectScene
             _constraintTreeClearHandlers = _constraintTrees.Select(id => id.GetClearTreeHandler()).ToList();
         }
 
-        public override async void UpdateStateAsync()
+        public override async UniTask UpdateStateAsync()
         {
             // 現在状態をPlayerPrefsから得る
             state = (ETreeState)Enum.ToObject(typeof(ETreeState),


### PR DESCRIPTION
### 対象イシュー
Close #782 

### 概要
- `async void` を廃止し、`async UniTask` にする
- `UniTask` を返す関数に、`Async` 接尾辞をつける（今までは `async` がついている関数のみに付けていた）
- `.continueWith(..)` などを使い、投げっぱなしになっている関数では、極力 `UniTask` を返すようにする
- `UniTask` を返しているにもかかわらず、`await` していない場合（意図的な投げっぱなし）には、`.Forget()` を使い、投げっぱなしにしていることを示す

### 詳細

#### 現実装になった経緯
http://neue.cc/2013/10/10_429.html

> 自分で書く場合は、必ずasync Taskで書くべき、というのは非同期のベストプラクティスで散々言われていることなのですけれど、理由としては、まず、voidだと、終了を待てないから。voidだと、その中の処理が軽かろうと重かろうと、終了を感知できない。例外が発生しても分からない。投げっぱなし。これがTaskになっていれば、awaitで終了待ちできる。例外を受け取ることができる。await Task.WhenAllで複数同時に走らせたのを待つことができる。はい、async Taskで書かない理由のほうがない。

以上の理由から `async void` は `async UniTask` にした

----

https://stackoverflow.com/questions/41558559/whats-the-naming-convention-for-non-async-asynchronous-method> 

> Async suffix means "returns an awaitable".

以上の理由から `UniTask` のみを返している関数にも `Async` 接尾辞をつける
