### PR TITLE
TornadoGimmickが出現するときに画面中央に一瞬画像が出現される問題の修正

### DIFF
--- a/Assets/Project/Actors/Tiles/Goal/GoalTilePrefab.prefab
+++ b/Assets/Project/Actors/Tiles/Goal/GoalTilePrefab.prefab
@@ -177,7 +177,7 @@ SpriteRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2963319632678618457}
-  m_Enabled: 1
+  m_Enabled: 0
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
@@ -264,7 +264,7 @@ SpriteRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4165035812717637358}
-  m_Enabled: 1
+  m_Enabled: 0
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1

--- a/Assets/Project/GameDatas/Stages/Spring_1/2.asset
+++ b/Assets/Project/GameDatas/Stages/Spring_1/2.asset
@@ -111,10 +111,17 @@ MonoBehaviour:
     isSelfish: 0
     isDark: 0
     isReverse: 0
+  - type: 1
+    initPos: 15
+    goalColor: 0
+    life: 0
+    isSelfish: 0
+    isDark: 0
+    isReverse: 0
   gimmicks:
   - loop: 1
     appearTime: 3
-    interval: 5
+    interval: 1
     type: 0
     targetDirections: 00000000
     targetLines: 00000000
@@ -123,6 +130,26 @@ MonoBehaviour:
     randomColumn: 
     targetRow: 0
     targetColumn: 0
+    targetBottle: 0
+    randomAttackableBottles: 
+    isRandom: 0
+    targets: []
+    targetDirection: 0
+    attackTimes: 0
+    duration: 0
+    width: 0
+    height: 0
+  - loop: 0
+    appearTime: 0
+    interval: 0
+    type: 8
+    targetDirections: 
+    targetLines: 
+    randomDirection: 
+    randomRow: 
+    randomColumn: 
+    targetRow: -1
+    targetColumn: -1
     targetBottle: 0
     randomAttackableBottles: 
     isRandom: 0

--- a/Assets/Project/Scripts/Common/Components/SpriteRendererUnifier.cs
+++ b/Assets/Project/Scripts/Common/Components/SpriteRendererUnifier.cs
@@ -29,6 +29,9 @@ namespace Treevel.Common.Components
             baseWidth = Constants.WindowSize.WIDTH;
         }
 
+        /// <summary>
+        /// SpriteおよびColliderのサイズを画面に対する比率で調整する
+        /// </summary>
         public void Unify()
         {
             if (_renderer.sprite == null) return;
@@ -40,14 +43,16 @@ namespace Treevel.Common.Components
             var heightEfficient = widthEfficient * ImageRatio;
             transform.localScale = new Vector3(widthEfficient / originalWidth, heightEfficient / originalHeight);
 
-            _renderer.enabled = true;
-
             var collider = GetComponent<BoxCollider2D>();
             if (collider == null) return;
 
             collider.size = new Vector2(originalWidth, originalHeight);
         }
 
+        /// <summary>
+        /// Spriteを設定し、サイズを調整する
+        /// </summary>
+        /// <param name="sprite"></param>
         public void SetSprite(Sprite sprite)
         {
             _renderer.sprite = sprite;

--- a/Assets/Project/Scripts/Common/Managers/AddressableAssetManager.cs
+++ b/Assets/Project/Scripts/Common/Managers/AddressableAssetManager.cs
@@ -274,6 +274,10 @@ namespace Treevel.Common.Managers
                         }
 
                         break;
+                    case EGimmickType.Erasable:
+                        tasks.Add(LoadAssetAsync<GameObject>(Constants.Address.ERASABLE_PREFAB));
+                        tasks.Add(LoadAssetAsync<GameObject>(Constants.Address.ERASABLE_BOTTLE_PREFAB));
+                        break;
                     default:
                         throw new ArgumentOutOfRangeException();
                 }

--- a/Assets/Project/Scripts/Modules/GamePlayScene/BoardManager.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/BoardManager.cs
@@ -437,6 +437,8 @@ namespace Treevel.Modules.GamePlayScene
 
                 // 適切な場所に設置
                 targetSquare.bottle.transform.position = targetSquare.worldPosition;
+                // 表示
+                bottle.GetComponent<SpriteRenderer>().enabled = true;
             }
         }
 

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Bottle/BottleControllerBase.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Bottle/BottleControllerBase.cs
@@ -108,6 +108,10 @@ namespace Treevel.Modules.GamePlayScene.Bottle
             BoardManager.Instance.InitializeBottle(this, Id);
 
             GetComponent<SpriteRendererUnifier>().Unify();
+            GamePlayDirector.Instance.GameStart.Subscribe(_ => {
+                // 表示
+                GetComponent<SpriteRenderer>().enabled = true;
+            }).AddTo(compositeDisposableOnGameEnd, this);
         }
 
         /// <summary>

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Gimmick/TornadoController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Gimmick/TornadoController.cs
@@ -28,7 +28,7 @@ namespace Treevel.Modules.GamePlayScene.Gimmick
         /// <summary>
         /// 警告のプレハブ
         /// </summary>
