### PR TITLE
ステージ記録リセット機能修正

### DIFF
--- a/Assets/Project/Scripts/Common/Entities/GameDatas/StageData.cs
+++ b/Assets/Project/Scripts/Common/Entities/GameDatas/StageData.cs
@@ -35,6 +35,11 @@ namespace Treevel.Common.Entities.GameDatas
         public List<string> ConstraintStages => constraintStages;
 
         /// <summary>
+        /// ステージIDを取得
+        /// </summary>
+        public string StageId => EncodeStageIdKey(treeId, stageNumber);
+
+        /// <summary>
         /// ステージのkeyを生成する
         /// </summary>
         /// <param name="treeId"></param>

--- a/Assets/Project/Scripts/Common/Entities/StageRecord.cs
+++ b/Assets/Project/Scripts/Common/Entities/StageRecord.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Linq;
-using Treevel.Common.Entities.GameDatas;
-using UnityEngine;
 
 namespace Treevel.Common.Entities
 {
@@ -66,19 +63,6 @@ namespace Treevel.Common.Entities
         {
             this.treeId = treeId;
             this.stageNumber = stageNumber;
-        }
-
-        /// <summary>
-        /// オブジェクト情報のリセット
-        /// </summary>
-        public static void Reset()
-        {
-            foreach (ETreeId treeId in Enum.GetValues(typeof(ETreeId))) {
-                var stageNum = treeId.GetStageNum();
-
-                Enumerable.Range(1, stageNum).ToList()
-                    .ForEach(stageId => PlayerPrefs.DeleteKey(StageData.EncodeStageIdKey(treeId, stageId)));
-            }
         }
 
         /// <summary>

--- a/Assets/Project/Scripts/Common/Networks/Database/IDatabaseService.cs
+++ b/Assets/Project/Scripts/Common/Networks/Database/IDatabaseService.cs
@@ -13,6 +13,8 @@ namespace Treevel.Common.Networks.Database
         UniTask<bool> UpdateDataAsync<T>(string key, T data);
 
         UniTask<bool> LoginAsync();
+
+        UniTask<bool> DeleteDataAsync(IEnumerable<string> keys);
     }
 
     public class NetworkErrorException : Exception

--- a/Assets/Project/Scripts/Common/Networks/Database/PlayFabDatabaseService.cs
+++ b/Assets/Project/Scripts/Common/Networks/Database/PlayFabDatabaseService.cs
@@ -168,7 +168,7 @@ namespace Treevel.Common.Networks.Database
         public async UniTask<bool> DeleteDataAsync(IEnumerable<string> keys)
         {
             var request = new UpdateUserDataRequest {
-                KeysToRemove = keys.ToList()
+                KeysToRemove = keys.ToList(),
             };
 
             try {

--- a/Assets/Project/Scripts/Common/Networks/Database/PlayFabDatabaseService.cs
+++ b/Assets/Project/Scripts/Common/Networks/Database/PlayFabDatabaseService.cs
@@ -164,5 +164,29 @@ namespace Treevel.Common.Networks.Database
 
             return isSuccess;
         }
+
+        public async UniTask<bool> DeleteDataAsync(IEnumerable<string> keys)
+        {
+            var request = new UpdateUserDataRequest {
+                KeysToRemove = keys.ToList()
+            };
+
+            try {
+                var task = PlayFabClientAPIAsync.UpdateUserDataAsync(request);
+                // UpdateUserDataResultは現状使いところがないが、念の為変数で保存しておく
+                var result = await task;
+
+                // 成功状態を返す
+                if (task.Status == UniTaskStatus.Succeeded) {
+                    return true;
+                }
+
+                return false;
+            } catch(Exception e) {
+                // ローカルに切り替えるため呼び出し先に投げる
+                Debug.LogError(e.Message + e.StackTrace);
+                throw;
+            }
+        }
     }
 }

