### PR TITLE
フェイドイン・アウト中 ChangeBGMVolume適用されない問題を修正

### DIFF
--- a/Assets/Project/Actors/Common/AudioMixer.mixer
+++ b/Assets/Project/Actors/Common/AudioMixer.mixer
@@ -1,0 +1,143 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!244 &-8687580155820483864
+AudioMixerEffectController:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_EffectID: 5d8c806d57b20467cb436cbb95837135
+  m_EffectName: Attenuation
+  m_MixLevel: 7570286c1fa90484d88405a054a3f0e5
+  m_Parameters: []
+  m_SendTarget: {fileID: 0}
+  m_EnableWetMix: 0
+  m_Bypass: 0
+--- !u!243 &-6485719781099264269
+AudioMixerGroupController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: SE
+  m_AudioMixer: {fileID: 24100000}
+  m_GroupID: 2fd32ff19eedb47b6989f5b92b8b983f
+  m_Children: []
+  m_Volume: c173acdda685d48799f5ee3a64cefb75
+  m_Pitch: bb37258fcf13f41d18987a569cded080
+  m_Send: 00000000000000000000000000000000
+  m_Effects:
+  - {fileID: 2343537003804529954}
+  m_UserColorIndex: 0
+  m_Mute: 0
+  m_Solo: 0
+  m_BypassEffects: 0
+--- !u!241 &24100000
+AudioMixerController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: AudioMixer
+  m_OutputGroup: {fileID: 0}
+  m_MasterGroup: {fileID: 24300002}
+  m_Snapshots:
+  - {fileID: 24500006}
+  m_StartSnapshot: {fileID: 24500006}
+  m_SuspendThreshold: -80
+  m_EnableSuspend: 1
+  m_UpdateMode: 0
+  m_ExposedParameters:
+  - guid: df4fe8c65205a4d7f84593033cd828e8
+    name: BGMVolume
+  m_AudioMixerGroupViews:
+  - guids:
+    - a405a8b5d40f44177a60b88a035b62f7
+    - f368926d30f3441ba95c68017b5e6bc3
+    - 2fd32ff19eedb47b6989f5b92b8b983f
+    name: View
+  m_CurrentViewIndex: 0
+  m_TargetSnapshot: {fileID: 24500006}
+--- !u!243 &24300002
+AudioMixerGroupController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Master
+  m_AudioMixer: {fileID: 24100000}
+  m_GroupID: a405a8b5d40f44177a60b88a035b62f7
+  m_Children:
+  - {fileID: 5587728878416907349}
+  - {fileID: -6485719781099264269}
+  m_Volume: a6e1194e999c14c43ad281bf44c18239
+  m_Pitch: d3ecbbe2b7b764af1baf65fcfb7aa233
+  m_Send: 00000000000000000000000000000000
+  m_Effects:
+  - {fileID: 24400004}
+  m_UserColorIndex: 0
+  m_Mute: 0
+  m_Solo: 0
+  m_BypassEffects: 0
+--- !u!244 &24400004
+AudioMixerEffectController:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_EffectID: 93bb5257547984e5bbc7b79a7b96688e
+  m_EffectName: Attenuation
+  m_MixLevel: 809697d758309452db8bca02f2ab09da
+  m_Parameters: []
+  m_SendTarget: {fileID: 0}
+  m_EnableWetMix: 0
+  m_Bypass: 0
+--- !u!245 &24500006
+AudioMixerSnapshotController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Snapshot
+  m_AudioMixer: {fileID: 24100000}
+  m_SnapshotID: 34a890c1e01ba459ab39d75ad408f461
+  m_FloatValues:
+    df4fe8c65205a4d7f84593033cd828e8: 0
+    c173acdda685d48799f5ee3a64cefb75: 0
+    a6e1194e999c14c43ad281bf44c18239: 0
+  m_TransitionOverrides: {}
+--- !u!244 &2343537003804529954
+AudioMixerEffectController:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_EffectID: 778262dfc8da7421a90e6c64829f3a21
+  m_EffectName: Attenuation
+  m_MixLevel: 605585b5233ea43a1b4bce5fbbcac87d
+  m_Parameters: []
+  m_SendTarget: {fileID: 0}
+  m_EnableWetMix: 0
+  m_Bypass: 0
+--- !u!243 &5587728878416907349
+AudioMixerGroupController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: BGM
+  m_AudioMixer: {fileID: 24100000}
+  m_GroupID: f368926d30f3441ba95c68017b5e6bc3
+  m_Children: []
+  m_Volume: df4fe8c65205a4d7f84593033cd828e8
+  m_Pitch: 66deddd987d494a19b7b273df5909a2e
+  m_Send: 00000000000000000000000000000000
+  m_Effects:
+  - {fileID: -8687580155820483864}
+  m_UserColorIndex: 0
+  m_Mute: 0
+  m_Solo: 0
+  m_BypassEffects: 0