-        [SerializeField] protected AssetReferenceGameObject _warningPrefab;
+        [SerializeField] private AssetReferenceGameObject _warningPrefab;
 
         /// <summary>
         /// 竜巻の移動方向

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Tile/GoalTileController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Tile/GoalTileController.cs
@@ -1,11 +1,10 @@
 ﻿using Cysharp.Threading.Tasks;
-using Cysharp.Threading.Tasks.Triggers;
-using Treevel.Common.Components;
 using Treevel.Common.Entities;
 using Treevel.Common.Entities.GameDatas;
 using Treevel.Common.Managers;
 using Treevel.Common.Utils;
 using Treevel.Modules.GamePlayScene.Bottle;
+using UniRx;
 using UnityEngine;
 
 namespace Treevel.Modules.GamePlayScene.Tile
@@ -37,6 +36,11 @@ namespace Treevel.Modules.GamePlayScene.Tile
             _wound.color = GoalColor.GetMainColor();
             _mainColorLayer.color = GoalColor.GetMainColor(_mainColorLayer.color.a);
             bottleHandler = new GoalTileBottleHandler(this);
+            GamePlayDirector.Instance.GameStart.Subscribe(_ => {
+                // 表示
+                _wound.GetComponent<SpriteRenderer>().enabled = true;
+                _mainColorLayer.GetComponent<SpriteRenderer>().enabled = true;
+            }).AddTo(compositeDisposableOnGameEnd, this);
             #if UNITY_EDITOR
             name = Constants.TileName.GOAL_TILE + tileData.number;
             #endif

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Tile/NormalTileController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Tile/NormalTileController.cs
@@ -1,6 +1,4 @@
 ﻿using Treevel.Common.Components;
-using Treevel.Common.Entities;
-using Treevel.Common.Entities.GameDatas;
 using Treevel.Common.Managers;
 using Treevel.Common.Utils;
 using UnityEngine;

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Tile/SpiderwebTileController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Tile/SpiderwebTileController.cs
@@ -1,5 +1,4 @@
-﻿using System.Threading.Tasks;
-using Cysharp.Threading.Tasks;
+﻿using Cysharp.Threading.Tasks;
 using Treevel.Common.Entities.GameDatas;
 using Treevel.Common.Utils;
 using Treevel.Modules.GamePlayScene.Bottle;

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Tile/TileControllerBase.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Tile/TileControllerBase.cs
@@ -1,6 +1,6 @@
 ﻿using Treevel.Common.Components;
-using Treevel.Common.Entities;
 using Treevel.Common.Entities.GameDatas;
+using UniRx;
 using UnityEngine;
 
 namespace Treevel.Modules.GamePlayScene.Tile
@@ -30,6 +30,10 @@ namespace Treevel.Modules.GamePlayScene.Tile
         {
             TileNumber = tileNum;
             GetComponent<SpriteRendererUnifier>().Unify();
+            GamePlayDirector.Instance.GameStart.Subscribe(_ => {
+                // 表示
+                GetComponent<SpriteRenderer>().enabled = true;
+            }).AddTo(compositeDisposableOnGameEnd, this);
         }
 
         /// <summary>


### PR DESCRIPTION
### 対象イシュー
Close #784

### 概要
タイトル通り

### 詳細
#### バグ原因
`GameObject`にアタッチしている`SpriteRendererUnifier`の`Unify`メソッドの中で必ず表示するように以前に変更した。
(出現と同時に描画するものしか考えてなかった)
`Tornado`は出現してから、警告を消すまで画面外で待機して、その後、表示して移動させている。
`Unify`メソッドが出現時に処理されるようになっているので、画面外にpositionを変えるまでの一瞬描画されてしまっていた。

#### 現実装になった経緯
- `Unify`メソッドで描画しないように変更
- `Base`クラスの`Initialize`メソッドで描画するようにすると、それを継承するクラスで`base.Initialize`を呼んでから描画設定するときに、親クラスの画像が描画されるのでこれは無し。
- Game開始時に呼ばれるイベントのタイミングで描画するようにしました。
(Game準備完了してからGame開始するまでの間にアニメーションとか入れるなら、Game準備完了のタイミングで描画します)

#### 技術的な内容
特に無し

### キャプチャ
https://user-images.githubusercontent.com/26213141/114269302-4d938f80-9a41-11eb-9e3e-c2940babfff4.mov


### 動作確認方法
Spring_2_1をプレイ

- [x] Tornadoが一瞬中央に表示されないことを確認する
- [x] Bottle, Tileが問題なく表示されることを確認する


### 参考 URL