--- a/Assets/Project/Scripts/Common/Networks/Requests/DeleteAllStageRecordRequest.cs
+++ b/Assets/Project/Scripts/Common/Networks/Requests/DeleteAllStageRecordRequest.cs
@@ -1,0 +1,27 @@
+using System.Linq;
+using Cysharp.Threading.Tasks;
+using Treevel.Common.Entities.GameDatas;
+using Treevel.Common.Utils;
+
+namespace Treevel.Common.Networks.Requests
+{
+    public class DeleteAllStageRecordRequest : DeleteServerRequestBase
+    {
+        public DeleteAllStageRecordRequest()
+        {
+            // 遊んだことがあるステージのみ削除
+            keys = StageRecordService.Instance.Get()
+                .Where(s => s.challengeNum > 0)
+                .Select(s => StageData.EncodeStageIdKey(s.treeId, s.stageNumber));
+        }
+
+        public override async UniTask<bool> Execute()
+        {
+            var allSuccess = true;
+            for (var i = 0 ; i < keys.Count() / 10 ; i++) {
+                allSuccess &= await remoteDatabaseService.DeleteDataAsync(keys.Skip(i * 10).Take(10));
+            }
+            return allSuccess;
+        }
+    }
+}

--- a/Assets/Project/Scripts/Common/Networks/Requests/DeleteAllStageRecordRequest.cs
+++ b/Assets/Project/Scripts/Common/Networks/Requests/DeleteAllStageRecordRequest.cs
@@ -1,5 +1,4 @@
 using System.Linq;
-using Cysharp.Threading.Tasks;
 using Treevel.Common.Entities.GameDatas;
 using Treevel.Common.Utils;
 
@@ -13,15 +12,6 @@ namespace Treevel.Common.Networks.Requests
             keys = StageRecordService.Instance.Get()
                 .Where(s => s.challengeNum > 0)
                 .Select(s => StageData.EncodeStageIdKey(s.treeId, s.stageNumber));
-        }
-
-        public override async UniTask<bool> Execute()
-        {
-            var allSuccess = true;
-            for (var i = 0 ; i < keys.Count() / 10 ; i++) {
-                allSuccess &= await remoteDatabaseService.DeleteDataAsync(keys.Skip(i * 10).Take(10));
-            }
-            return allSuccess;
         }
     }
 }

--- a/Assets/Project/Scripts/Common/Networks/Requests/DeleteAllStageRecordRequest.cs
+++ b/Assets/Project/Scripts/Common/Networks/Requests/DeleteAllStageRecordRequest.cs
@@ -10,8 +10,8 @@ namespace Treevel.Common.Networks.Requests
         {
             // 遊んだことがあるステージのみ削除
             keys = StageRecordService.Instance.Get()
-                .Where(s => s.challengeNum > 0)
-                .Select(s => StageData.EncodeStageIdKey(s.treeId, s.stageNumber));
+                .Where(stageRecord => stageRecord.challengeNum > 0)
+                .Select(stageRecord => StageData.EncodeStageIdKey(stageRecord.treeId, stageRecord.stageNumber));
         }
     }
 }

--- a/Assets/Project/Scripts/Common/Networks/Requests/DeleteAllStageRecordRequest.cs.meta
+++ b/Assets/Project/Scripts/Common/Networks/Requests/DeleteAllStageRecordRequest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b5aefd7d6a4b742c9b3cb9a0050d83e9
+timeCreated: 1617929851

--- a/Assets/Project/Scripts/Common/Networks/Requests/ServerRequestBase.cs
+++ b/Assets/Project/Scripts/Common/Networks/Requests/ServerRequestBase.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
+using System.Linq;
 using Cysharp.Threading.Tasks;
 using Treevel.Common.Networks.Database;
-using Treevel.Common.Utils;
 
 namespace Treevel.Common.Networks.Requests
 {
@@ -58,7 +58,12 @@ namespace Treevel.Common.Networks.Requests
 
         public override async UniTask<bool> Execute()
         {
-            return await remoteDatabaseService.DeleteDataAsync(keys);
+            var allSuccess = true;
+            // PlayFabの仕様上一回のリクエストにつき10個の値しか消せないので分けてリクエストを送る
+            for (var i = 0 ; i <= keys.Count() / 10 ; i++) {
+                allSuccess &= await remoteDatabaseService.DeleteDataAsync(keys.Skip(i * 10).Take(10));
+            }
+            return allSuccess;
         }
     }
 }