--- a/Assets/Project/Actors/Common/AudioMixer.mixer.meta
+++ b/Assets/Project/Actors/Common/AudioMixer.mixer.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 29b40342b690845b993e9bacc177dd10
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 24100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/Actors/Common/SoundManager.prefab
+++ b/Assets/Project/Actors/Common/SoundManager.prefab
@@ -112,6 +112,10 @@ MonoBehaviour:
     clip: {fileID: 8300000, guid: ea1901f8359f640dca12203a7a35bdc3, type: 3}
   _INITIAL_BGM_VOLUME: 0.25
   _INITIAL_SE_VOLUME: 1
+  _bgmMixer: {fileID: 5587728878416907349, guid: 29b40342b690845b993e9bacc177dd10,
+    type: 2}
+  _seMixer: {fileID: -6485719781099264269, guid: 29b40342b690845b993e9bacc177dd10,
+    type: 2}
 --- !u!81 &1835023510
 AudioListener:
   m_ObjectHideFlags: 0

--- a/Assets/Project/Scripts/Common/Managers/SoundManager.cs
+++ b/Assets/Project/Scripts/Common/Managers/SoundManager.cs
@@ -7,6 +7,7 @@ using Treevel.Common.Entities;
 using Treevel.Common.Patterns.Singleton;
 using UniRx;
 using UnityEngine;
+using UnityEngine.Audio;
 using Random = UnityEngine.Random;
 #if UNITY_EDITOR
 using UnityEditor;
@@ -92,6 +93,12 @@ namespace Treevel.Common.Managers
         [SerializeField] [Range(0, 1)] private float _INITIAL_SE_VOLUME = 1.0f;
 
         /// <summary>
+        /// オーディオミキサー
+        /// </summary>
+        [SerializeField] private AudioMixerGroup _bgmMixer;
+        [SerializeField] private AudioMixerGroup _seMixer;
+
+        /// <summary>
         /// BGMループでフェイドインフェイドアウトする時間（秒）
         /// </summary>
         private const float _BGM_LOOP_FADE_TIME = 2.0f;
@@ -117,6 +124,7 @@ namespace Treevel.Common.Managers
             _bgmPlayer = gameObject.AddComponent(typeof(AudioSource)) as AudioSource;
             _bgmPlayer.loop = true;
             _bgmPlayer.playOnAwake = false;
+            _bgmPlayer.outputAudioMixerGroup = _bgmMixer;
 
             // SE再生用のAudioSourceをアタッチする
             _sePlayers = new AudioSource[_MAX_SE_NUM];
@@ -124,6 +132,7 @@ namespace Treevel.Common.Managers
                 var player = gameObject.AddComponent(typeof(AudioSource)) as AudioSource;
                 player.loop = false;
                 player.playOnAwake = false;
+                player.outputAudioMixerGroup = _seMixer;
 
                 _sePlayers[i] = player;
             }
