### PR TITLE
川のSEの再生タイミング修正

### DIFF
--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/LevelSelectDirector.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/LevelSelectDirector.cs
@@ -7,6 +7,7 @@ using Treevel.Common.Utils;
 using Treevel.Modules.MenuSelectScene.Settings;
 using UniRx;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 namespace Treevel.Modules.MenuSelectScene.LevelSelect
 {
@@ -43,7 +44,9 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
         /// </summary>
         private void OnEnable()
         {
-            SoundManager.Instance.PlaySE(ESEKey.LevelSelect_River);
+            if (SceneManager.GetActiveScene().name == Constants.SceneName.MENU_SELECT_SCENE) {
+                SoundManager.Instance.PlaySE(ESEKey.LevelSelect_River);
+            }
             _trees.ForEach(tree => tree.UpdateStateAsync().Forget());
             _roads.ForEach(road => road.UpdateStateAsync().Forget());
         }

--- a/Assets/Project/Scripts/Modules/StartUpScene/StartUpDirector.cs
+++ b/Assets/Project/Scripts/Modules/StartUpScene/StartUpDirector.cs
@@ -62,6 +62,7 @@ namespace Treevel.Modules.StartUpScene
 
             // MenuSelectSceneのBGMを流す
             SoundManager.Instance.PlayBGM(EBGMKey.MenuSelect);
+            SoundManager.Instance.PlaySE(ESEKey.LevelSelect_River);
 
             // Unload Startup Scene
             SceneManager.UnloadSceneAsync(Constants.SceneName.START_UP_SCENE);


### PR DESCRIPTION
### 対象イシュー
Close #867 

### 概要
タイトル通り

### 詳細

`LevelSelectDirector.OnEnable` はフッターの切り替えるところで必要なので、そこでアクティブシーンかどうか判断してSEを再生。
一番最初の再生は `StartupScene`のボタン押下直後BGMと同じタイミングで再生する。

### 動作確認方法
- [x] StartupSceneで川の音しないことを確認
- [x] ボタン押下後レベル選択画面の表示とともに川の音が再生されることを確認