### PR TITLE
OnDisable時SoundManagerのヌルチェック

### DIFF
--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/LevelSelectDirector.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/LevelSelectDirector.cs
@@ -48,7 +48,8 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
         /// </summary>
         private void OnDisable()
         {
-            SoundManager.Instance.StopSE(ESEKey.LevelSelect_River);
+            if (SoundManager.Instance)
+                SoundManager.Instance.StopSE(ESEKey.LevelSelect_River);
             _trees.ForEach(tree => tree.SaveState());
             _roads.ForEach(road => road.SaveState());
         }

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/LevelSelectDirector.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/LevelSelectDirector.cs
@@ -22,6 +22,11 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
         /// </summary>
         private List<RoadController> _roads;
 
+        /// <summary>
+        /// アプリ閉じているかどうか（#837の回避策）
+        /// </summary>
+        private bool _isQuitApplication;
+
         private void Awake()
         {
             _trees = GameObject.FindGameObjectsWithTag(Constants.TagName.TREE).Select(tree => tree.GetComponent<LevelTreeController>()).ToList();
@@ -43,12 +48,17 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
             _roads.ForEach(road => road.UpdateStateAsync().Forget());
         }
 
+        private void OnApplicationQuit()
+        {
+            _isQuitApplication = true;
+        }
+
         /// <summary>
         /// 木と道の状態の保存
         /// </summary>
         private void OnDisable()
         {
-            if (SoundManager.Instance)
+            if (!_isQuitApplication)
                 SoundManager.Instance.StopSE(ESEKey.LevelSelect_River);
             _trees.ForEach(tree => tree.SaveState());
             _roads.ForEach(road => road.SaveState());


### PR DESCRIPTION
### 対象イシュー
Close #837 

### 概要
ExecutionOrderを設定したらバキバキにバグったので、普通にnull checkで対応しました。
現状は LevelSelectScene のみだけだが、今後も `OnDisable` や `OnDestroy` 系で `SoundManager` を使う場合は null check していただきたいです。

### 動作確認
- [ ] StartUpSceneにてプレイして何秒か経ってから中止する。何回か繰り返してみて下記のエラーが出なければいいです

SE Clip list is empty
UnityEngine.Debug:LogError (object)
Treevel.Common.Managers.SoundManager:GetSEClip (Treevel.Common.Managers.ESEKey) (at Assets/Project/Scripts/Common/Managers/SoundManager.cs:289)
Treevel.Common.Managers.SoundManager:StopSE (Treevel.Common.Managers.ESEKey) (at Assets/Project/Scripts/Common/Managers/SoundManager.cs:165)
Treevel.Modules.MenuSelectScene.LevelSelect.LevelSelectDirector:OnDisable () (at Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/LevelSelectDirector.cs:51)
Some objects were not cleaned up when closing the scene. (Did you spawn new GameObjects from OnDestroy?)
The following scene GameObjects were found:
_Treevel.Common.Managers.SoundManager