--- a/Assets/Project/Scripts/Common/Networks/Requests/ServerRequestBase.cs
+++ b/Assets/Project/Scripts/Common/Networks/Requests/ServerRequestBase.cs
@@ -51,4 +51,14 @@ namespace Treevel.Common.Networks.Requests
             return await remoteDatabaseService.UpdateDataAsync(key, data);
         }
     }
+
+    public abstract class DeleteServerRequestBase : ServerRequestBase<bool>
+    {
+        protected IEnumerable<string> keys;
+
+        public override async UniTask<bool> Execute()
+        {
+            return await remoteDatabaseService.DeleteDataAsync(keys);
+        }
+    }
 }

--- a/Assets/Project/Scripts/Common/Utils/PlayerPrefsUtility.cs
+++ b/Assets/Project/Scripts/Common/Utils/PlayerPrefsUtility.cs
@@ -182,5 +182,15 @@ namespace Treevel.Common.Utils
             var memoryStream = new MemoryStream(Convert.FromBase64String(str));
             return (T)binaryFormatter.Deserialize(memoryStream);
         }
+
+        /// <summary>
+        /// PlayerPrefsから複数キーを同時に削除する
+        /// </summary>
+        public static void DeleteKeys(IEnumerable<string> keys)
+        {
+            foreach (var key in keys) {
+                PlayerPrefs.DeleteKey(key);
+            }
+        }
     }
 }

--- a/Assets/Project/Scripts/Common/Utils/StageRecordService.cs
+++ b/Assets/Project/Scripts/Common/Utils/StageRecordService.cs
@@ -115,8 +115,18 @@ namespace Treevel.Common.Utils
                         });
                 }
             } else {
+                var stageIds = GameDataManager.GetAllStages().Select(data => data.StageId);
+                PlayerPrefsUtility.DeleteKeys(stageIds);
+
                 // 途中で失敗する可能性を考慮してリモートと同期を取る
                 await PreloadAllStageRecordsAsync();
+
+                // PlayerPrefsも同期する
+                foreach (var stageRecord in _cachedStageRecordDic.Values) {
+                    if (stageRecord.challengeNum > 0) {
+                        PlayerPrefsUtility.SetObject(StageData.EncodeStageIdKey(stageRecord.treeId, stageRecord.stageNumber), stageRecord);
+                    }
+                }
             }
         }
     }

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/Settings/ResetController.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/Settings/ResetController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Cysharp.Threading.Tasks;
 using Treevel.Common.Entities;
 using Treevel.Common.Managers;
 using Treevel.Common.Utils;
@@ -36,7 +37,7 @@ namespace Treevel.Modules.MenuSelectScene.Settings
             _dataResetSubject.OnNext(Unit.Default);
 
             // 全ステージをリセット
-            StageRecord.Reset();
+            StageRecordService.Instance.ResetAsync().Forget();
 
             // ステージ選択画面のブランチをリセット
             PlayerPrefs.DeleteKey(Constants.PlayerPrefsKeys.BRANCH_STATE);


### PR DESCRIPTION
### 対象イシュー
Close #890 

### 概要
ステージ記録のリセット機能を修正

### 詳細

#### 現実装になった経緯
PlayFabのデータを削除するために
`UpdateUserData.KeysToRemove`を利用しますが、`KeysToRemove` は一回10個キーしか入れられないという制限があるため、`DeleteAllStageRecordRequest.cs` では10個つずリクエストを送るように実装しました。

![image](https://user-images.githubusercontent.com/17778395/116277576-92991f00-a7c0-11eb-8cd4-ecfaae54e868.png)

#### 技術的な内容


### キャプチャ


### 動作確認方法
- [ ] 設定画面からリセット機能を使用し、正常にステージ記録がリセットされることを確認

### 参考 URL
