### PR TITLE
ゲーム画面の一時停止復帰時にBGMを最初から再生するのをやめる

### DIFF
--- a/Assets/Project/Scripts/Modules/GamePlayScene/GamePlayDirector.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/GamePlayDirector.cs
@@ -388,6 +388,9 @@ namespace Treevel.Modules.GamePlayScene
 
             public override void OnEnter(StateBase from = null)
             {
+                // 一時停止だったらそのまま処理終わる
+                if (from is PausingState) return;
+
                 Instance._stageStatus.challengeNum++;
 
                 // todo: 暫定で10が難しいステージのBGMを流す


### PR DESCRIPTION
### 対象イシュー
Close #749 

### 概要
- タイトルまま

### 動作確認方法
- [ ] issue の内容が修正されていること