### PR TITLE
ScaledCanvasSizeのデフォルト値を決める

### DIFF
--- a/Assets/Project/Scripts/Common/Utils/Constants.cs
+++ b/Assets/Project/Scripts/Common/Utils/Constants.cs
@@ -187,6 +187,15 @@ namespace Treevel.Common.Utils
         }
 
         /// <summary>
+        /// 理想的なデバイス(iPhone X/XS)のサイズ
+        /// </summary>
+        public static class DeviceSize
+        {
+            public const int WIDTH = 1125;
+            public const int HEIGHT = 2236;
+        }
+
+        /// <summary>
         /// ゲーム画面のウィンドウサイズ
         /// </summary>
         public static class WindowSize

--- a/Assets/Project/Scripts/Common/Utils/RuntimeConstants.cs
+++ b/Assets/Project/Scripts/Common/Utils/RuntimeConstants.cs
@@ -9,8 +9,9 @@ namespace Treevel.Common.Utils
         /// </summary>
         public static class ScaledCanvasSize
         {
-            public static readonly Vector2 SIZE_DELTA =
-                GameObject.Find("UIManager/Canvas").GetComponent<RectTransform>().sizeDelta;
+            public static readonly Vector2 SIZE_DELTA = GameObject.Find("UIManager/Canvas") ?
+                GameObject.Find("UIManager/Canvas").GetComponent<RectTransform>().sizeDelta :
+                new Vector2(Constants.DeviceSize.WIDTH, Constants.DeviceSize.HEIGHT);
         }
     }
 }

--- a/Assets/Project/Scripts/Common/Utils/RuntimeConstants.cs
+++ b/Assets/Project/Scripts/Common/Utils/RuntimeConstants.cs
@@ -9,9 +9,7 @@ namespace Treevel.Common.Utils
         /// </summary>
         public static class ScaledCanvasSize
         {
-            public static readonly Vector2 SIZE_DELTA = GameObject.Find("UIManager/Canvas") ?
-                GameObject.Find("UIManager/Canvas").GetComponent<RectTransform>().sizeDelta :
-                new Vector2(Constants.DeviceSize.WIDTH, Constants.DeviceSize.HEIGHT);
+            public static readonly Vector2 SIZE_DELTA = GameObject.Find("UIManager/Canvas")?.GetComponent<RectTransform>().sizeDelta ?? new Vector2();
         }
     }
 }


### PR DESCRIPTION
### 対象イシュー
Close #450

### 概要
実行時定数としている`ScaledCanvasSize`(理想的なデバイスとの縦横比を考慮して補正がかかった後のキャンバスサイズ)は、起動画面である`StartUpScene`のキャンバスサイズを実行時に取得している。
それでは、`StartUpScene`以外でデバッグのために実行する時にエラーが出るので、取得できなかった時にデフォルト値を返却するように修正する。

### 詳細
`UIManager`が欲しいんじゃなくて、`UIManager`の子オブジェクトの`Canvas`のサイズが欲しいです。
`UIManager.Instance`で`UIManager`を作成しても子オブジェクトの`Canvas`が存在しないので、素直に、無い場合はデフォルト値を返すようにしました。
その結果、`MenuSelectScene`から実行した時に、
<img width="1066" alt="スクリーンショット 2021-04-14 21 14 39" src="https://user-images.githubusercontent.com/26213141/114710479-b728dc00-9d68-11eb-9e63-43bc3bf147f9.png">
このエラーが出なくなり、拡大縮小ができるようになりました。

ただ、`MenuSelectScene`から実行しても、前回の拡大率の取得に失敗するので、以下のようなエラーが出るようになりました。
<img width="1085" alt="スクリーンショット 2021-04-14 21 31 58" src="https://user-images.githubusercontent.com/26213141/114711019-6e255780-9d69-11eb-9406-4feaea8267eb.png">

`StartUpScene`から実行した時にはこれまで通り問題がないのと、`MenuSelectScene`から実行して上記のエラーが出ても拡大縮小等は出来て、デザインを見るのには使えるのでこれは放置します。

#### 現実装になった経緯


#### 技術的な内容


### キャプチャ


### 動作確認方法

- [x] MenuSelectSceneから実行。拡大縮小ができる。

### 参考 URL
