### PR TITLE
StageStatus 取得失敗時に、PlayerPrefs からデータを取る

### DIFF
--- a/Assets/Project/Scripts/Common/Networks/Requests/ServerRequestBase.cs
+++ b/Assets/Project/Scripts/Common/Networks/Requests/ServerRequestBase.cs
@@ -48,12 +48,7 @@ namespace Treevel.Common.Networks.Requests
 
         public override async UniTask<bool> Execute()
         {
-            if (await remoteDatabaseService.UpdateDataAsync(key, data)) {
-                // 成功したらローカルも更新する
-                PlayerPrefsUtility.SetObject(key, data);
-            }
-
-            return false;
+            return await remoteDatabaseService.UpdateDataAsync(key, data);
         }
     }
 }

--- a/Assets/Project/Scripts/Common/Networks/Requests/UpdateStageStatusRequest.cs
+++ b/Assets/Project/Scripts/Common/Networks/Requests/UpdateStageStatusRequest.cs
@@ -5,9 +5,9 @@ namespace Treevel.Common.Networks.Requests
 {
     public class UpdateStageStatusRequest : UpdateServerRequestBase<StageStatus>
     {
-        public UpdateStageStatusRequest(ETreeId treeId, int stageNumber, StageStatus data)
+        public UpdateStageStatusRequest(string key, StageStatus data)
         {
-            key = StageData.EncodeStageIdKey(treeId, stageNumber);
+            this.key = key;
             this.data = data;
         }
     }

--- a/Assets/Project/Scripts/Common/Networks/Requests/UpdateStageStatusRequest.cs
+++ b/Assets/Project/Scripts/Common/Networks/Requests/UpdateStageStatusRequest.cs
@@ -5,6 +5,12 @@ namespace Treevel.Common.Networks.Requests
 {
     public class UpdateStageStatusRequest : UpdateServerRequestBase<StageStatus>
     {
+        public UpdateStageStatusRequest(ETreeId treeId, int stageNumber, StageStatus data)
+        {
+            key = StageData.EncodeStageIdKey(treeId, stageNumber);
+            this.data = data;
+        }
+
         public UpdateStageStatusRequest(string key, StageStatus data)
         {
             this.key = key;

--- a/Assets/Project/Scripts/Common/Utils/PlayerPrefsUtility.cs
+++ b/Assets/Project/Scripts/Common/Utils/PlayerPrefsUtility.cs
@@ -76,6 +76,21 @@ namespace Treevel.Common.Utils
         }
 
         /// <summary>
+        /// 指定されたオブジェクト情報を読み込む
+        /// </summary>
+        /// <param name="key"> キー </param>
+        /// <param name="defaultValue"> デフォルト値 </param>
+        /// <typeparam name="T"> オブジェクトの型 </typeparam>
+        /// <returns> 読み込みたいオブジェクト </returns>
+        public static T GetObjectOrDefault<T>(string key, T defaultValue)
+        {
+            var json = PlayerPrefs.GetString(key);
+            if (json == "") return defaultValue;
+            var obj = JsonUtility.FromJson<T>(json);
+            return obj;
+        }
+
+        /// <summary>
         /// 指定された辞書型オブジェクト情報を読み込む
         /// </summary>
         /// <param name="key"> キー </param>

--- a/Assets/Project/Scripts/Common/Utils/PlayerPrefsUtility.cs
+++ b/Assets/Project/Scripts/Common/Utils/PlayerPrefsUtility.cs
@@ -71,8 +71,14 @@ namespace Treevel.Common.Utils
         {
             var json = PlayerPrefs.GetString(key);
             if (json == "") return new T();
-            var obj = JsonUtility.FromJson<T>(json);
-            return obj;
+
+            try {
+                var obj = JsonUtility.FromJson<T>(json);
+                return obj;
+            } catch (Exception e) {
+                Debug.LogError(e);
+                return new T();
+            }
         }
 
         /// <summary>
@@ -86,8 +92,14 @@ namespace Treevel.Common.Utils
         {
             var json = PlayerPrefs.GetString(key);
             if (json == "") return defaultValue;
-            var obj = JsonUtility.FromJson<T>(json);
-            return obj;
+
+            try {
+                var obj = JsonUtility.FromJson<T>(json);
+                return obj;
+            } catch (Exception e) {
+                Debug.LogError(e);
+                return defaultValue;
+            }
         }
 
         /// <summary>

--- a/Assets/Project/Scripts/Common/Utils/StageStatusService.cs
+++ b/Assets/Project/Scripts/Common/Utils/StageStatusService.cs
@@ -33,9 +33,14 @@ namespace Treevel.Common.Utils
             var stageStatusList = stageStatuses as List<StageStatus> ?? stageStatuses.ToList();
 
             foreach (var stageData in GameDataManager.GetAllStages()) {
-                var stageStatus = stageStatusList.FirstOrDefault(stageStatus => stageStatus.treeId == stageData.TreeId
-                                                                                && stageStatus.stageNumber == stageData.StageNumber)
-                                  ?? new StageStatus(stageData.TreeId, stageData.StageNumber);
+                StageStatus stageStatus;
+                try {
+                    stageStatus = stageStatusList.First(stageStatus => stageStatus.treeId == stageData.TreeId
+                                                                       && stageStatus.stageNumber == stageData.StageNumber);
+                } catch {
+                    stageStatus = PlayerPrefsUtility.GetObjectOrDefault(StageData.EncodeStageIdKey(stageData.TreeId, stageData.StageNumber),
+                                                                        new StageStatus(stageData.TreeId, stageData.StageNumber));
+                }
 
                 _cachedStageStatusDic[StageData.EncodeStageIdKey(stageData.TreeId, stageData.StageNumber)] = stageStatus;
             }

--- a/Assets/Project/Scripts/Common/Utils/StageStatusService.cs
+++ b/Assets/Project/Scripts/Common/Utils/StageStatusService.cs
@@ -6,7 +6,6 @@ using Treevel.Common.Entities.GameDatas;
 using Treevel.Common.Managers;
 using Treevel.Common.Networks;
 using Treevel.Common.Networks.Requests;
-using UnityEngine;
 
 namespace Treevel.Common.Utils
 {
@@ -80,10 +79,14 @@ namespace Treevel.Common.Utils
         /// <param name="stageStatus"> 保存する StageStatus </param>
         public void Set(ETreeId treeId, int stageNumber, StageStatus stageStatus)
         {
-            NetworkService.Execute(new UpdateStageStatusRequest(treeId, stageNumber, stageStatus))
+            var key = StageData.EncodeStageIdKey(treeId, stageNumber);
+
+            NetworkService.Execute(new UpdateStageStatusRequest(key, stageStatus))
                 .ContinueWith(isSuccess => {
                     if (isSuccess) {
-                        _cachedStageStatusDic[StageData.EncodeStageIdKey(treeId, stageNumber)] = stageStatus;
+                        // データの保存に成功したら、PlayerPrefs とオンメモリにも保存する
+                        PlayerPrefsUtility.SetObject(key, stageStatus);
+                        _cachedStageStatusDic[key] = stageStatus;
                     }
                 });
         }


### PR DESCRIPTION
### 対象イシュー
Close #873 

### 概要
- `StageStatus` を `PlayFab` から取得することに失敗した場合、`PlayerPrefs` から取得するようにする
- `PlayerPrefs` の保存ロジックを移動した

### 実装対象外
- オフライン状態の時に `PlayerPrefs` から取得する想定だったが、オフラインの場合には既存の多くの部分がエラーハンドリングを記述していないため、まともに確認できる状態ではなかった。なので、オフライン時には `PlayerPrefs` から取得することはできない。オフライン対応についてはアイデアに起票した

### 詳細

#### 現実装になった経緯
- 実装対象外の問題があり、今回の修正コードでは、どのような時にこんなこと起こるの？状態ですが、イメージとしては `GetAllStageStatusListRequest` した際に、何らかの原因で取得に失敗した場合には空のリストが返ってくる、という前提での実装になっています。なので `GetAllStageStatusListRequest` した際に例外が throw される場合の対応は含まれていません。

### 動作確認方法
https://github.com/LITO-apps/Treevel-client/blob/f5d0489e77052dde8f10bcb95bf4ea633ff87e43/Assets/Project/Scripts/Common/Networks/Requests/GetAllStageStatusListRequest.cs#L12-L13

の部分を

```
keys = new List<string>();
```

として、常に空リストを返すようにする。

その後、アプリを実行すると、このブランチにおいては `PlayerPrefs` のデータを見ていることにより、データが取得できる

|本ブランチの修正を適用前|本ブランチの修正を適用後|
|---|---|
|<img width="334" alt="スクリーンショット 2021-04-19 20 17 57" src="https://user-images.githubusercontent.com/26104258/115229293-d1d6c880-a14d-11eb-8474-2e52536b5c4e.png">|<img width="335" alt="スクリーンショット 2021-04-19 20 19 05" src="https://user-images.githubusercontent.com/26104258/115229296-d4392280-a14d-11eb-8d76-0a2528184b25.png">|
