### PR TITLE
ギミックのloopが有効するときintervalの値の検証

### DIFF
--- a/Assets/Project/Resources/GameDatas/translation.csv
+++ b/Assets/Project/Resources/GameDatas/translation.csv
@@ -40,6 +40,7 @@ ErrorInvalidBottleAccess,ボトルの不正アクセスが発生しました。,
 ErrorInvalidBottleColor,ボトルの色が正しく設定されていません。,Invalid bottle color.
 ErrorInvalidLifeValue,ライフの値が正しく設定されいません。,Invalid life value.
 ErrorInvalidTileColor,タイルの色が正しく設定されていません。,Invalid tile color.
+ErrorInvalidGimmickData,ギミックデータが正しく設定されていません。。,Invalid gimmick data.
 RecordShareButton,共有,Share
 RecordToIndividualButton,個別記録へ,Individual
 RecordToGeneralButton,総合記録へ,General

--- a/Assets/Project/Scripts/Common/Entities/ErrorCode.cs
+++ b/Assets/Project/Scripts/Common/Entities/ErrorCode.cs
@@ -13,5 +13,6 @@
         InvalidBottleColor, // ボトルの色が不適当
         InvalidLifeValue,   // lifeの値が不適当
         InvalidTileColor,   // タイルの色が不適当
+        InvalidGimmickData, // 不正のギミックデータ
     }
 }

--- a/Assets/Project/Scripts/Common/Entities/TextIndex.cs
+++ b/Assets/Project/Scripts/Common/Entities/TextIndex.cs
@@ -65,5 +65,6 @@ namespace Treevel.Common.Entities
         ErrorInvalidBottleColor,         // ボトルの色が正しく設定されていません。
         ErrorInvalidLifeValue,           // ライフの値が正しく設定されていません。
         ErrorInvalidTileColor,           // タイルの色が正しく設定されていません。
+        ErrorInvalidGimmickData,         // ギミックデータが正しく設定されていません。
     }
 }

--- a/Assets/Project/Scripts/Editor/StageDataEditor.cs
+++ b/Assets/Project/Scripts/Editor/StageDataEditor.cs
@@ -369,7 +369,14 @@ namespace Treevel.Editor
 
                 var intervalProp = gimmickDataProp.FindPropertyRelative("interval");
                 if (loopProp.boolValue) {
+                    // 初期値設定
+                    if (intervalProp.floatValue == 0) {
+                        intervalProp.floatValue = 1.0f;
+                    }
                     EditorGUILayout.PropertyField(intervalProp);
+
+                    // 0以下にならないように
+                    intervalProp.floatValue = Mathf.Max(0.0001f, intervalProp.floatValue);
                 }
 
                 switch ((EGimmickType)gimmickTypeProp.enumValueIndex) {

--- a/Assets/Project/Scripts/Editor/StageDataEditor.cs
+++ b/Assets/Project/Scripts/Editor/StageDataEditor.cs
@@ -364,10 +364,13 @@ namespace Treevel.Editor
                 }
 
                 EditorGUILayout.PropertyField(gimmickDataProp.FindPropertyRelative("appearTime"));
-                var intervalProp = gimmickDataProp.FindPropertyRelative("interval");
-                EditorGUILayout.PropertyField(intervalProp);
                 var loopProp = gimmickDataProp.FindPropertyRelative("loop");
                 EditorGUILayout.PropertyField(loopProp);
+
+                var intervalProp = gimmickDataProp.FindPropertyRelative("interval");
+                if (loopProp.boolValue) {
+                    EditorGUILayout.PropertyField(intervalProp);
+                }
 
                 switch ((EGimmickType)gimmickTypeProp.enumValueIndex) {
                     case EGimmickType.Tornado: {

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Gimmick/GimmickGenerator.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Gimmick/GimmickGenerator.cs
@@ -60,6 +60,11 @@ namespace Treevel.Modules.GamePlayScene.Gimmick
             // 出現時間経つまで待つ
             yield return new WaitForSeconds(data.appearTime - (Time.time - _startTime));
 
+            if (data.loop && data.interval <= 0) {
+                UIManager.Instance.ShowErrorMessageAsync(EErrorCode.InvalidGimmickData).Forget();
+                yield break;
+            }
+
             do {
                 var instantiateTime = Time.time;
                 // ギミックインスタンス作成


### PR DESCRIPTION
### 対象イシュー
Close #804 

### 概要
loop有効時intervalが0だと限りなく無限のギミックを作ることになってしまうため、エディタ及びギミックジェネレータの対応を行う。


### 動作確認方法
- [x] ステージデータエディタでloop つけた時のみ interval入力できることを確認。
- [x] interval の初期値は1であることを確認
- [x] intervalの最小値は0.0001であることを確認


### 参考 URL
