### PR TITLE
プログレスバーが表示されたままの不具合を修正

### DIFF
--- a/Assets/Project/Scripts/Common/Components/UIs/ProgressBar.cs
+++ b/Assets/Project/Scripts/Common/Components/UIs/ProgressBar.cs
@@ -56,7 +56,10 @@ namespace Treevel.Common.Components.UIs
             // アセットロードするイベントを購読
             AddressableAssetManager.OnAssetStartLoad.Subscribe(op => {
                 _loadingOps.Add(op);
-                op.Completed += op1 => _loadingOps.Remove(op1);
+                op.Completed += op1 => {
+                    var idx = _loadingOps.FindIndex(h => h.GetHashCode() == op1.GetHashCode());
+                    _loadingOps.RemoveAt(idx);
+                };
 
                 if (!gameObject.activeSelf) {
                     gameObject.SetActive(true);


### PR DESCRIPTION
### 対象イシュー
Close #872 

### 概要
タイトルまま

### 詳細

#### 現実装になった経緯
なぜか `op1` が `_loadingOps` に入っているのに `_loadingOps.Contains(op1)` と `_loadingOps.Remove(op1)` の判定が失敗になってしまう。原因は分からないので、インデックスを検索してから削除にするように対応した。

![image](https://user-images.githubusercontent.com/17778395/116103840-ec2f1a00-a6ea-11eb-8c2c-fab4bfa1afa5.png)
![image](https://user-images.githubusercontent.com/17778395/116104083-20a2d600-a6eb-11eb-8c02-8450a44c5936.png)


### 動作確認方法
- [x] 任意のステージをプレイし、ゲーム画面に入ってプログレスバーが消えることを確認
