### PR TITLE
特定条件下でBGMが再生されない不具合修正

### DIFF
--- a/Assets/Project/Scripts/Common/Managers/SoundManager.cs
+++ b/Assets/Project/Scripts/Common/Managers/SoundManager.cs
@@ -230,6 +230,9 @@ namespace Treevel.Common.Managers
             // 実行中のタイマーを取り消し
             _loopVolumeController?.Dispose();
 
+            // Fade out タスクを止める
+            _fadeCancellationToken.Cancel();
+
             // BGM再生中であれば停止しておく
             if (_bgmPlayer.isPlaying) _bgmPlayer.Stop();
 


### PR DESCRIPTION
### 対象イシュー
Close #910 

### 概要
タイトル通り

### 詳細
StopBGMを呼び出した後2秒にBGMを止める処理がよばれるため、この2秒の間に PlayBGMを呼ぶと再生されたBGMがとめられてしまうので、再生する時点でキャンセルさせる処理を入れました。
```
        public void StopBGMAsync(float fadeOutTime = 2.0f)
        {
            FadeBGMVolumeAsync(_bgmPlayer.volume, 0, fadeOutTime).ContinueWith(() => {
                _bgmPlayer.Stop();
                ResetBGMVolume();
            });
        }
```

### 動作確認方法
- [x] #910 で書いた手順でバグが再現しないことを確認