@@ -383,6 +392,9 @@ namespace Treevel.Common.Managers
             public override void OnInspectorGUI()
             {
                 EditorGUI.BeginChangeCheck();
+
+                EditorGUILayout.PropertyField(serializedObject.FindProperty("_bgmMixer"));
+                EditorGUILayout.PropertyField(serializedObject.FindProperty("_seMixer"));
 
                 EditorGUILayout.PropertyField(serializedObject.FindProperty("_INITIAL_BGM_VOLUME"),
                                               new GUIContent("Initial BGM Volume"));

--- a/Assets/Project/Scripts/Common/Managers/SoundManager.cs
+++ b/Assets/Project/Scripts/Common/Managers/SoundManager.cs
@@ -281,10 +281,9 @@ namespace Treevel.Common.Managers
         /// <param name="ratio"> 音量への倍率 </param>
         public void ChangeBGMVolume(float ratio)
         {
-            // BGM が再生中ではないなら，何もしない
-            if (!_bgmPlayer.isPlaying) return;
-
-            _bgmPlayer.volume *= ratio;
+            // 倍率からdBに変換する
+            var dB = 10 * Mathf.Log10(ratio);
+            _bgmMixer.audioMixer.SetFloat("BGMVolume", dB);
         }
 
         /// <summary>

--- a/Assets/Project/Scripts/Common/Managers/SoundManager.cs
+++ b/Assets/Project/Scripts/Common/Managers/SoundManager.cs
@@ -278,11 +278,11 @@ namespace Treevel.Common.Managers
         /// <summary>
         /// BGM の音量を変更する
         /// </summary>
-        /// <param name="ratio"> 音量への倍率 </param>
-        public void ChangeBGMVolume(float ratio)
+        /// <param name="volume"></param>
+        public void SetMasterBGMVolume(float volume)
         {
             // 倍率からdBに変換する
-            var dB = 10 * Mathf.Log10(ratio);
+            var dB = 10 * Mathf.Log10(volume);
             _bgmMixer.audioMixer.SetFloat("BGMVolume", dB);
         }
 

--- a/Assets/Project/Scripts/Modules/GamePlayScene/GamePlayDirector.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/GamePlayDirector.cs
@@ -448,7 +448,7 @@ namespace Treevel.Modules.GamePlayScene
                 // ゲーム内の時間を一時停止する
                 Time.timeScale = 0.0f;
                 // ポーズ中は BGM を少し下げる
-                SoundManager.Instance.ChangeBGMVolume(_BGM_VOLUME_RATIO_ON_PAUSE);
+                SoundManager.Instance.SetMasterBGMVolume(_BGM_VOLUME_RATIO_ON_PAUSE);
                 // 一時停止ポップアップ表示
                 Instance._pauseWindow.SetActive(true);
                 Instance._pauseBackground.SetActive(true);
@@ -461,7 +461,7 @@ namespace Treevel.Modules.GamePlayScene
                 // ゲーム内の時間を元に戻す
                 Time.timeScale = 1.0f;
                 // BGM を元に戻す
-                SoundManager.Instance.ChangeBGMVolume(1.0f);
+                SoundManager.Instance.SetMasterBGMVolume(1.0f);
                 if (!(to is FailureState)) {
                     // 一時停止ウィンドウを非表示にする
                     Instance._pauseWindow.SetActive(false);

--- a/Assets/Project/Scripts/Modules/GamePlayScene/GamePlayDirector.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/GamePlayDirector.cs
@@ -461,7 +461,7 @@ namespace Treevel.Modules.GamePlayScene
                 // ゲーム内の時間を元に戻す
                 Time.timeScale = 1.0f;
                 // BGM を元に戻す
-                SoundManager.Instance.ChangeBGMVolume(1 / _BGM_VOLUME_RATIO_ON_PAUSE);
+                SoundManager.Instance.ChangeBGMVolume(1.0f);
                 if (!(to is FailureState)) {
                     // 一時停止ウィンドウを非表示にする
                     Instance._pauseWindow.SetActive(false);


### PR DESCRIPTION
### 対象イシュー
Close #877 

### 概要
フェイドイン・アウト中 ChangeBGMVolumeを呼び出すとbgmPlayer.volumeの値が実行中のコルチーンにより上書きされるため変更が適用されない問題を修正。

### 詳細

#### 現実装になった経緯
別の変数(ratio)を用意してvolume設定するところで掛けることで解決を試みたが、色々不都合が生じたため、取りやめに。

最終的に `AudioMixer` 機能を導入することにした。
以下作業手順を書きます

1. AudioMixerを新たに作成
![image](https://user-images.githubusercontent.com/17778395/115897731-b34b3700-a497-11eb-8310-384251ef97f2.png)

2. 作ったAudioMixerをダブルクリックすると `Audio Mixer` ウィンドウが開く。 Groupsのところから BGMとSEの二つの `AudioMixerGroup` を `Master` に追加 
![image](https://user-images.githubusercontent.com/17778395/115897847-d5dd5000-a497-11eb-91c2-c82290f638f5.png)

3. BGM を選択して Inspector から AttenuationのVolumeのところで右クリック `Expose "Volume (of BGM) to script` を選択 
![image](https://user-images.githubusercontent.com/17778395/115898094-1fc63600-a498-11eb-9b63-bde26edc003c.png)

4. `Audio Mixer` ウィンドウの右上にある Exposed Parameters から変数名を変更する 
![image](https://user-images.githubusercontent.com/17778395/115898444-88151780-a498-11eb-99f2-4ec05b0e21a2.png)

5. Exposedした変数はソースコードから制御可能になる。
```
public void ChangeBGMVolume(float ratio)
{
        // 倍率からdBに変換する
        var dB = 10 * Mathf.Log10(ratio);
        _bgmMixer.audioMixer.SetFloat("BGMVolume", dB);
}
```

#### 技術的な内容


### キャプチャ


### 動作確認方法
現状カウントダウンステート加入することにより、フェイドイン中一時停止が不可能になっていますので、フェイドインの秒数を一時的に上げていただくか、AudioMixer を開きながらゲームを進んで添付動画のように目視でBGMの値が変化したのを確認していただければと思います。（右のBGMのところを注目）

https://user-images.githubusercontent.com/17778395/115899708-0aeaa200-a49a-11eb-9ddf-067dd669057c.mov





### 参考 URL
[デジベルの計算について](https://ja.wikipedia.org/wiki/デシベル)
[Audio Mixerのパラメータ制御について](https://forum.unity.com/threads/changing-audio-mixer-group-volume-with-ui-slider.297884/)