### PR TITLE
Canvas配下のオブジェクトの配置方法を修正する

### DIFF
--- a/Assets/Project/Actors/UIs/GamePlayScene/TutorialWindow.prefab
+++ b/Assets/Project/Actors/UIs/GamePlayScene/TutorialWindow.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: 661024639250351558}
   - component: {fileID: 4373183528451975935}
   - component: {fileID: 6074595473572188508}
+  - component: {fileID: 5633787746816256352}
   m_Layer: 5
   m_Name: CloseButton
   m_TagString: Untagged
@@ -33,10 +34,10 @@ RectTransform:
   m_Father: {fileID: 8624659820823176700}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 1, y: 1}
-  m_AnchorMax: {x: 1, y: 1}
+  m_AnchorMin: {x: 1, y: 0.98}
+  m_AnchorMax: {x: 1, y: 1.02}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 64, y: 64}
+  m_SizeDelta: {x: 68.20801, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &661024639250351558
 CanvasRenderer:
@@ -90,6 +91,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -131,6 +133,20 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+--- !u!114 &5633787746816256352
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6003721642979162466}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_AspectMode: 2
+  m_AspectRatio: 1
 --- !u!1 &8624659819804652251
 GameObject:
   m_ObjectHideFlags: 0
@@ -168,7 +184,7 @@ RectTransform:
   m_AnchorMin: {x: 0.1, y: 0.1}
   m_AnchorMax: {x: 0.9, y: 0.9}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 47.34005, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8624659819804652249
 CanvasRenderer:

--- a/Assets/Project/Actors/UIs/MenuSelectScene/LevelSelect/LevelTree.prefab
+++ b/Assets/Project/Actors/UIs/MenuSelectScene/LevelSelect/LevelTree.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 5891168163236371066}
   - component: {fileID: -9161208834189306802}
   - component: {fileID: -2037017567522478634}
+  - component: {fileID: 3068888141515440203}
   m_Layer: 5
   m_Name: LevelTree
   m_TagString: Tree
@@ -37,7 +38,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 1, y: 1}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &7206146101052041129
 MonoBehaviour:
@@ -52,7 +53,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   treeId: 0
-  _levelName: 0
+  _seasonId: 0
   _material: {fileID: 2100000, guid: 9d74c72ba7f3b48f484c5c3de3672ecb, type: 2}
   _button: {fileID: 5891168163236371066}
 --- !u!114 &5891168163236371066
@@ -69,6 +70,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -148,3 +150,17 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!114 &3068888141515440203
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5235287849498325587}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_AspectMode: 2
+  m_AspectRatio: 1

--- a/Assets/Project/Actors/UIs/MenuSelectScene/LevelSelect/Road.prefab
+++ b/Assets/Project/Actors/UIs/MenuSelectScene/LevelSelect/Road.prefab
@@ -56,6 +56,8 @@ MonoBehaviour:
   secondControlPoint: {x: 0, y: 0}
   _middlePointNum: 0
   width: 0
+  Scale:
+    value: 1
   lineRenderer: {fileID: 3838137885523574259}
 --- !u!120 &3838137885523574259
 LineRenderer:
@@ -68,10 +70,12 @@ LineRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 0
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
   m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:

--- a/Assets/Project/Actors/UIs/MenuSelectScene/Record/ClearStageNum.prefab
+++ b/Assets/Project/Actors/UIs/MenuSelectScene/Record/ClearStageNum.prefab
@@ -747,13 +747,43 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_FontData.m_Alignment
-      value: 3
+      propertyPath: _indexStr
+      value: RecordClearStageNum
       objectReference: {fileID: 0}
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: _indexStr
-      value: RecordClearStageNum
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_FontData.m_Alignment
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -764,36 +794,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -809,56 +809,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.4
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.9
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.2
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 08bc31bccfd004d24846b057a089c860, type: 3}

--- a/Assets/Project/Actors/UIs/MenuSelectScene/Record/General/ClearStageGauge.png.meta
+++ b/Assets/Project/Actors/UIs/MenuSelectScene/Record/General/ClearStageGauge.png.meta
@@ -46,7 +46,7 @@ TextureImporter:
   spriteMeshType: 1
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 100
+  spritePixelsToUnits: 1
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
@@ -55,6 +55,8 @@ TextureImporter:
   textureType: 8
   textureShape: 1
   singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
   maxTextureSizeSet: 0
   compressionQualitySet: 0
   textureFormatSet: 0
@@ -63,6 +65,42 @@ TextureImporter:
   platformSettings:
   - serializedVersion: 3
     buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: iPhone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Android
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1

--- a/Assets/Project/Actors/UIs/MenuSelectScene/Record/General/ClearStageIndicator.png.meta
+++ b/Assets/Project/Actors/UIs/MenuSelectScene/Record/General/ClearStageIndicator.png.meta
@@ -46,7 +46,7 @@ TextureImporter:
   spriteMeshType: 1
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 100
+  spritePixelsToUnits: 1
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
@@ -55,6 +55,8 @@ TextureImporter:
   textureType: 8
   textureShape: 1
   singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
   maxTextureSizeSet: 0
   compressionQualitySet: 0
   textureFormatSet: 0
@@ -63,6 +65,42 @@ TextureImporter:
   platformSettings:
   - serializedVersion: 3
     buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: iPhone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Android
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1

--- a/Assets/Project/Actors/UIs/MenuSelectScene/Record/Individual/GraphPopup.prefab
+++ b/Assets/Project/Actors/UIs/MenuSelectScene/Record/Individual/GraphPopup.prefab
@@ -223,6 +223,18 @@ MonoBehaviour:
   m_EffectColor: {r: 1, g: 1, b: 1, a: 1}
   m_EffectDistance: {x: 5, y: 5}
   m_UseGraphicAlpha: 1
+--- !u!114 &4919366949468379830
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4760276496520202178}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb219b23cdf4b314f94a27bca3cc8012, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &3630860517936981000
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -237,6 +249,31 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -244,36 +281,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
@@ -289,56 +296,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.6
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
@@ -379,6 +336,31 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.55
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -386,36 +368,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
@@ -431,56 +383,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.9
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.9
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
@@ -531,42 +433,37 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.55
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
@@ -584,58 +481,14 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 08bc31bccfd004d24846b057a089c860, type: 3}
+--- !u!1 &4760276496520202178 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1664642187462754051, guid: 08bc31bccfd004d24846b057a089c860,
+    type: 3}
+  m_PrefabInstance: {fileID: 6131115977345267905}
+  m_PrefabAsset: {fileID: 0}
 --- !u!224 &2464404292220582778 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,

--- a/Assets/Project/Actors/UIs/MenuSelectScene/Record/Individual/IndividualRecord.prefab
+++ b/Assets/Project/Actors/UIs/MenuSelectScene/Record/Individual/IndividualRecord.prefab
@@ -53,6 +53,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -152,6 +153,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -433,6 +435,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -705,6 +708,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -913,6 +917,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -1752,6 +1757,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -1892,6 +1898,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -2413,6 +2420,51 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.58
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.525
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -2425,6 +2477,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
@@ -2443,13 +2500,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
-      propertyPath: m_RootOrder
-      value: 5
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
@@ -2465,56 +2522,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.525
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.58
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 7851764554404753390, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
@@ -2554,6 +2561,51 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.265
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.21
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -2566,6 +2618,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
@@ -2584,13 +2641,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
-      propertyPath: m_RootOrder
-      value: 2
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
@@ -2606,56 +2663,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.21
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.265
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba, type: 3}
@@ -2685,6 +2692,66 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -2697,6 +2764,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
@@ -2715,12 +2787,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_RootOrder
+      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
@@ -2738,71 +2810,6 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.2
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.6
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.8
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_LocalScale.z
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
       propertyPath: m_Text
@@ -2810,7 +2817,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_Color.r
+      propertyPath: m_Color.b
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
@@ -2820,7 +2827,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_Color.b
+      propertyPath: m_Color.r
       value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
@@ -2867,7 +2874,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_Color.r
+      propertyPath: m_Color.b
       value: 0.9339623
       objectReference: {fileID: 0}
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
@@ -2877,8 +2884,33 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_Color.b
+      propertyPath: m_Color.r
       value: 0.9339623
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.25
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -2889,36 +2921,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -2934,56 +2936,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.25
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.75
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 08bc31bccfd004d24846b057a089c860, type: 3}
@@ -3018,6 +2970,51 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.315
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -3030,6 +3027,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
@@ -3048,13 +3050,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
-      propertyPath: m_RootOrder
-      value: 3
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
@@ -3070,56 +3072,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.315
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.37
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 7851764554404753390, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
@@ -3154,6 +3106,51 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.16
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.05
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -3166,6 +3163,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
@@ -3184,12 +3186,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_RootOrder
+      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
@@ -3207,74 +3209,14 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.2
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.05
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.8
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.16
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
     - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_FontData.m_BestFit
+      propertyPath: m_Text
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_FontData.m_FontSize
-      value: 50
-      objectReference: {fileID: 0}
-    - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_FontData.m_MinSize
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_Color.r
+      propertyPath: m_Color.b
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
@@ -3284,7 +3226,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_Color.b
+      propertyPath: m_Color.r
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
@@ -3294,8 +3236,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_Text
+      propertyPath: m_FontData.m_BestFit
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_FontData.m_MinSize
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_FontData.m_FontSize
+      value: 50
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: bef1ce286d5014a08b1dda0760b28ee2, type: 3}
@@ -3319,6 +3271,51 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.89
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -3331,6 +3328,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
@@ -3349,13 +3351,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_RootOrder
-      value: 3
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
@@ -3372,74 +3374,14 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+    - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.2
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.89
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.8
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
+      propertyPath: m_Text
+      value: 30
       objectReference: {fileID: 0}
     - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_FontData.m_BestFit
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_FontData.m_FontSize
-      value: 50
-      objectReference: {fileID: 0}
-    - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_FontData.m_MinSize
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_Color.r
+      propertyPath: m_Color.b
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
@@ -3449,7 +3391,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_Color.b
+      propertyPath: m_Color.r
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
@@ -3459,8 +3401,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_Text
-      value: 30
+      propertyPath: m_FontData.m_BestFit
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_FontData.m_MinSize
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_FontData.m_FontSize
+      value: 50
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: bef1ce286d5014a08b1dda0760b28ee2, type: 3}
@@ -3496,6 +3448,51 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.44
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.33
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -3508,6 +3505,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
@@ -3526,13 +3528,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_RootOrder
-      value: 1
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
@@ -3549,74 +3551,14 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+    - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.2
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.33
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.8
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.44
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
+      propertyPath: m_Text
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_FontData.m_BestFit
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_FontData.m_FontSize
-      value: 50
-      objectReference: {fileID: 0}
-    - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_FontData.m_MinSize
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_Color.r
+      propertyPath: m_Color.b
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
@@ -3626,7 +3568,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_Color.b
+      propertyPath: m_Color.r
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
@@ -3636,8 +3578,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_Text
-      value: 10
+      propertyPath: m_FontData.m_BestFit
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_FontData.m_MinSize
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_FontData.m_FontSize
+      value: 50
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: bef1ce286d5014a08b1dda0760b28ee2, type: 3}
@@ -3678,6 +3630,51 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.685
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.63
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -3690,6 +3687,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
@@ -3708,13 +3710,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
-      propertyPath: m_RootOrder
-      value: 6
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
@@ -3730,56 +3732,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.63
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.685
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 7851764554404753390, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
@@ -3819,6 +3771,51 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.16
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.105
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -3831,6 +3828,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
@@ -3849,13 +3851,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
-      propertyPath: m_RootOrder
-      value: 1
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
@@ -3871,56 +3873,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.105
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.16
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 7851764554404753390, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
@@ -3965,12 +3917,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_FontData.m_Alignment
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Color.r
+      propertyPath: m_Color.b
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
@@ -3980,8 +3927,58 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_Color.b
+      propertyPath: m_Color.r
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_FontData.m_Alignment
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.975
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.765
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.025
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.735
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -4000,6 +3997,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
@@ -4015,13 +4017,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_RootOrder
-      value: 2
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -4037,56 +4039,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.025
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.735
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.975
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.765
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 08bc31bccfd004d24846b057a089c860, type: 3}
@@ -4116,18 +4068,63 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3935634172707820130, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
-      propertyPath: m_AnchorMin.x
-      value: -0.5
+      propertyPath: m_AnchorMax.x
+      value: 1.5
       objectReference: {fileID: 0}
     - target: {fileID: 3935634172707820130, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 1.5
+      propertyPath: m_AnchorMin.x
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511870, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
       propertyPath: m_Name
       value: BarGraph10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.945
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
@@ -4146,6 +4143,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -4161,13 +4163,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
-      propertyPath: m_RootOrder
-      value: 9
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
@@ -4183,56 +4185,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.945
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 7851764554404753390, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
@@ -4277,7 +4229,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_Color.r
+      propertyPath: m_Color.b
       value: 0.9339623
       objectReference: {fileID: 0}
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
@@ -4287,8 +4239,33 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_Color.b
+      propertyPath: m_Color.r
       value: 0.9339623
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.25
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -4299,36 +4276,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -4344,56 +4291,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.25
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.75
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 08bc31bccfd004d24846b057a089c860, type: 3}
@@ -4428,6 +4325,51 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.475
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.42
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -4440,6 +4382,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
@@ -4458,13 +4405,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
-      propertyPath: m_RootOrder
-      value: 4
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
@@ -4480,56 +4427,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.42
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.475
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 7851764554404753390, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
@@ -4564,6 +4461,51 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.72
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.61
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -4576,6 +4518,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
@@ -4594,13 +4541,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_RootOrder
-      value: 2
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
@@ -4617,74 +4564,14 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+    - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.2
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.61
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.8
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.72
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
+      propertyPath: m_Text
+      value: 20
       objectReference: {fileID: 0}
     - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_FontData.m_BestFit
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_FontData.m_FontSize
-      value: 50
-      objectReference: {fileID: 0}
-    - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_FontData.m_MinSize
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_Color.r
+      propertyPath: m_Color.b
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
@@ -4694,7 +4581,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_Color.b
+      propertyPath: m_Color.r
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
@@ -4704,8 +4591,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_Text
-      value: 20
+      propertyPath: m_FontData.m_BestFit
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_FontData.m_MinSize
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_FontData.m_FontSize
+      value: 50
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: bef1ce286d5014a08b1dda0760b28ee2, type: 3}
@@ -4746,6 +4643,31 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2196075647019294311, guid: a605ec9ee614346558f5d02cf0196b32,
         type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2196075647019294311, guid: a605ec9ee614346558f5d02cf0196b32,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2196075647019294311, guid: a605ec9ee614346558f5d02cf0196b32,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2196075647019294311, guid: a605ec9ee614346558f5d02cf0196b32,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2196075647019294311, guid: a605ec9ee614346558f5d02cf0196b32,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.78
+      objectReference: {fileID: 0}
+    - target: {fileID: 2196075647019294311, guid: a605ec9ee614346558f5d02cf0196b32,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -4753,36 +4675,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2196075647019294311, guid: a605ec9ee614346558f5d02cf0196b32,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2196075647019294311, guid: a605ec9ee614346558f5d02cf0196b32,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2196075647019294311, guid: a605ec9ee614346558f5d02cf0196b32,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2196075647019294311, guid: a605ec9ee614346558f5d02cf0196b32,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2196075647019294311, guid: a605ec9ee614346558f5d02cf0196b32,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2196075647019294311, guid: a605ec9ee614346558f5d02cf0196b32,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2196075647019294311, guid: a605ec9ee614346558f5d02cf0196b32,
         type: 3}
@@ -4798,56 +4690,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2196075647019294311, guid: a605ec9ee614346558f5d02cf0196b32,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2196075647019294311, guid: a605ec9ee614346558f5d02cf0196b32,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2196075647019294311, guid: a605ec9ee614346558f5d02cf0196b32,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2196075647019294311, guid: a605ec9ee614346558f5d02cf0196b32,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2196075647019294311, guid: a605ec9ee614346558f5d02cf0196b32,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2196075647019294311, guid: a605ec9ee614346558f5d02cf0196b32,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.78
-      objectReference: {fileID: 0}
-    - target: {fileID: 2196075647019294311, guid: a605ec9ee614346558f5d02cf0196b32,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2196075647019294311, guid: a605ec9ee614346558f5d02cf0196b32,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2196075647019294311, guid: a605ec9ee614346558f5d02cf0196b32,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 2196075647019294311, guid: a605ec9ee614346558f5d02cf0196b32,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a605ec9ee614346558f5d02cf0196b32, type: 3}
@@ -4893,7 +4735,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_Color.r
+      propertyPath: m_Color.b
       value: 0.9339623
       objectReference: {fileID: 0}
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
@@ -4903,8 +4745,33 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_Color.b
+      propertyPath: m_Color.r
       value: 0.9339623
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.25
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -4915,36 +4782,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -4960,56 +4797,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.25
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.75
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 08bc31bccfd004d24846b057a089c860, type: 3}
@@ -5049,7 +4836,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_Color.r
+      propertyPath: m_Color.b
       value: 0.9339623
       objectReference: {fileID: 0}
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
@@ -5059,8 +4846,33 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_Color.b
+      propertyPath: m_Color.r
       value: 0.9339623
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.25
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -5071,36 +4883,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -5116,56 +4898,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.25
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.75
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 08bc31bccfd004d24846b057a089c860, type: 3}
@@ -5200,6 +4932,51 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.79
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.735
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -5212,6 +4989,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
@@ -5230,13 +5012,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
-      propertyPath: m_RootOrder
-      value: 7
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
@@ -5252,56 +5034,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.735
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.79
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 7851764554404753390, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
@@ -5341,6 +5073,51 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.895
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.84
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -5353,6 +5130,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
@@ -5371,13 +5153,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
-      propertyPath: m_RootOrder
-      value: 8
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
@@ -5393,56 +5175,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.84
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.895
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 7851764554404753390, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
@@ -5477,42 +5209,37 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
@@ -5529,56 +5256,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.2
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.9
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.8
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
@@ -5607,6 +5284,51 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.95
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.98
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.02
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -5619,6 +5341,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
@@ -5637,13 +5364,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_RootOrder
-      value: 2
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
@@ -5659,56 +5386,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.25
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.02
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.95
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.98
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: bef1ce286d5014a08b1dda0760b28ee2, type: 3}
@@ -5744,6 +5421,51 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.055
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -5756,6 +5478,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
@@ -5774,12 +5501,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
         type: 3}
-      propertyPath: m_RootOrder
+      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
@@ -5796,56 +5523,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.055
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7555620190463511871, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 48a0a1a4c35174bd59cdd96c8b41d0ba, type: 3}
@@ -5870,6 +5547,51 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 3426876578049877271, guid: 1f44e7ebb5a604dbbbe8d7e3e7dd8202,
         type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3426876578049877271, guid: 1f44e7ebb5a604dbbbe8d7e3e7dd8202,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3426876578049877271, guid: 1f44e7ebb5a604dbbbe8d7e3e7dd8202,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3426876578049877271, guid: 1f44e7ebb5a604dbbbe8d7e3e7dd8202,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3426876578049877271, guid: 1f44e7ebb5a604dbbbe8d7e3e7dd8202,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3426876578049877271, guid: 1f44e7ebb5a604dbbbe8d7e3e7dd8202,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3426876578049877271, guid: 1f44e7ebb5a604dbbbe8d7e3e7dd8202,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3426876578049877271, guid: 1f44e7ebb5a604dbbbe8d7e3e7dd8202,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 3426876578049877271, guid: 1f44e7ebb5a604dbbbe8d7e3e7dd8202,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 300
+      objectReference: {fileID: 0}
+    - target: {fileID: 3426876578049877271, guid: 1f44e7ebb5a604dbbbe8d7e3e7dd8202,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -5882,6 +5604,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3426876578049877271, guid: 1f44e7ebb5a604dbbbe8d7e3e7dd8202,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3426876578049877271, guid: 1f44e7ebb5a604dbbbe8d7e3e7dd8202,
         type: 3}
@@ -5900,13 +5627,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3426876578049877271, guid: 1f44e7ebb5a604dbbbe8d7e3e7dd8202,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3426876578049877271, guid: 1f44e7ebb5a604dbbbe8d7e3e7dd8202,
         type: 3}
-      propertyPath: m_RootOrder
-      value: 6
+      propertyPath: m_AnchoredPosition.y
+      value: -300
       objectReference: {fileID: 0}
     - target: {fileID: 3426876578049877271, guid: 1f44e7ebb5a604dbbbe8d7e3e7dd8202,
         type: 3}
@@ -5922,56 +5649,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3426876578049877271, guid: 1f44e7ebb5a604dbbbe8d7e3e7dd8202,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3426876578049877271, guid: 1f44e7ebb5a604dbbbe8d7e3e7dd8202,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -300
-      objectReference: {fileID: 0}
-    - target: {fileID: 3426876578049877271, guid: 1f44e7ebb5a604dbbbe8d7e3e7dd8202,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 600
-      objectReference: {fileID: 0}
-    - target: {fileID: 3426876578049877271, guid: 1f44e7ebb5a604dbbbe8d7e3e7dd8202,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 300
-      objectReference: {fileID: 0}
-    - target: {fileID: 3426876578049877271, guid: 1f44e7ebb5a604dbbbe8d7e3e7dd8202,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3426876578049877271, guid: 1f44e7ebb5a604dbbbe8d7e3e7dd8202,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3426876578049877271, guid: 1f44e7ebb5a604dbbbe8d7e3e7dd8202,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3426876578049877271, guid: 1f44e7ebb5a604dbbbe8d7e3e7dd8202,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3426876578049877271, guid: 1f44e7ebb5a604dbbbe8d7e3e7dd8202,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3426876578049877271, guid: 1f44e7ebb5a604dbbbe8d7e3e7dd8202,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3833596106734212813, guid: 1f44e7ebb5a604dbbbe8d7e3e7dd8202,
         type: 3}

--- a/Assets/Project/Actors/UIs/StageSelectScene/Button/BackButton.prefab
+++ b/Assets/Project/Actors/UIs/StageSelectScene/Button/BackButton.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: 3312996573423678124}
   - component: {fileID: 3312996573423678125}
   - component: {fileID: 3312996573423678126}
+  - component: {fileID: 3731367334575451823}
   m_Layer: 5
   m_Name: BackButton
   m_TagString: Untagged
@@ -33,10 +34,10 @@ RectTransform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.11, y: 0.89}
-  m_AnchorMax: {x: 0.11, y: 0.89}
+  m_AnchorMin: {x: 0.11, y: 0.85}
+  m_AnchorMax: {x: 0.11, y: 0.93}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 200, y: 200}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &3312996573423678124
 CanvasRenderer:
@@ -61,6 +62,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -89,6 +91,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -120,6 +123,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 0}
+        m_TargetAssemblyTypeName: 
         m_MethodName: BackButtonDown
         m_Mode: 1
         m_Arguments:
@@ -130,3 +134,17 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+--- !u!114 &3731367334575451823
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3312996573423678128}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_AspectMode: 2
+  m_AspectRatio: 1

--- a/Assets/Project/Actors/UIs/StageSelectScene/OverviewPopup/OverviewPopup.prefab
+++ b/Assets/Project/Actors/UIs/StageSelectScene/OverviewPopup/OverviewPopup.prefab
@@ -90,6 +90,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -141,8 +142,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8117246199234384618}
   - component: {fileID: 8744144807903586594}
-  - component: {fileID: 1780978162377829471}
-  - component: {fileID: 1693733533331841365}
+  - component: {fileID: 9132518810833793751}
   m_Layer: 5
   m_Name: PreviewWindow
   m_TagString: Untagged
@@ -165,10 +165,10 @@ RectTransform:
   m_Father: {fileID: 5186227659161571785}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.035, y: 0.37}
-  m_AnchorMax: {x: 0.5, y: 0.97}
+  m_AnchorMin: {x: 0.03, y: 0.4}
+  m_AnchorMax: {x: 0.03, y: 0.95}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 482.3279, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &8744144807903586594
 CanvasRenderer:
@@ -178,37 +178,7 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 553552984877971758}
   m_CullTransparentMesh: 0
---- !u!114 &1780978162377829471
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 553552984877971758}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0.392}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!114 &1693733533331841365
+--- !u!114 &9132518810833793751
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -220,7 +190,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_AspectMode: 1
+  m_AspectMode: 2
   m_AspectRatio: 0.6
 --- !u!1 &905809797969315720
 GameObject:
@@ -453,6 +423,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -1063,6 +1034,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -1220,38 +1192,23 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4776947057259749833, guid: e09ad2effd55946168e9f5e6b9fd36e2,
         type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4776947057259749833, guid: e09ad2effd55946168e9f5e6b9fd36e2,
-        type: 3}
       propertyPath: m_AnchorMin.y
       value: 0.8
       objectReference: {fileID: 0}
     - target: {fileID: 4776947057259749833, guid: e09ad2effd55946168e9f5e6b9fd36e2,
         type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4784787348686252064, guid: e09ad2effd55946168e9f5e6b9fd36e2,
-        type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4784787348686252064, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+    - target: {fileID: 4776947057259749833, guid: e09ad2effd55946168e9f5e6b9fd36e2,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4784787348686252064, guid: e09ad2effd55946168e9f5e6b9fd36e2,
         type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.2
-      objectReference: {fileID: 0}
-    - target: {fileID: 4784787348686252064, guid: e09ad2effd55946168e9f5e6b9fd36e2,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
+      propertyPath: m_AnchorMax.x
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4784787348686252064, guid: e09ad2effd55946168e9f5e6b9fd36e2,
         type: 3}
@@ -1265,13 +1222,28 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4784787348686252064, guid: e09ad2effd55946168e9f5e6b9fd36e2,
         type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4784787348686252064, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4784787348686252064, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4784787348686252064, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4784787348686252064, guid: e09ad2effd55946168e9f5e6b9fd36e2,
         type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 1
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6199307567626244220, guid: e09ad2effd55946168e9f5e6b9fd36e2,
         type: 3}
@@ -1282,6 +1254,51 @@ PrefabInstance:
         type: 3}
       propertyPath: m_IsActive
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.67
+      objectReference: {fileID: 0}
+    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
         type: 3}
@@ -1300,6 +1317,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -1315,13 +1337,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
         type: 3}
-      propertyPath: m_RootOrder
-      value: 2
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
         type: 3}
@@ -1338,60 +1360,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.67
-      objectReference: {fileID: 0}
-    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
     - target: {fileID: 9218009246373953127, guid: e09ad2effd55946168e9f5e6b9fd36e2,
         type: 3}
-      propertyPath: m_FontData.m_FontSize
-      value: 40
+      propertyPath: m_RaycastTarget
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 9218009246373953127, guid: e09ad2effd55946168e9f5e6b9fd36e2,
         type: 3}
@@ -1400,8 +1372,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 9218009246373953127, guid: e09ad2effd55946168e9f5e6b9fd36e2,
         type: 3}
-      propertyPath: m_RaycastTarget
-      value: 0
+      propertyPath: m_FontData.m_FontSize
+      value: 40
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e09ad2effd55946168e9f5e6b9fd36e2, type: 3}
@@ -1420,37 +1392,22 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4776947057259749833, guid: e09ad2effd55946168e9f5e6b9fd36e2,
         type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 4776947057259749833, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 0.8
       objectReference: {fileID: 0}
     - target: {fileID: 4776947057259749833, guid: e09ad2effd55946168e9f5e6b9fd36e2,
         type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4776947057259749833, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+        type: 3}
       propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4776947057259749833, guid: e09ad2effd55946168e9f5e6b9fd36e2,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.8
-      objectReference: {fileID: 0}
-    - target: {fileID: 4776947057259749833, guid: e09ad2effd55946168e9f5e6b9fd36e2,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4784787348686252064, guid: e09ad2effd55946168e9f5e6b9fd36e2,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4784787348686252064, guid: e09ad2effd55946168e9f5e6b9fd36e2,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4784787348686252064, guid: e09ad2effd55946168e9f5e6b9fd36e2,
-        type: 3}
-      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4784787348686252064, guid: e09ad2effd55946168e9f5e6b9fd36e2,
@@ -1465,7 +1422,17 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4784787348686252064, guid: e09ad2effd55946168e9f5e6b9fd36e2,
         type: 3}
-      propertyPath: m_AnchoredPosition.y
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4784787348686252064, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4784787348686252064, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+        type: 3}
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4784787348686252064, guid: e09ad2effd55946168e9f5e6b9fd36e2,
@@ -1475,8 +1442,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4784787348686252064, guid: e09ad2effd55946168e9f5e6b9fd36e2,
         type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.2
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4784787348686252064, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6199307567626244220, guid: e09ad2effd55946168e9f5e6b9fd36e2,
         type: 3}
@@ -1487,6 +1459,51 @@ PrefabInstance:
         type: 3}
       propertyPath: m_IsActive
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.67
+      objectReference: {fileID: 0}
+    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.33
+      objectReference: {fileID: 0}
+    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
         type: 3}
@@ -1505,6 +1522,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -1520,13 +1542,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
         type: 3}
-      propertyPath: m_RootOrder
-      value: 1
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
         type: 3}
@@ -1542,56 +1564,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.33
-      objectReference: {fileID: 0}
-    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.67
-      objectReference: {fileID: 0}
-    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 9218009246373953127, guid: e09ad2effd55946168e9f5e6b9fd36e2,
         type: 3}
@@ -1635,7 +1607,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_Color.r
+      propertyPath: _indexStr
+      value: StageSelectOverviewSuccessPercentage
+      objectReference: {fileID: 0}
+    - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_Color.b
       value: 0.3584906
       objectReference: {fileID: 0}
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
@@ -1645,18 +1622,58 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_Color.b
+      propertyPath: m_Color.r
       value: 0.3584906
-      objectReference: {fileID: 0}
-    - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: _indexStr
-      value: StageSelectOverviewSuccessPercentage
       objectReference: {fileID: 0}
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
       propertyPath: m_FontData.m_VerticalOverflow
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.97
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.95
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.03
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -1675,6 +1692,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -1690,12 +1712,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_RootOrder
+      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
@@ -1713,67 +1735,17 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.03
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.6
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.97
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.95
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 1
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 08bc31bccfd004d24846b057a089c860, type: 3}
---- !u!224 &8809982008358625778 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-    type: 3}
-  m_PrefabInstance: {fileID: 965490159706432073}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1909494427684396362 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1664642187462754051, guid: 08bc31bccfd004d24846b057a089c860,
+    type: 3}
+  m_PrefabInstance: {fileID: 965490159706432073}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &8809982008358625778 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
     type: 3}
   m_PrefabInstance: {fileID: 965490159706432073}
   m_PrefabAsset: {fileID: 0}
@@ -1791,6 +1763,51 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -1803,6 +1820,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
@@ -1821,13 +1843,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_RootOrder
-      value: 1
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
@@ -1843,56 +1865,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.2
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.2
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.8
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.8
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
@@ -1931,13 +1903,58 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_FontData.m_MaxSize
-      value: 100
+      propertyPath: m_Enabled
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_Enabled
+      propertyPath: m_FontData.m_MaxSize
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMax.y
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -1956,6 +1973,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
@@ -1971,12 +1993,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_RootOrder
+      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
@@ -1993,56 +2015,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.9
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 08bc31bccfd004d24846b057a089c860, type: 3}
@@ -2072,6 +2044,51 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.97
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.03
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.05
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -2084,6 +2101,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
@@ -2102,13 +2124,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_RootOrder
-      value: 1
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
@@ -2125,59 +2147,14 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+    - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.03
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.05
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.97
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.6
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
+      propertyPath: m_Text
+      value: 99:99'60
       objectReference: {fileID: 0}
     - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_Color.r
+      propertyPath: m_Color.b
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
@@ -2187,13 +2164,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_Color.b
+      propertyPath: m_Color.r
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_Text
-      value: 99:99'60
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: bef1ce286d5014a08b1dda0760b28ee2, type: 3}
@@ -2222,7 +2194,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_Color.r
+      propertyPath: _indexStr
+      value: StageSelectOverviewShortestClearTime
+      objectReference: {fileID: 0}
+    - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_Color.b
       value: 0.3584906
       objectReference: {fileID: 0}
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
@@ -2232,13 +2209,53 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_Color.b
+      propertyPath: m_Color.r
       value: 0.3584906
       objectReference: {fileID: 0}
-    - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: _indexStr
-      value: StageSelectOverviewShortestClearTime
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.97
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.95
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.03
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -2257,6 +2274,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -2272,12 +2294,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_RootOrder
+      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
@@ -2294,56 +2316,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.03
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.6
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.97
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.95
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 08bc31bccfd004d24846b057a089c860, type: 3}
@@ -2373,6 +2345,51 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -2385,6 +2402,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
@@ -2403,13 +2425,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_RootOrder
-      value: 1
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
@@ -2426,59 +2448,14 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+    - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.6
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0
+      propertyPath: m_Text
+      value: 100%
       objectReference: {fileID: 0}
     - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_Color.r
+      propertyPath: m_Color.b
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
@@ -2488,13 +2465,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_Color.b
+      propertyPath: m_Color.r
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_Text
-      value: 100%
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: bef1ce286d5014a08b1dda0760b28ee2, type: 3}
@@ -2528,13 +2500,58 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_FontData.m_MaxSize
-      value: 100
+      propertyPath: m_Enabled
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_Enabled
+      propertyPath: m_FontData.m_MaxSize
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMax.y
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -2553,6 +2570,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
@@ -2568,12 +2590,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_RootOrder
+      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
@@ -2590,56 +2612,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.9
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 08bc31bccfd004d24846b057a089c860, type: 3}
@@ -2669,33 +2641,23 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4776947057259749833, guid: e09ad2effd55946168e9f5e6b9fd36e2,
         type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4776947057259749833, guid: e09ad2effd55946168e9f5e6b9fd36e2,
-        type: 3}
       propertyPath: m_AnchorMin.y
       value: 0.8
       objectReference: {fileID: 0}
     - target: {fileID: 4776947057259749833, guid: e09ad2effd55946168e9f5e6b9fd36e2,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4784787348686252064, guid: e09ad2effd55946168e9f5e6b9fd36e2,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.2
-      objectReference: {fileID: 0}
-    - target: {fileID: 4784787348686252064, guid: e09ad2effd55946168e9f5e6b9fd36e2,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4784787348686252064, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+    - target: {fileID: 4776947057259749833, guid: e09ad2effd55946168e9f5e6b9fd36e2,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4784787348686252064, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4784787348686252064, guid: e09ad2effd55946168e9f5e6b9fd36e2,
         type: 3}
@@ -2709,8 +2671,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4784787348686252064, guid: e09ad2effd55946168e9f5e6b9fd36e2,
         type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
+      propertyPath: m_AnchorMin.y
+      value: 0.2
       objectReference: {fileID: 0}
     - target: {fileID: 4784787348686252064, guid: e09ad2effd55946168e9f5e6b9fd36e2,
         type: 3}
@@ -2719,8 +2681,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4784787348686252064, guid: e09ad2effd55946168e9f5e6b9fd36e2,
         type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 1
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4784787348686252064, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4784787348686252064, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6199307567626244220, guid: e09ad2effd55946168e9f5e6b9fd36e2,
         type: 3}
@@ -2731,6 +2703,51 @@ PrefabInstance:
         type: 3}
       propertyPath: m_IsActive
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.33
+      objectReference: {fileID: 0}
+    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
         type: 3}
@@ -2749,6 +2766,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -2764,12 +2786,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
         type: 3}
-      propertyPath: m_RootOrder
+      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
@@ -2787,59 +2809,14 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
+    - target: {fileID: 9218009246373953127, guid: e09ad2effd55946168e9f5e6b9fd36e2,
         type: 3}
-      propertyPath: m_AnchoredPosition.x
+      propertyPath: m_RaycastTarget
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.33
-      objectReference: {fileID: 0}
-    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6221122847775854018, guid: e09ad2effd55946168e9f5e6b9fd36e2,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 9218009246373953127, guid: e09ad2effd55946168e9f5e6b9fd36e2,
         type: 3}
-      propertyPath: m_FontData.m_FontSize
+      propertyPath: m_FontData.m_MaxSize
       value: 40
       objectReference: {fileID: 0}
     - target: {fileID: 9218009246373953127, guid: e09ad2effd55946168e9f5e6b9fd36e2,
@@ -2849,13 +2826,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 9218009246373953127, guid: e09ad2effd55946168e9f5e6b9fd36e2,
         type: 3}
-      propertyPath: m_FontData.m_MaxSize
+      propertyPath: m_FontData.m_FontSize
       value: 40
-      objectReference: {fileID: 0}
-    - target: {fileID: 9218009246373953127, guid: e09ad2effd55946168e9f5e6b9fd36e2,
-        type: 3}
-      propertyPath: m_RaycastTarget
-      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e09ad2effd55946168e9f5e6b9fd36e2, type: 3}

--- a/Assets/Project/Actors/UIs/StageSelectScene/TreeCanvas/Stage.prefab
+++ b/Assets/Project/Actors/UIs/StageSelectScene/TreeCanvas/Stage.prefab
@@ -37,10 +37,10 @@ RectTransform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0.5, y: 0.47}
+  m_AnchorMax: {x: 0.5, y: 0.53}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 150, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4716757183531113043
 CanvasRenderer:
@@ -94,6 +94,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -147,7 +148,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_AspectMode: 1
+  m_AspectMode: 2
   m_AspectRatio: 1
 --- !u!114 &-4298890105320246028
 MonoBehaviour:
@@ -176,6 +177,7 @@ GameObject:
   - component: {fileID: 3500068229682574767}
   - component: {fileID: 1590324510496380829}
   - component: {fileID: 4638716436415458539}
+  - component: {fileID: 8684866445502281975}
   m_Layer: 5
   m_Name: Lock
   m_TagString: Untagged
@@ -197,10 +199,10 @@ RectTransform:
   m_Father: {fileID: 4716757183531113070}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 1}
-  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchorMin: {x: 0.5, y: 0.8}
+  m_AnchorMax: {x: 0.5, y: 1.48}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1590324510496380829
 CanvasRenderer:
@@ -240,6 +242,20 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!114 &8684866445502281975
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6372067160872805139}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_AspectMode: 2
+  m_AspectRatio: 1
 --- !u!1001 &3023088688763797386
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -251,6 +267,51 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: Base Text
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
@@ -269,6 +330,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -284,12 +350,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_RootOrder
+      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
@@ -306,56 +372,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 9178724915984365835, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}

--- a/Assets/Project/Actors/UIs/StageSelectScene/TreeCanvas/StageTree.prefab
+++ b/Assets/Project/Actors/UIs/StageSelectScene/TreeCanvas/StageTree.prefab
@@ -340,12 +340,12 @@ PrefabInstance:
     - target: {fileID: 2850028561387380508, guid: 995502db3c4e3402e8a8e9a9e999c831,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 2.406
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 2850028561387380508, guid: 995502db3c4e3402e8a8e9a9e999c831,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
-      value: 2.406
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 4570591737211165032, guid: 995502db3c4e3402e8a8e9a9e999c831,
         type: 3}
@@ -615,12 +615,12 @@ PrefabInstance:
     - target: {fileID: 2850028561387380508, guid: 995502db3c4e3402e8a8e9a9e999c831,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 2.406
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 2850028561387380508, guid: 995502db3c4e3402e8a8e9a9e999c831,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
-      value: 2.406
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 4570591737211165032, guid: 995502db3c4e3402e8a8e9a9e999c831,
         type: 3}
@@ -755,12 +755,12 @@ PrefabInstance:
     - target: {fileID: 2850028561387380508, guid: 995502db3c4e3402e8a8e9a9e999c831,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 2.406
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 2850028561387380508, guid: 995502db3c4e3402e8a8e9a9e999c831,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
-      value: 2.406
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 4570591737211165032, guid: 995502db3c4e3402e8a8e9a9e999c831,
         type: 3}
@@ -895,12 +895,12 @@ PrefabInstance:
     - target: {fileID: 2850028561387380508, guid: 995502db3c4e3402e8a8e9a9e999c831,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 2.406
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 2850028561387380508, guid: 995502db3c4e3402e8a8e9a9e999c831,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
-      value: 2.406
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 4570591737211165032, guid: 995502db3c4e3402e8a8e9a9e999c831,
         type: 3}
@@ -932,15 +932,10 @@ PrefabInstance:
       propertyPath: stageNumber
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
+    - target: {fileID: 3500068229682574767, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
+      propertyPath: m_SizeDelta.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
@@ -955,7 +950,7 @@ PrefabInstance:
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0.74
+      value: 0.77
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
@@ -965,16 +960,11 @@ PrefabInstance:
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0.74
+      value: 0.71
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 150
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
@@ -985,41 +975,6 @@ PrefabInstance:
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
@@ -1072,15 +1027,10 @@ PrefabInstance:
       propertyPath: stageNumber
       value: 5
       objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
+    - target: {fileID: 3500068229682574767, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
+      propertyPath: m_SizeDelta.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
@@ -1095,7 +1045,7 @@ PrefabInstance:
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0.55
+      value: 0.58
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
@@ -1105,16 +1055,11 @@ PrefabInstance:
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0.55
+      value: 0.52
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 150
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
@@ -1125,41 +1070,6 @@ PrefabInstance:
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
@@ -1217,15 +1127,10 @@ PrefabInstance:
       propertyPath: stageNumber
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
+    - target: {fileID: 3500068229682574767, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
+      propertyPath: m_SizeDelta.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
@@ -1234,32 +1139,17 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.51
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0.2
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.51
+      value: 0.23
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0.2
+      value: 0.17
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 150
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
@@ -1270,41 +1160,6 @@ PrefabInstance:
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
@@ -1357,15 +1212,10 @@ PrefabInstance:
       propertyPath: stageNumber
       value: 6
       objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
+    - target: {fileID: 3500068229682574767, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
+      propertyPath: m_SizeDelta.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
@@ -1380,7 +1230,7 @@ PrefabInstance:
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0.65
+      value: 0.68
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
@@ -1390,16 +1240,11 @@ PrefabInstance:
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0.65
+      value: 0.62
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 150
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
@@ -1410,41 +1255,6 @@ PrefabInstance:
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
@@ -1497,15 +1307,10 @@ PrefabInstance:
       propertyPath: stageNumber
       value: 3
       objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
+    - target: {fileID: 3500068229682574767, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
+      propertyPath: m_SizeDelta.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
@@ -1520,7 +1325,7 @@ PrefabInstance:
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0.5
+      value: 0.53
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
@@ -1530,16 +1335,11 @@ PrefabInstance:
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0.5
+      value: 0.47
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 150
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
@@ -1550,41 +1350,6 @@ PrefabInstance:
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
@@ -1637,15 +1402,10 @@ PrefabInstance:
       propertyPath: stageNumber
       value: 4
       objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
+    - target: {fileID: 3500068229682574767, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
+      propertyPath: m_SizeDelta.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
@@ -1660,7 +1420,7 @@ PrefabInstance:
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0.55
+      value: 0.58
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
@@ -1670,16 +1430,11 @@ PrefabInstance:
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0.55
+      value: 0.52
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 150
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
@@ -1690,41 +1445,6 @@ PrefabInstance:
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
@@ -1777,15 +1497,10 @@ PrefabInstance:
       propertyPath: stageNumber
       value: 10
       objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
+    - target: {fileID: 3500068229682574767, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
+      propertyPath: m_SizeDelta.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
@@ -1800,7 +1515,7 @@ PrefabInstance:
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0.85
+      value: 0.88
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
@@ -1810,16 +1525,11 @@ PrefabInstance:
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0.85
+      value: 0.82
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 150
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
@@ -1830,41 +1540,6 @@ PrefabInstance:
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
@@ -1917,15 +1592,10 @@ PrefabInstance:
       propertyPath: stageNumber
       value: 9
       objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
+    - target: {fileID: 3500068229682574767, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
+      propertyPath: m_SizeDelta.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
@@ -1940,7 +1610,7 @@ PrefabInstance:
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0.75
+      value: 0.78
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
@@ -1950,16 +1620,11 @@ PrefabInstance:
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0.75
+      value: 0.72
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 150
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
@@ -1970,41 +1635,6 @@ PrefabInstance:
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
@@ -2057,15 +1687,10 @@ PrefabInstance:
       propertyPath: stageNumber
       value: 7
       objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
+    - target: {fileID: 3500068229682574767, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
+      propertyPath: m_SizeDelta.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
@@ -2080,7 +1705,7 @@ PrefabInstance:
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0.66
+      value: 0.69
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
@@ -2090,16 +1715,11 @@ PrefabInstance:
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0.66
+      value: 0.63
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 150
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
@@ -2110,41 +1730,6 @@ PrefabInstance:
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
@@ -2197,15 +1782,10 @@ PrefabInstance:
       propertyPath: stageNumber
       value: 2
       objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
+    - target: {fileID: 3500068229682574767, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
+      propertyPath: m_SizeDelta.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
@@ -2220,7 +1800,7 @@ PrefabInstance:
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0.35
+      value: 0.38
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
@@ -2230,16 +1810,11 @@ PrefabInstance:
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0.35
+      value: 0.32
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 150
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
@@ -2250,41 +1825,6 @@ PrefabInstance:
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4716757183531113070, guid: b19ab4fa034614c8d95f79160d286468,
@@ -2440,12 +1980,12 @@ PrefabInstance:
     - target: {fileID: 2850028561387380508, guid: 995502db3c4e3402e8a8e9a9e999c831,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 2.406
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 2850028561387380508, guid: 995502db3c4e3402e8a8e9a9e999c831,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
-      value: 2.406
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 4570591737211165032, guid: 995502db3c4e3402e8a8e9a9e999c831,
         type: 3}
@@ -2580,12 +2120,12 @@ PrefabInstance:
     - target: {fileID: 2850028561387380508, guid: 995502db3c4e3402e8a8e9a9e999c831,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 2.406
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 2850028561387380508, guid: 995502db3c4e3402e8a8e9a9e999c831,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
-      value: 2.406
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 4570591737211165032, guid: 995502db3c4e3402e8a8e9a9e999c831,
         type: 3}
@@ -2720,12 +2260,12 @@ PrefabInstance:
     - target: {fileID: 2850028561387380508, guid: 995502db3c4e3402e8a8e9a9e999c831,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 2.406
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 2850028561387380508, guid: 995502db3c4e3402e8a8e9a9e999c831,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
-      value: 2.406
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 4570591737211165032, guid: 995502db3c4e3402e8a8e9a9e999c831,
         type: 3}
@@ -2860,12 +2400,12 @@ PrefabInstance:
     - target: {fileID: 2850028561387380508, guid: 995502db3c4e3402e8a8e9a9e999c831,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 2.406
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 2850028561387380508, guid: 995502db3c4e3402e8a8e9a9e999c831,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
-      value: 2.406
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 4570591737211165032, guid: 995502db3c4e3402e8a8e9a9e999c831,
         type: 3}
@@ -3000,12 +2540,12 @@ PrefabInstance:
     - target: {fileID: 2850028561387380508, guid: 995502db3c4e3402e8a8e9a9e999c831,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 2.406
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 2850028561387380508, guid: 995502db3c4e3402e8a8e9a9e999c831,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
-      value: 2.406
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 4570591737211165032, guid: 995502db3c4e3402e8a8e9a9e999c831,
         type: 3}

--- a/Assets/Project/Actors/UIs/StageSelectScene/TreeCanvas/TreeCanvas.prefab
+++ b/Assets/Project/Actors/UIs/StageSelectScene/TreeCanvas/TreeCanvas.prefab
@@ -3841,21 +3841,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1706829439654611743}
     m_Modifications:
-    - target: {fileID: 3312996573423678126, guid: ca625f1d124a0415dae944a17da5115e,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
     - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,
         type: 3}
       propertyPath: m_RootOrder
@@ -3863,33 +3848,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,
         type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.11
-      objectReference: {fileID: 0}
-    - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.92
-      objectReference: {fileID: 0}
-    - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.11
-      objectReference: {fileID: 0}
-    - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.92
-      objectReference: {fileID: 0}
-    - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,
-        type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 200
       objectReference: {fileID: 0}
     - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,
         type: 3}
@@ -3903,37 +3863,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,
         type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,
-        type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,

--- a/Assets/Project/Actors/UIs/StageSelectScene/TreeCanvas/TreeCanvas.prefab
+++ b/Assets/Project/Actors/UIs/StageSelectScene/TreeCanvas/TreeCanvas.prefab
@@ -138,6 +138,7 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
 --- !u!114 &1706829439666749347
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -536,6 +537,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -565,7 +567,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 1706829441294677237}
   m_Direction: 0
   m_Value: 0
-  m_Size: 0.3333333
+  m_Size: 0.33333334
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -705,6 +707,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9e091a00d71c543bc9f703455766de30, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &8139887256703613692
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3591550205515086092}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb219b23cdf4b314f94a27bca3cc8012, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1706829439521263599
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -714,23 +728,23 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: -2088437028303738681, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: _constraintTrees.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -2088437028303738681, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
       propertyPath: treeId
       value: 3
       objectReference: {fileID: 0}
     - target: {fileID: -2088437028303738681, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: _constraintTrees.Array.data[0]
+      propertyPath: _treeImage
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: -2088437028303738681, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: _constraintTrees.Array.size
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -2088437028303738681, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: _treeImage
-      value: 
+      propertyPath: _constraintTrees.Array.data[0]
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 628439882213713615, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
@@ -739,14 +753,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 628439882213713615, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: startObject
-      value: 
-      objectReference: {fileID: 1783978665681611472}
-    - target: {fileID: 628439882213713615, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
       propertyPath: endObject
       value: 
       objectReference: {fileID: 1783978664484292864}
+    - target: {fileID: 628439882213713615, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: startObject
+      value: 
+      objectReference: {fileID: 1783978665681611472}
     - target: {fileID: 741995402223462307, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: _treeId
@@ -954,74 +968,74 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1441698683106573151, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: startObject
-      value: 
-      objectReference: {fileID: 1783978664091411224}
-    - target: {fileID: 1441698683106573151, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
       propertyPath: endObject
       value: 
       objectReference: {fileID: 1783978665508401661}
+    - target: {fileID: 1441698683106573151, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: startObject
+      value: 
+      objectReference: {fileID: 1783978664091411224}
     - target: {fileID: 2508518794759423879, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: _treeId
       value: 3
       objectReference: {fileID: 0}
-    - target: {fileID: 2508518794759423879, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: startObject
-      value: 
-      objectReference: {fileID: 1783978664091411224}
     - target: {fileID: 2508518794759423879, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: endObject
       value: 
       objectReference: {fileID: 1783978665467118574}
+    - target: {fileID: 2508518794759423879, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: startObject
+      value: 
+      objectReference: {fileID: 1783978664091411224}
     - target: {fileID: 5289361830297375294, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: _treeId
       value: 3
       objectReference: {fileID: 0}
-    - target: {fileID: 5289361830297375294, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: startObject
-      value: 
-      objectReference: {fileID: 1783978664484292864}
     - target: {fileID: 5289361830297375294, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: endObject
       value: 
       objectReference: {fileID: 1783978664955578071}
-    - target: {fileID: 5437569074542598252, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: _treeId
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 5437569074542598252, guid: 721561d07622f4e70a342b2ce2ad79a1,
+    - target: {fileID: 5289361830297375294, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: startObject
       value: 
       objectReference: {fileID: 1783978664484292864}
     - target: {fileID: 5437569074542598252, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
+      propertyPath: _treeId
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5437569074542598252, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
       propertyPath: endObject
       value: 
       objectReference: {fileID: 1783978663793950196}
+    - target: {fileID: 5437569074542598252, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: startObject
+      value: 
+      objectReference: {fileID: 1783978664484292864}
     - target: {fileID: 5736389750613315289, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: _treeId
       value: 3
       objectReference: {fileID: 0}
-    - target: {fileID: 5736389750613315289, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: startObject
-      value: 
-      objectReference: {fileID: 1783978664091411224}
     - target: {fileID: 5736389750613315289, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: endObject
       value: 
       objectReference: {fileID: 1783978665165046478}
+    - target: {fileID: 5736389750613315289, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: startObject
+      value: 
+      objectReference: {fileID: 1783978664091411224}
     - target: {fileID: 5799450989049247345, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: _treeId
@@ -1029,14 +1043,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5799450989049247345, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: startObject
-      value: 
-      objectReference: {fileID: 1783978664091411224}
-    - target: {fileID: 5799450989049247345, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
       propertyPath: endObject
       value: 
       objectReference: {fileID: 1783978663594912644}
+    - target: {fileID: 5799450989049247345, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: startObject
+      value: 
+      objectReference: {fileID: 1783978664091411224}
     - target: {fileID: 6489206248158990791, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: m_Sprite
@@ -1055,6 +1069,51 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.6666
+      objectReference: {fileID: 0}
+    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -1067,6 +1126,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
@@ -1085,13 +1149,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: m_RootOrder
-      value: 2
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
@@ -1107,56 +1171,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.6666
-      objectReference: {fileID: 0}
-    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 6826760224826900712, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
@@ -1181,14 +1195,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7769318828683111250, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: startObject
-      value: 
-      objectReference: {fileID: 1783978663948744302}
-    - target: {fileID: 7769318828683111250, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
       propertyPath: endObject
       value: 
       objectReference: {fileID: 1783978665681611472}
+    - target: {fileID: 7769318828683111250, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: startObject
+      value: 
+      objectReference: {fileID: 1783978663948744302}
     - target: {fileID: 8445743169044297970, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: _treeId
@@ -1196,14 +1210,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8445743169044297970, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: startObject
-      value: 
-      objectReference: {fileID: 1783978664484292864}
-    - target: {fileID: 8445743169044297970, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
       propertyPath: endObject
       value: 
       objectReference: {fileID: 1783978664091411224}
+    - target: {fileID: 8445743169044297970, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: startObject
+      value: 
+      objectReference: {fileID: 1783978664484292864}
     - target: {fileID: 8779286536910858151, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: _treeId
@@ -1265,15 +1279,15 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 1706829439521263599}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1783978663948744302 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1111851934611044737, guid: 721561d07622f4e70a342b2ce2ad79a1,
-    type: 3}
-  m_PrefabInstance: {fileID: 1706829439521263599}
-  m_PrefabAsset: {fileID: 0}
 --- !u!224 &5265383150768198641 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1706829439521263599}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1783978663948744302 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1111851934611044737, guid: 721561d07622f4e70a342b2ce2ad79a1,
     type: 3}
   m_PrefabInstance: {fileID: 1706829439521263599}
   m_PrefabAsset: {fileID: 0}
@@ -1296,6 +1310,51 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5516472073009240669, guid: 48d0f5da9aeda4b42ad9eb03ed71958d,
         type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5516472073009240669, guid: 48d0f5da9aeda4b42ad9eb03ed71958d,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5516472073009240669, guid: 48d0f5da9aeda4b42ad9eb03ed71958d,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5516472073009240669, guid: 48d0f5da9aeda4b42ad9eb03ed71958d,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 5516472073009240669, guid: 48d0f5da9aeda4b42ad9eb03ed71958d,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.58
+      objectReference: {fileID: 0}
+    - target: {fileID: 5516472073009240669, guid: 48d0f5da9aeda4b42ad9eb03ed71958d,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5516472073009240669, guid: 48d0f5da9aeda4b42ad9eb03ed71958d,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.42
+      objectReference: {fileID: 0}
+    - target: {fileID: 5516472073009240669, guid: 48d0f5da9aeda4b42ad9eb03ed71958d,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5516472073009240669, guid: 48d0f5da9aeda4b42ad9eb03ed71958d,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5516472073009240669, guid: 48d0f5da9aeda4b42ad9eb03ed71958d,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -1308,6 +1367,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5516472073009240669, guid: 48d0f5da9aeda4b42ad9eb03ed71958d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5516472073009240669, guid: 48d0f5da9aeda4b42ad9eb03ed71958d,
         type: 3}
@@ -1326,13 +1390,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5516472073009240669, guid: 48d0f5da9aeda4b42ad9eb03ed71958d,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5516472073009240669, guid: 48d0f5da9aeda4b42ad9eb03ed71958d,
         type: 3}
-      propertyPath: m_RootOrder
-      value: 3
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5516472073009240669, guid: 48d0f5da9aeda4b42ad9eb03ed71958d,
         type: 3}
@@ -1348,56 +1412,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5516472073009240669, guid: 48d0f5da9aeda4b42ad9eb03ed71958d,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5516472073009240669, guid: 48d0f5da9aeda4b42ad9eb03ed71958d,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5516472073009240669, guid: 48d0f5da9aeda4b42ad9eb03ed71958d,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5516472073009240669, guid: 48d0f5da9aeda4b42ad9eb03ed71958d,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5516472073009240669, guid: 48d0f5da9aeda4b42ad9eb03ed71958d,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.3
-      objectReference: {fileID: 0}
-    - target: {fileID: 5516472073009240669, guid: 48d0f5da9aeda4b42ad9eb03ed71958d,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.42
-      objectReference: {fileID: 0}
-    - target: {fileID: 5516472073009240669, guid: 48d0f5da9aeda4b42ad9eb03ed71958d,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.7
-      objectReference: {fileID: 0}
-    - target: {fileID: 5516472073009240669, guid: 48d0f5da9aeda4b42ad9eb03ed71958d,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.58
-      objectReference: {fileID: 0}
-    - target: {fileID: 5516472073009240669, guid: 48d0f5da9aeda4b42ad9eb03ed71958d,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5516472073009240669, guid: 48d0f5da9aeda4b42ad9eb03ed71958d,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 48d0f5da9aeda4b42ad9eb03ed71958d, type: 3}
@@ -1416,6 +1430,51 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 3530007683359684582, guid: c2d06662606ab469393fe431ecdc78ae,
         type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3530007683359684582, guid: c2d06662606ab469393fe431ecdc78ae,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3530007683359684582, guid: c2d06662606ab469393fe431ecdc78ae,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3530007683359684582, guid: c2d06662606ab469393fe431ecdc78ae,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3530007683359684582, guid: c2d06662606ab469393fe431ecdc78ae,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3530007683359684582, guid: c2d06662606ab469393fe431ecdc78ae,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3530007683359684582, guid: c2d06662606ab469393fe431ecdc78ae,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3530007683359684582, guid: c2d06662606ab469393fe431ecdc78ae,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3530007683359684582, guid: c2d06662606ab469393fe431ecdc78ae,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3530007683359684582, guid: c2d06662606ab469393fe431ecdc78ae,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -1428,6 +1487,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3530007683359684582, guid: c2d06662606ab469393fe431ecdc78ae,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3530007683359684582, guid: c2d06662606ab469393fe431ecdc78ae,
         type: 3}
@@ -1446,13 +1510,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3530007683359684582, guid: c2d06662606ab469393fe431ecdc78ae,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3530007683359684582, guid: c2d06662606ab469393fe431ecdc78ae,
         type: 3}
-      propertyPath: m_RootOrder
-      value: 2
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3530007683359684582, guid: c2d06662606ab469393fe431ecdc78ae,
         type: 3}
@@ -1468,56 +1532,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3530007683359684582, guid: c2d06662606ab469393fe431ecdc78ae,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3530007683359684582, guid: c2d06662606ab469393fe431ecdc78ae,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3530007683359684582, guid: c2d06662606ab469393fe431ecdc78ae,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3530007683359684582, guid: c2d06662606ab469393fe431ecdc78ae,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3530007683359684582, guid: c2d06662606ab469393fe431ecdc78ae,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3530007683359684582, guid: c2d06662606ab469393fe431ecdc78ae,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3530007683359684582, guid: c2d06662606ab469393fe431ecdc78ae,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3530007683359684582, guid: c2d06662606ab469393fe431ecdc78ae,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3530007683359684582, guid: c2d06662606ab469393fe431ecdc78ae,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3530007683359684582, guid: c2d06662606ab469393fe431ecdc78ae,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 4370443534887082157, guid: c2d06662606ab469393fe431ecdc78ae,
         type: 3}
@@ -1546,23 +1560,23 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: -2088437028303738681, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: _constraintTrees.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -2088437028303738681, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
       propertyPath: treeId
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: -2088437028303738681, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: _constraintTrees.Array.data[0]
+      propertyPath: _treeImage
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: -2088437028303738681, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: _constraintTrees.Array.size
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -2088437028303738681, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: _treeImage
-      value: 
+      propertyPath: _constraintTrees.Array.data[0]
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 628439882213713615, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
@@ -1571,14 +1585,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 628439882213713615, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: startObject
-      value: 
-      objectReference: {fileID: 1783978665183257471}
-    - target: {fileID: 628439882213713615, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
       propertyPath: endObject
       value: 
       objectReference: {fileID: 1783978664237072559}
+    - target: {fileID: 628439882213713615, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: startObject
+      value: 
+      objectReference: {fileID: 1783978665183257471}
     - target: {fileID: 741995402223462307, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: _treeId
@@ -1786,74 +1800,74 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1441698683106573151, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: startObject
-      value: 
-      objectReference: {fileID: 1783978664623811255}
-    - target: {fileID: 1441698683106573151, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
       propertyPath: endObject
       value: 
       objectReference: {fileID: 1783978665353984082}
+    - target: {fileID: 1441698683106573151, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: startObject
+      value: 
+      objectReference: {fileID: 1783978664623811255}
     - target: {fileID: 2508518794759423879, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: _treeId
       value: 2
       objectReference: {fileID: 0}
-    - target: {fileID: 2508518794759423879, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: startObject
-      value: 
-      objectReference: {fileID: 1783978664623811255}
     - target: {fileID: 2508518794759423879, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: endObject
       value: 
       objectReference: {fileID: 1783978665395571265}
+    - target: {fileID: 2508518794759423879, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: startObject
+      value: 
+      objectReference: {fileID: 1783978664623811255}
     - target: {fileID: 5289361830297375294, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: _treeId
       value: 2
       objectReference: {fileID: 0}
-    - target: {fileID: 5289361830297375294, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: startObject
-      value: 
-      objectReference: {fileID: 1783978664237072559}
     - target: {fileID: 5289361830297375294, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: endObject
       value: 
       objectReference: {fileID: 1783978664833175416}
-    - target: {fileID: 5437569074542598252, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: _treeId
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 5437569074542598252, guid: 721561d07622f4e70a342b2ce2ad79a1,
+    - target: {fileID: 5289361830297375294, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: startObject
       value: 
       objectReference: {fileID: 1783978664237072559}
     - target: {fileID: 5437569074542598252, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
+      propertyPath: _treeId
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5437569074542598252, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
       propertyPath: endObject
       value: 
       objectReference: {fileID: 1783978663849243739}
+    - target: {fileID: 5437569074542598252, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: startObject
+      value: 
+      objectReference: {fileID: 1783978664237072559}
     - target: {fileID: 5736389750613315289, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: _treeId
       value: 2
       objectReference: {fileID: 0}
-    - target: {fileID: 5736389750613315289, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: startObject
-      value: 
-      objectReference: {fileID: 1783978664623811255}
     - target: {fileID: 5736389750613315289, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: endObject
       value: 
       objectReference: {fileID: 1783978665697446753}
+    - target: {fileID: 5736389750613315289, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: startObject
+      value: 
+      objectReference: {fileID: 1783978664623811255}
     - target: {fileID: 5799450989049247345, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: _treeId
@@ -1861,14 +1875,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5799450989049247345, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: startObject
-      value: 
-      objectReference: {fileID: 1783978664623811255}
-    - target: {fileID: 5799450989049247345, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
       propertyPath: endObject
       value: 
       objectReference: {fileID: 1783978664052859435}
+    - target: {fileID: 5799450989049247345, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: startObject
+      value: 
+      objectReference: {fileID: 1783978664623811255}
     - target: {fileID: 6489206248158990791, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: m_Sprite
@@ -1887,6 +1901,51 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.6666
+      objectReference: {fileID: 0}
+    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.3333
+      objectReference: {fileID: 0}
+    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -1899,6 +1958,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
@@ -1917,13 +1981,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: m_RootOrder
-      value: 1
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
@@ -1939,56 +2003,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.3333
-      objectReference: {fileID: 0}
-    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.6666
-      objectReference: {fileID: 0}
-    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 6826760224826900712, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
@@ -2013,14 +2027,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7769318828683111250, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: startObject
-      value: 
-      objectReference: {fileID: 1783978663692615617}
-    - target: {fileID: 7769318828683111250, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
       propertyPath: endObject
       value: 
       objectReference: {fileID: 1783978665183257471}
+    - target: {fileID: 7769318828683111250, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: startObject
+      value: 
+      objectReference: {fileID: 1783978663692615617}
     - target: {fileID: 8445743169044297970, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: _treeId
@@ -2028,14 +2042,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8445743169044297970, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: startObject
-      value: 
-      objectReference: {fileID: 1783978664237072559}
-    - target: {fileID: 8445743169044297970, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
       propertyPath: endObject
       value: 
       objectReference: {fileID: 1783978664623811255}
+    - target: {fileID: 8445743169044297970, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: startObject
+      value: 
+      objectReference: {fileID: 1783978664237072559}
     - target: {fileID: 8779286536910858151, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: _treeId
@@ -2079,9 +2093,9 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 1706829439961417280}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1783978665697446753 stripped
+--- !u!1 &1783978665395571265 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 1111851935911234849, guid: 721561d07622f4e70a342b2ce2ad79a1,
+  m_CorrespondingSourceObject: {fileID: 1111851936146197505, guid: 721561d07622f4e70a342b2ce2ad79a1,
     type: 3}
   m_PrefabInstance: {fileID: 1706829439961417280}
   m_PrefabAsset: {fileID: 0}
@@ -2103,9 +2117,9 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 1706829439961417280}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1783978665395571265 stripped
+--- !u!1 &1783978665697446753 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 1111851936146197505, guid: 721561d07622f4e70a342b2ce2ad79a1,
+  m_CorrespondingSourceObject: {fileID: 1111851935911234849, guid: 721561d07622f4e70a342b2ce2ad79a1,
     type: 3}
   m_PrefabInstance: {fileID: 1706829439961417280}
   m_PrefabAsset: {fileID: 0}
@@ -2123,6 +2137,66 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1232283201739966426, guid: 6133eaa162bfb4280a93ab87bd182bc3,
         type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1232283201739966426, guid: 6133eaa162bfb4280a93ab87bd182bc3,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1232283201739966426, guid: 6133eaa162bfb4280a93ab87bd182bc3,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1232283201739966426, guid: 6133eaa162bfb4280a93ab87bd182bc3,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 1232283201739966426, guid: 6133eaa162bfb4280a93ab87bd182bc3,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.08
+      objectReference: {fileID: 0}
+    - target: {fileID: 1232283201739966426, guid: 6133eaa162bfb4280a93ab87bd182bc3,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1232283201739966426, guid: 6133eaa162bfb4280a93ab87bd182bc3,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1232283201739966426, guid: 6133eaa162bfb4280a93ab87bd182bc3,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1232283201739966426, guid: 6133eaa162bfb4280a93ab87bd182bc3,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1232283201739966426, guid: 6133eaa162bfb4280a93ab87bd182bc3,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1232283201739966426, guid: 6133eaa162bfb4280a93ab87bd182bc3,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1232283201739966426, guid: 6133eaa162bfb4280a93ab87bd182bc3,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1232283201739966426, guid: 6133eaa162bfb4280a93ab87bd182bc3,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -2135,6 +2209,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1232283201739966426, guid: 6133eaa162bfb4280a93ab87bd182bc3,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1232283201739966426, guid: 6133eaa162bfb4280a93ab87bd182bc3,
         type: 3}
@@ -2153,12 +2232,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1232283201739966426, guid: 6133eaa162bfb4280a93ab87bd182bc3,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1232283201739966426, guid: 6133eaa162bfb4280a93ab87bd182bc3,
         type: 3}
-      propertyPath: m_RootOrder
+      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1232283201739966426, guid: 6133eaa162bfb4280a93ab87bd182bc3,
@@ -2176,71 +2255,6 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1232283201739966426, guid: 6133eaa162bfb4280a93ab87bd182bc3,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1232283201739966426, guid: 6133eaa162bfb4280a93ab87bd182bc3,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1232283201739966426, guid: 6133eaa162bfb4280a93ab87bd182bc3,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1232283201739966426, guid: 6133eaa162bfb4280a93ab87bd182bc3,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1232283201739966426, guid: 6133eaa162bfb4280a93ab87bd182bc3,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.2
-      objectReference: {fileID: 0}
-    - target: {fileID: 1232283201739966426, guid: 6133eaa162bfb4280a93ab87bd182bc3,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1232283201739966426, guid: 6133eaa162bfb4280a93ab87bd182bc3,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.8
-      objectReference: {fileID: 0}
-    - target: {fileID: 1232283201739966426, guid: 6133eaa162bfb4280a93ab87bd182bc3,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.08
-      objectReference: {fileID: 0}
-    - target: {fileID: 1232283201739966426, guid: 6133eaa162bfb4280a93ab87bd182bc3,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1232283201739966426, guid: 6133eaa162bfb4280a93ab87bd182bc3,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1232283201739966426, guid: 6133eaa162bfb4280a93ab87bd182bc3,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1232283201739966426, guid: 6133eaa162bfb4280a93ab87bd182bc3,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1232283201739966426, guid: 6133eaa162bfb4280a93ab87bd182bc3,
-        type: 3}
-      propertyPath: m_LocalScale.z
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 4813430151696820849, guid: 6133eaa162bfb4280a93ab87bd182bc3,
         type: 3}
       propertyPath: m_Text
@@ -2253,6 +2267,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6133eaa162bfb4280a93ab87bd182bc3, type: 3}
+--- !u!1 &3591550205515086092 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2772070811221779287, guid: 6133eaa162bfb4280a93ab87bd182bc3,
+    type: 3}
+  m_PrefabInstance: {fileID: 1706829440206461531}
+  m_PrefabAsset: {fileID: 0}
 --- !u!224 &483595305205046657 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 1232283201739966426, guid: 6133eaa162bfb4280a93ab87bd182bc3,
@@ -2268,22 +2288,22 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 3585425056201347506, guid: c69d8a8760be44426bfdd6805ded5f74,
         type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3585425056201347506, guid: c69d8a8760be44426bfdd6805ded5f74,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3585425056201347506, guid: c69d8a8760be44426bfdd6805ded5f74,
-        type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3585425056201347506, guid: c69d8a8760be44426bfdd6805ded5f74,
         type: 3}
       propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3585425056201347506, guid: c69d8a8760be44426bfdd6805ded5f74,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3585425056201347506, guid: c69d8a8760be44426bfdd6805ded5f74,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3585425056827976462, guid: c69d8a8760be44426bfdd6805ded5f74,
@@ -2295,6 +2315,66 @@ PrefabInstance:
         type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3585425056827976463, guid: c69d8a8760be44426bfdd6805ded5f74,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3585425056827976463, guid: c69d8a8760be44426bfdd6805ded5f74,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3585425056827976463, guid: c69d8a8760be44426bfdd6805ded5f74,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 3585425056827976463, guid: c69d8a8760be44426bfdd6805ded5f74,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3585425056827976463, guid: c69d8a8760be44426bfdd6805ded5f74,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3585425056827976463, guid: c69d8a8760be44426bfdd6805ded5f74,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3585425056827976463, guid: c69d8a8760be44426bfdd6805ded5f74,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3585425056827976463, guid: c69d8a8760be44426bfdd6805ded5f74,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3585425056827976463, guid: c69d8a8760be44426bfdd6805ded5f74,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3585425056827976463, guid: c69d8a8760be44426bfdd6805ded5f74,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3585425056827976463, guid: c69d8a8760be44426bfdd6805ded5f74,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3585425056827976463, guid: c69d8a8760be44426bfdd6805ded5f74,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3585425056827976463, guid: c69d8a8760be44426bfdd6805ded5f74,
         type: 3}
@@ -2313,6 +2393,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3585425056827976463, guid: c69d8a8760be44426bfdd6805ded5f74,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3585425056827976463, guid: c69d8a8760be44426bfdd6805ded5f74,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
@@ -2328,13 +2413,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3585425056827976463, guid: c69d8a8760be44426bfdd6805ded5f74,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3585425056827976463, guid: c69d8a8760be44426bfdd6805ded5f74,
         type: 3}
-      propertyPath: m_RootOrder
-      value: 4
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3585425056827976463, guid: c69d8a8760be44426bfdd6805ded5f74,
         type: 3}
@@ -2350,71 +2435,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3585425056827976463, guid: c69d8a8760be44426bfdd6805ded5f74,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3585425056827976463, guid: c69d8a8760be44426bfdd6805ded5f74,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3585425056827976463, guid: c69d8a8760be44426bfdd6805ded5f74,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3585425056827976463, guid: c69d8a8760be44426bfdd6805ded5f74,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3585425056827976463, guid: c69d8a8760be44426bfdd6805ded5f74,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3585425056827976463, guid: c69d8a8760be44426bfdd6805ded5f74,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3585425056827976463, guid: c69d8a8760be44426bfdd6805ded5f74,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3585425056827976463, guid: c69d8a8760be44426bfdd6805ded5f74,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3585425056827976463, guid: c69d8a8760be44426bfdd6805ded5f74,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3585425056827976463, guid: c69d8a8760be44426bfdd6805ded5f74,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3585425056827976463, guid: c69d8a8760be44426bfdd6805ded5f74,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3585425056827976463, guid: c69d8a8760be44426bfdd6805ded5f74,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3585425056827976463, guid: c69d8a8760be44426bfdd6805ded5f74,
-        type: 3}
-      propertyPath: m_LocalScale.z
-      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3585425056906245322, guid: c69d8a8760be44426bfdd6805ded5f74,
         type: 3}
@@ -2433,13 +2453,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3877992080819516550, guid: c69d8a8760be44426bfdd6805ded5f74,
         type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
+      propertyPath: m_AnchorMin.y
+      value: 0.7
       objectReference: {fileID: 0}
     - target: {fileID: 3877992080819516550, guid: c69d8a8760be44426bfdd6805ded5f74,
         type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.7
+      propertyPath: m_SizeDelta.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3877992080819516550, guid: c69d8a8760be44426bfdd6805ded5f74,
         type: 3}
@@ -2453,13 +2473,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4806284743604297953, guid: c69d8a8760be44426bfdd6805ded5f74,
         type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
+      propertyPath: m_AnchorMin.y
+      value: 0.7
       objectReference: {fileID: 0}
     - target: {fileID: 4806284743604297953, guid: c69d8a8760be44426bfdd6805ded5f74,
         type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.7
+      propertyPath: m_SizeDelta.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4806284743604297953, guid: c69d8a8760be44426bfdd6805ded5f74,
         type: 3}
@@ -2473,13 +2493,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5330151350029844723, guid: c69d8a8760be44426bfdd6805ded5f74,
         type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
+      propertyPath: m_AnchorMin.y
+      value: 0.7
       objectReference: {fileID: 0}
     - target: {fileID: 5330151350029844723, guid: c69d8a8760be44426bfdd6805ded5f74,
         type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.7
+      propertyPath: m_SizeDelta.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5330151350029844723, guid: c69d8a8760be44426bfdd6805ded5f74,
         type: 3}
@@ -2513,14 +2533,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 628439882213713615, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: constraintObjects.Array.size
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 628439882213713615, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
       propertyPath: _width
       value: 0.03
       objectReference: {fileID: 0}
+    - target: {fileID: 628439882213713615, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: _render
+      value: 
+      objectReference: {fileID: 573118182729258555}
     - target: {fileID: 628439882213713615, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: _treeId
@@ -2528,19 +2548,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 628439882213713615, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: startObject
-      value: 
-      objectReference: {fileID: 1783978663706842047}
-    - target: {fileID: 628439882213713615, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
       propertyPath: endObject
       value: 
       objectReference: {fileID: 1783978664639787119}
     - target: {fileID: 628439882213713615, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: _render
+      propertyPath: startObject
       value: 
-      objectReference: {fileID: 573118182729258555}
+      objectReference: {fileID: 1783978663706842047}
+    - target: {fileID: 628439882213713615, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: constraintObjects.Array.size
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 628439882213713615, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: constraintObjects.Array.data[0]
@@ -2593,12 +2613,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 741995402850388900, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: _stageNumber
+      propertyPath: stageNumber
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 741995402850388900, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: stageNumber
+      propertyPath: _stageNumber
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 741995403045391088, guid: 721561d07622f4e70a342b2ce2ad79a1,
@@ -2628,12 +2648,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 741995403230533402, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: _stageNumber
+      propertyPath: stageNumber
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 741995403230533402, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: stageNumber
+      propertyPath: _stageNumber
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 741995403540841068, guid: 721561d07622f4e70a342b2ce2ad79a1,
@@ -2655,11 +2675,6 @@ PrefabInstance:
         type: 3}
       propertyPath: _stageNumber
       value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 928485103331441963, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: m_Parameters.widthCurve.m_Curve.Array.size
-      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 928485103331441963, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
@@ -2688,13 +2703,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 928485103331441963, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 3.12
+      propertyPath: m_Parameters.widthCurve.m_Curve.Array.size
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 928485103331441963, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].time
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 928485103331441963, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
+      value: 3.12
       objectReference: {fileID: 0}
     - target: {fileID: 928485103331441963, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
@@ -2783,12 +2803,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1111851935911234850, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: m_RaycastTarget
+      propertyPath: m_Enabled
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1111851935911234850, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: m_Enabled
+      propertyPath: m_RaycastTarget
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1111851936146197504, guid: 721561d07622f4e70a342b2ce2ad79a1,
@@ -2823,11 +2843,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1178816816637649083, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: m_Parameters.widthCurve.m_Curve.Array.size
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 1178816816637649083, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
       propertyPath: m_Positions.Array.data[0].x
       value: 11.24884
       objectReference: {fileID: 0}
@@ -2848,13 +2863,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1178816816637649083, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 3.12
+      propertyPath: m_Parameters.widthCurve.m_Curve.Array.size
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 1178816816637649083, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].time
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1178816816637649083, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
+      value: 3.12
       objectReference: {fileID: 0}
     - target: {fileID: 1178816816637649083, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
@@ -2883,14 +2903,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1441698683106573151, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: startObject
-      value: 
-      objectReference: {fileID: 1783978665026509431}
-    - target: {fileID: 1441698683106573151, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
       propertyPath: endObject
       value: 
       objectReference: {fileID: 1783978663609125010}
+    - target: {fileID: 1441698683106573151, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: startObject
+      value: 
+      objectReference: {fileID: 1783978665026509431}
     - target: {fileID: 2508518794759423879, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: _width
@@ -2903,19 +2923,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2508518794759423879, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: startObject
-      value: 
-      objectReference: {fileID: 1783978665026509431}
-    - target: {fileID: 2508518794759423879, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
       propertyPath: endObject
       value: 
       objectReference: {fileID: 1783978663650769537}
-    - target: {fileID: 4193794178640904691, guid: 721561d07622f4e70a342b2ce2ad79a1,
+    - target: {fileID: 2508518794759423879, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: m_Parameters.widthCurve.m_Curve.Array.size
-      value: 2
-      objectReference: {fileID: 0}
+      propertyPath: startObject
+      value: 
+      objectReference: {fileID: 1783978665026509431}
     - target: {fileID: 4193794178640904691, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: m_Positions.Array.data[0].x
@@ -2943,13 +2958,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4193794178640904691, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 3.12
+      propertyPath: m_Parameters.widthCurve.m_Curve.Array.size
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 4193794178640904691, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].time
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4193794178640904691, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
+      value: 3.12
       objectReference: {fileID: 0}
     - target: {fileID: 4193794178640904691, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
@@ -2965,11 +2985,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].outWeight
       value: 0.33333334
-      objectReference: {fileID: 0}
-    - target: {fileID: 5231103500094124037, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: m_Parameters.widthCurve.m_Curve.Array.size
-      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 5231103500094124037, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
@@ -2998,13 +3013,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5231103500094124037, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 3.12
+      propertyPath: m_Parameters.widthCurve.m_Curve.Array.size
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 5231103500094124037, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].time
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231103500094124037, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
+      value: 3.12
       objectReference: {fileID: 0}
     - target: {fileID: 5231103500094124037, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
@@ -3028,14 +3048,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5289361830297375294, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
+      propertyPath: _render
+      value: 
+      objectReference: {fileID: 5056174324638999242}
+    - target: {fileID: 5289361830297375294, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
       propertyPath: _treeId
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5289361830297375294, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: startObject
-      value: 
-      objectReference: {fileID: 1783978664639787119}
     - target: {fileID: 5289361830297375294, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: endObject
@@ -3043,29 +3063,29 @@ PrefabInstance:
       objectReference: {fileID: 1783978664162049976}
     - target: {fileID: 5289361830297375294, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: _render
-      value: 
-      objectReference: {fileID: 5056174324638999242}
-    - target: {fileID: 5437569074542598252, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: _width
-      value: 0.03
-      objectReference: {fileID: 0}
-    - target: {fileID: 5437569074542598252, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: _treeId
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5437569074542598252, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
       propertyPath: startObject
       value: 
       objectReference: {fileID: 1783978664639787119}
     - target: {fileID: 5437569074542598252, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
+      propertyPath: _width
+      value: 0.03
+      objectReference: {fileID: 0}
+    - target: {fileID: 5437569074542598252, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: _treeId
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5437569074542598252, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
       propertyPath: endObject
       value: 
       objectReference: {fileID: 1783978665594111131}
+    - target: {fileID: 5437569074542598252, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: startObject
+      value: 
+      objectReference: {fileID: 1783978664639787119}
     - target: {fileID: 5736389750613315289, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: _width
@@ -3076,16 +3096,16 @@ PrefabInstance:
       propertyPath: _treeId
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5736389750613315289, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: startObject
-      value: 
-      objectReference: {fileID: 1783978665026509431}
     - target: {fileID: 5736389750613315289, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: endObject
       value: 
       objectReference: {fileID: 1783978663952612257}
+    - target: {fileID: 5736389750613315289, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: startObject
+      value: 
+      objectReference: {fileID: 1783978665026509431}
     - target: {fileID: 5799450989049247345, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: _width
@@ -3098,19 +3118,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5799450989049247345, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: startObject
-      value: 
-      objectReference: {fileID: 1783978665026509431}
-    - target: {fileID: 5799450989049247345, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
       propertyPath: endObject
       value: 
       objectReference: {fileID: 1783978665529299691}
-    - target: {fileID: 5874034867768546378, guid: 721561d07622f4e70a342b2ce2ad79a1,
+    - target: {fileID: 5799450989049247345, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: m_Parameters.widthCurve.m_Curve.Array.size
-      value: 2
-      objectReference: {fileID: 0}
+      propertyPath: startObject
+      value: 
+      objectReference: {fileID: 1783978665026509431}
     - target: {fileID: 5874034867768546378, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: m_Positions.Array.data[0].x
@@ -3133,13 +3148,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5874034867768546378, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 3.12
+      propertyPath: m_Parameters.widthCurve.m_Curve.Array.size
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 5874034867768546378, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].time
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5874034867768546378, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
+      value: 3.12
       objectReference: {fileID: 0}
     - target: {fileID: 5874034867768546378, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
@@ -3155,11 +3175,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].outWeight
       value: 0.33333334
-      objectReference: {fileID: 0}
-    - target: {fileID: 6022849114226171416, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: m_Parameters.widthCurve.m_Curve.Array.size
-      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 6022849114226171416, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
@@ -3183,13 +3198,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6022849114226171416, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 3.12
+      propertyPath: m_Parameters.widthCurve.m_Curve.Array.size
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 6022849114226171416, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].time
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6022849114226171416, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
+      value: 3.12
       objectReference: {fileID: 0}
     - target: {fileID: 6022849114226171416, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
@@ -3205,11 +3225,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].outWeight
       value: 0.33333334
-      objectReference: {fileID: 0}
-    - target: {fileID: 6302951563963353261, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: m_Parameters.widthCurve.m_Curve.Array.size
-      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 6302951563963353261, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
@@ -3238,13 +3253,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6302951563963353261, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 3.12
+      propertyPath: m_Parameters.widthCurve.m_Curve.Array.size
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 6302951563963353261, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].time
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6302951563963353261, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
+      value: 3.12
       objectReference: {fileID: 0}
     - target: {fileID: 6302951563963353261, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
@@ -3279,6 +3299,51 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.3333
+      objectReference: {fileID: 0}
+    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -3291,6 +3356,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
@@ -3309,12 +3379,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: m_RootOrder
+      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
@@ -3331,56 +3401,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.3333
-      objectReference: {fileID: 0}
-    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 6826760224826900712, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
@@ -3425,28 +3445,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7769318828683111250, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: constraintObjects.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7769318828683111250, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: startObject
-      value: 
-      objectReference: {fileID: 1783978665169047297}
-    - target: {fileID: 7769318828683111250, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: endObject
-      value: 
-      objectReference: {fileID: 1783978663706842047}
-    - target: {fileID: 7769318828683111250, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
       propertyPath: _width
       value: 0.03
-      objectReference: {fileID: 0}
-    - target: {fileID: 7769318828683111250, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: _treeId
-      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7769318828683111250, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
@@ -3455,14 +3455,29 @@ PrefabInstance:
       objectReference: {fileID: 7250407284197907366}
     - target: {fileID: 7769318828683111250, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
+      propertyPath: _treeId
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7769318828683111250, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: endObject
+      value: 
+      objectReference: {fileID: 1783978663706842047}
+    - target: {fileID: 7769318828683111250, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: startObject
+      value: 
+      objectReference: {fileID: 1783978665169047297}
+    - target: {fileID: 7769318828683111250, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: constraintObjects.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7769318828683111250, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
       propertyPath: constraintObjects.Array.data[0]
       value: 
       objectReference: {fileID: 1783978665169047297}
-    - target: {fileID: 7914543847607762566, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: m_Parameters.widthCurve.m_Curve.Array.size
-      value: 2
-      objectReference: {fileID: 0}
     - target: {fileID: 7914543847607762566, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: m_Positions.Array.data[0].x
@@ -3485,13 +3500,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7914543847607762566, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 3.12
+      propertyPath: m_Parameters.widthCurve.m_Curve.Array.size
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 7914543847607762566, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].time
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7914543847607762566, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
+      value: 3.12
       objectReference: {fileID: 0}
     - target: {fileID: 7914543847607762566, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
@@ -3507,16 +3527,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].outWeight
       value: 0.33333334
-      objectReference: {fileID: 0}
-    - target: {fileID: 8300555603325087014, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: m_Parameters.widthCurve.m_Curve.Array.size
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 8300555603325087014, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
-      propertyPath: m_Parameters.widthMultiplier
-      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 8300555603325087014, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
@@ -3550,13 +3560,23 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8300555603325087014, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 2.316
+      propertyPath: m_Parameters.widthMultiplier
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8300555603325087014, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: m_Parameters.widthCurve.m_Curve.Array.size
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 8300555603325087014, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].time
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8300555603325087014, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
+      value: 2.316
       objectReference: {fileID: 0}
     - target: {fileID: 8300555603325087014, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
@@ -3585,14 +3605,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8445743169044297970, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
-      propertyPath: startObject
-      value: 
-      objectReference: {fileID: 1783978664639787119}
-    - target: {fileID: 8445743169044297970, guid: 721561d07622f4e70a342b2ce2ad79a1,
-        type: 3}
       propertyPath: endObject
       value: 
       objectReference: {fileID: 1783978665026509431}
+    - target: {fileID: 8445743169044297970, guid: 721561d07622f4e70a342b2ce2ad79a1,
+        type: 3}
+      propertyPath: startObject
+      value: 
+      objectReference: {fileID: 1783978664639787119}
     - target: {fileID: 8779286536910858151, guid: 721561d07622f4e70a342b2ce2ad79a1,
         type: 3}
       propertyPath: _treeId
@@ -3600,21 +3620,9 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 721561d07622f4e70a342b2ce2ad79a1, type: 3}
---- !u!1 &1783978664162049976 stripped
+--- !u!1 &1783978665026509431 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 1111851935617878328, guid: 721561d07622f4e70a342b2ce2ad79a1,
-    type: 3}
-  m_PrefabInstance: {fileID: 1706829441437841024}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1783978663706842047 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1111851936334472511, guid: 721561d07622f4e70a342b2ce2ad79a1,
-    type: 3}
-  m_PrefabInstance: {fileID: 1706829441437841024}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1783978665169047297 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1111851934611044737, guid: 721561d07622f4e70a342b2ce2ad79a1,
+  m_CorrespondingSourceObject: {fileID: 1111851934837599479, guid: 721561d07622f4e70a342b2ce2ad79a1,
     type: 3}
   m_PrefabInstance: {fileID: 1706829441437841024}
   m_PrefabAsset: {fileID: 0}
@@ -3624,9 +3632,21 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 1706829441437841024}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1783978665026509431 stripped
+--- !u!1 &1783978664162049976 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 1111851934837599479, guid: 721561d07622f4e70a342b2ce2ad79a1,
+  m_CorrespondingSourceObject: {fileID: 1111851935617878328, guid: 721561d07622f4e70a342b2ce2ad79a1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1706829441437841024}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1783978665529299691 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1111851934264550507, guid: 721561d07622f4e70a342b2ce2ad79a1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1706829441437841024}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1783978663706842047 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1111851936334472511, guid: 721561d07622f4e70a342b2ce2ad79a1,
     type: 3}
   m_PrefabInstance: {fileID: 1706829441437841024}
   m_PrefabAsset: {fileID: 0}
@@ -3636,9 +3656,9 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 1706829441437841024}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1783978665529299691 stripped
+--- !u!1 &1783978665169047297 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 1111851934264550507, guid: 721561d07622f4e70a342b2ce2ad79a1,
+  m_CorrespondingSourceObject: {fileID: 1111851934611044737, guid: 721561d07622f4e70a342b2ce2ad79a1,
     type: 3}
   m_PrefabInstance: {fileID: 1706829441437841024}
   m_PrefabAsset: {fileID: 0}
@@ -3654,15 +3674,15 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 1706829441437841024}
   m_PrefabAsset: {fileID: 0}
---- !u!224 &5265383152113756830 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
-    type: 3}
-  m_PrefabInstance: {fileID: 1706829441437841024}
-  m_PrefabAsset: {fileID: 0}
 --- !u!120 &7250407284197907366 stripped
 LineRenderer:
   m_CorrespondingSourceObject: {fileID: 8300555603325087014, guid: 721561d07622f4e70a342b2ce2ad79a1,
+    type: 3}
+  m_PrefabInstance: {fileID: 1706829441437841024}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &5265383152113756830 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6826760224180116510, guid: 721561d07622f4e70a342b2ce2ad79a1,
     type: 3}
   m_PrefabInstance: {fileID: 1706829441437841024}
   m_PrefabAsset: {fileID: 0}
@@ -3693,6 +3713,51 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4569299527894993288, guid: 8c32505b4b587443e8b5583c6e44769a,
         type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4569299527894993288, guid: 8c32505b4b587443e8b5583c6e44769a,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4569299527894993288, guid: 8c32505b4b587443e8b5583c6e44769a,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4569299527894993288, guid: 8c32505b4b587443e8b5583c6e44769a,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.15
+      objectReference: {fileID: 0}
+    - target: {fileID: 4569299527894993288, guid: 8c32505b4b587443e8b5583c6e44769a,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.07
+      objectReference: {fileID: 0}
+    - target: {fileID: 4569299527894993288, guid: 8c32505b4b587443e8b5583c6e44769a,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.05
+      objectReference: {fileID: 0}
+    - target: {fileID: 4569299527894993288, guid: 8c32505b4b587443e8b5583c6e44769a,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.01
+      objectReference: {fileID: 0}
+    - target: {fileID: 4569299527894993288, guid: 8c32505b4b587443e8b5583c6e44769a,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4569299527894993288, guid: 8c32505b4b587443e8b5583c6e44769a,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4569299527894993288, guid: 8c32505b4b587443e8b5583c6e44769a,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -3705,6 +3770,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4569299527894993288, guid: 8c32505b4b587443e8b5583c6e44769a,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4569299527894993288, guid: 8c32505b4b587443e8b5583c6e44769a,
         type: 3}
@@ -3723,13 +3793,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4569299527894993288, guid: 8c32505b4b587443e8b5583c6e44769a,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4569299527894993288, guid: 8c32505b4b587443e8b5583c6e44769a,
         type: 3}
-      propertyPath: m_RootOrder
-      value: 1
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4569299527894993288, guid: 8c32505b4b587443e8b5583c6e44769a,
         type: 3}
@@ -3745,56 +3815,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4569299527894993288, guid: 8c32505b4b587443e8b5583c6e44769a,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4569299527894993288, guid: 8c32505b4b587443e8b5583c6e44769a,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4569299527894993288, guid: 8c32505b4b587443e8b5583c6e44769a,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4569299527894993288, guid: 8c32505b4b587443e8b5583c6e44769a,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4569299527894993288, guid: 8c32505b4b587443e8b5583c6e44769a,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.05
-      objectReference: {fileID: 0}
-    - target: {fileID: 4569299527894993288, guid: 8c32505b4b587443e8b5583c6e44769a,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.01
-      objectReference: {fileID: 0}
-    - target: {fileID: 4569299527894993288, guid: 8c32505b4b587443e8b5583c6e44769a,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.15
-      objectReference: {fileID: 0}
-    - target: {fileID: 4569299527894993288, guid: 8c32505b4b587443e8b5583c6e44769a,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.07
-      objectReference: {fileID: 0}
-    - target: {fileID: 4569299527894993288, guid: 8c32505b4b587443e8b5583c6e44769a,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 4569299527894993288, guid: 8c32505b4b587443e8b5583c6e44769a,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 4569299527894993289, guid: 8c32505b4b587443e8b5583c6e44769a,
         type: 3}
@@ -3828,6 +3848,51 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,
         type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.11
+      objectReference: {fileID: 0}
+    - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.92
+      objectReference: {fileID: 0}
+    - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.11
+      objectReference: {fileID: 0}
+    - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.92
+      objectReference: {fileID: 0}
+    - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 200
+      objectReference: {fileID: 0}
+    - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -3840,6 +3905,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,
         type: 3}
@@ -3858,13 +3928,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,
         type: 3}
-      propertyPath: m_RootOrder
-      value: 3
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,
         type: 3}
@@ -3880,56 +3950,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 200
-      objectReference: {fileID: 0}
-    - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 200
-      objectReference: {fileID: 0}
-    - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.11
-      objectReference: {fileID: 0}
-    - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.92
-      objectReference: {fileID: 0}
-    - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.11
-      objectReference: {fileID: 0}
-    - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.92
-      objectReference: {fileID: 0}
-    - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3312996573423678127, guid: ca625f1d124a0415dae944a17da5115e,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 3312996573423678128, guid: ca625f1d124a0415dae944a17da5115e,
         type: 3}
@@ -3958,6 +3978,51 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7067239024651614270, guid: 69e021127347c4129aaa52db23e8f900,
         type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7067239024651614270, guid: 69e021127347c4129aaa52db23e8f900,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7067239024651614270, guid: 69e021127347c4129aaa52db23e8f900,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7067239024651614270, guid: 69e021127347c4129aaa52db23e8f900,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.95
+      objectReference: {fileID: 0}
+    - target: {fileID: 7067239024651614270, guid: 69e021127347c4129aaa52db23e8f900,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.07
+      objectReference: {fileID: 0}
+    - target: {fileID: 7067239024651614270, guid: 69e021127347c4129aaa52db23e8f900,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.85
+      objectReference: {fileID: 0}
+    - target: {fileID: 7067239024651614270, guid: 69e021127347c4129aaa52db23e8f900,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.01
+      objectReference: {fileID: 0}
+    - target: {fileID: 7067239024651614270, guid: 69e021127347c4129aaa52db23e8f900,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7067239024651614270, guid: 69e021127347c4129aaa52db23e8f900,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7067239024651614270, guid: 69e021127347c4129aaa52db23e8f900,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -3970,6 +4035,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7067239024651614270, guid: 69e021127347c4129aaa52db23e8f900,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7067239024651614270, guid: 69e021127347c4129aaa52db23e8f900,
         type: 3}
@@ -3988,13 +4058,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7067239024651614270, guid: 69e021127347c4129aaa52db23e8f900,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7067239024651614270, guid: 69e021127347c4129aaa52db23e8f900,
         type: 3}
-      propertyPath: m_RootOrder
-      value: 2
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7067239024651614270, guid: 69e021127347c4129aaa52db23e8f900,
         type: 3}
@@ -4010,56 +4080,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7067239024651614270, guid: 69e021127347c4129aaa52db23e8f900,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7067239024651614270, guid: 69e021127347c4129aaa52db23e8f900,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7067239024651614270, guid: 69e021127347c4129aaa52db23e8f900,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7067239024651614270, guid: 69e021127347c4129aaa52db23e8f900,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7067239024651614270, guid: 69e021127347c4129aaa52db23e8f900,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.85
-      objectReference: {fileID: 0}
-    - target: {fileID: 7067239024651614270, guid: 69e021127347c4129aaa52db23e8f900,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.01
-      objectReference: {fileID: 0}
-    - target: {fileID: 7067239024651614270, guid: 69e021127347c4129aaa52db23e8f900,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.95
-      objectReference: {fileID: 0}
-    - target: {fileID: 7067239024651614270, guid: 69e021127347c4129aaa52db23e8f900,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.07
-      objectReference: {fileID: 0}
-    - target: {fileID: 7067239024651614270, guid: 69e021127347c4129aaa52db23e8f900,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7067239024651614270, guid: 69e021127347c4129aaa52db23e8f900,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 7067239024651614271, guid: 69e021127347c4129aaa52db23e8f900,
         type: 3}

--- a/Assets/Project/Scenes/MenuSelectScene.unity
+++ b/Assets/Project/Scenes/MenuSelectScene.unity
@@ -2075,12 +2075,12 @@ PrefabInstance:
     - target: {fileID: 3838137885523574259, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 6.4159994
+      value: 4.416
       objectReference: {fileID: 0}
     - target: {fileID: 3838137885523574259, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
-      value: 6.4159994
+      value: 4.416
       objectReference: {fileID: 0}
     - target: {fileID: 4879365460225979789, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
@@ -2179,48 +2179,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
       propertyPath: m_RootOrder
       value: 9
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
@@ -2230,41 +2190,6 @@ PrefabInstance:
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
@@ -3033,12 +2958,12 @@ PrefabInstance:
     - target: {fileID: 3838137885523574259, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 6.4159994
+      value: 4.416
       objectReference: {fileID: 0}
     - target: {fileID: 3838137885523574259, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
-      value: 6.4159994
+      value: 4.416
       objectReference: {fileID: 0}
     - target: {fileID: 4879365460225979789, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
@@ -3147,48 +3072,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
       propertyPath: m_RootOrder
       value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
@@ -3198,41 +3083,6 @@ PrefabInstance:
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
@@ -4782,12 +4632,12 @@ PrefabInstance:
     - target: {fileID: 3838137885523574259, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 6.1759996
+      value: 4.416
       objectReference: {fileID: 0}
     - target: {fileID: 3838137885523574259, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
-      value: 6.1759996
+      value: 4.416
       objectReference: {fileID: 0}
     - target: {fileID: 4879365460225979789, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
@@ -4936,48 +4786,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
       propertyPath: m_RootOrder
       value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
@@ -4987,41 +4797,6 @@ PrefabInstance:
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
@@ -5448,12 +5223,12 @@ PrefabInstance:
     - target: {fileID: 3838137885523574259, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 8.02
+      value: 5.52
       objectReference: {fileID: 0}
     - target: {fileID: 3838137885523574259, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
-      value: 8.02
+      value: 5.52
       objectReference: {fileID: 0}
     - target: {fileID: 4879365460225979789, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
@@ -5552,48 +5327,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
       propertyPath: m_RootOrder
       value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
@@ -5603,41 +5338,6 @@ PrefabInstance:
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
@@ -6793,7 +6493,7 @@ PrefabInstance:
     - target: {fileID: 3838137885523574259, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_SortingLayer
-      value: -1
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3838137885523574259, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
@@ -7148,12 +6848,12 @@ PrefabInstance:
     - target: {fileID: 3838137885523574259, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 8.02
+      value: 5.52
       objectReference: {fileID: 0}
     - target: {fileID: 3838137885523574259, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
-      value: 8.02
+      value: 5.52
       objectReference: {fileID: 0}
     - target: {fileID: 3838137885523574259, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
@@ -7292,48 +6992,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
       propertyPath: m_RootOrder
       value: 8
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
@@ -7347,43 +7007,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
@@ -8360,12 +7985,12 @@ PrefabInstance:
     - target: {fileID: 3838137885523574259, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 6.4159994
+      value: 4.416
       objectReference: {fileID: 0}
     - target: {fileID: 3838137885523574259, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
-      value: 6.4159994
+      value: 4.416
       objectReference: {fileID: 0}
     - target: {fileID: 4879365460225979789, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
@@ -8464,48 +8089,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
       propertyPath: m_RootOrder
       value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
@@ -8515,41 +8100,6 @@ PrefabInstance:
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
@@ -9532,12 +9082,12 @@ PrefabInstance:
     - target: {fileID: 3838137885523574259, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 6.4159994
+      value: 4.416
       objectReference: {fileID: 0}
     - target: {fileID: 3838137885523574259, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
-      value: 6.4159994
+      value: 4.416
       objectReference: {fileID: 0}
     - target: {fileID: 4879365460225979789, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
@@ -9641,48 +9191,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
       propertyPath: m_RootOrder
       value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
@@ -9692,41 +9202,6 @@ PrefabInstance:
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
@@ -12086,12 +11561,12 @@ PrefabInstance:
     - target: {fileID: 3838137885523574259, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 9.672
+      value: 4.416
       objectReference: {fileID: 0}
     - target: {fileID: 3838137885523574259, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
-      value: 9.672
+      value: 4.416
       objectReference: {fileID: 0}
     - target: {fileID: 4879365460225979789, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
@@ -12250,47 +11725,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
       propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
@@ -12301,41 +11736,6 @@ PrefabInstance:
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
@@ -12862,12 +12262,12 @@ PrefabInstance:
     - target: {fileID: 3838137885523574259, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 6.4159994
+      value: 4.416
       objectReference: {fileID: 0}
     - target: {fileID: 3838137885523574259, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
-      value: 6.4159994
+      value: 4.416
       objectReference: {fileID: 0}
     - target: {fileID: 4879365460225979789, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
@@ -12966,48 +12366,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
       propertyPath: m_RootOrder
       value: 10
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
@@ -13017,41 +12377,6 @@ PrefabInstance:
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
@@ -13438,12 +12763,12 @@ PrefabInstance:
     - target: {fileID: 3838137885523574259, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 6.4159994
+      value: 4.416
       objectReference: {fileID: 0}
     - target: {fileID: 3838137885523574259, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
-      value: 6.4159994
+      value: 4.416
       objectReference: {fileID: 0}
     - target: {fileID: 4879365460225979789, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
@@ -13542,48 +12867,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
       propertyPath: m_RootOrder
       value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
@@ -13593,41 +12878,6 @@ PrefabInstance:
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
@@ -17997,12 +17247,12 @@ PrefabInstance:
     - target: {fileID: 3838137885523574259, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 7.7200003
+      value: 5.52
       objectReference: {fileID: 0}
     - target: {fileID: 3838137885523574259, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
-      value: 7.7200003
+      value: 5.52
       objectReference: {fileID: 0}
     - target: {fileID: 3838137885523574259, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
@@ -18176,48 +17426,8 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
       propertyPath: m_RootOrder
       value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
@@ -18227,41 +17437,6 @@ PrefabInstance:
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,

--- a/Assets/Project/Scenes/MenuSelectScene.unity
+++ b/Assets/Project/Scenes/MenuSelectScene.unity
@@ -397,6 +397,7 @@ GameObject:
   - component: {fileID: 51343194}
   - component: {fileID: 51343193}
   - component: {fileID: 51343192}
+  - component: {fileID: 51343191}
   m_Layer: 5
   m_Name: On
   m_TagString: Untagged
@@ -422,8 +423,22 @@ RectTransform:
   m_AnchorMin: {x: 0.6, y: 0}
   m_AnchorMax: {x: 0.7, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: -47.788475, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &51343191
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 51343189}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_AspectMode: 2
+  m_AspectRatio: 1
 --- !u!114 &51343192
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2379,6 +2394,7 @@ GameObject:
   - component: {fileID: 460448371}
   - component: {fileID: 460448370}
   - component: {fileID: 460448369}
+  - component: {fileID: 460448368}
   m_Layer: 5
   m_Name: Off
   m_TagString: Untagged
@@ -2404,8 +2420,22 @@ RectTransform:
   m_AnchorMin: {x: 0.8, y: 0}
   m_AnchorMax: {x: 0.9, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: -47.788475, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &460448368
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 460448366}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_AspectMode: 2
+  m_AspectRatio: 1
 --- !u!114 &460448369
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3623,6 +3653,7 @@ GameObject:
   - component: {fileID: 741065209}
   - component: {fileID: 741065208}
   - component: {fileID: 741065207}
+  - component: {fileID: 741065206}
   m_Layer: 5
   m_Name: Button
   m_TagString: Untagged
@@ -3647,8 +3678,22 @@ RectTransform:
   m_AnchorMin: {x: 0.7, y: 0}
   m_AnchorMax: {x: 0.8, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: -47.78856, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &741065206
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 741065204}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_AspectMode: 2
+  m_AspectRatio: 1
 --- !u!114 &741065207
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5280,6 +5325,24 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 08bc31bccfd004d24846b057a089c860, type: 3}
+--- !u!1 &844389622 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1664642187462754051, guid: 08bc31bccfd004d24846b057a089c860,
+    type: 3}
+  m_PrefabInstance: {fileID: 844389621}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &844389623
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 844389622}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb219b23cdf4b314f94a27bca3cc8012, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!120 &863611862 stripped
 LineRenderer:
   m_CorrespondingSourceObject: {fileID: 3838137885523574259, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
@@ -5371,6 +5434,24 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 879018555}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &879018557 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1664642187462754051, guid: 08bc31bccfd004d24846b057a089c860,
+    type: 3}
+  m_PrefabInstance: {fileID: 879018555}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &879018558
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 879018557}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb219b23cdf4b314f94a27bca3cc8012, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &921726172
 GameObject:
   m_ObjectHideFlags: 0
@@ -6680,6 +6761,7 @@ GameObject:
   - component: {fileID: 1108274622}
   - component: {fileID: 1108274621}
   - component: {fileID: 1108274620}
+  - component: {fileID: 1108274623}
   m_Layer: 5
   m_Name: Button
   m_TagString: Untagged
@@ -6704,7 +6786,7 @@ RectTransform:
   m_AnchorMin: {x: 0.7, y: 0}
   m_AnchorMax: {x: 0.8, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: -47.78868, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1108274620
 MonoBehaviour:
@@ -6800,6 +6882,20 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1108274618}
   m_CullTransparentMesh: 0
+--- !u!114 &1108274623
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1108274618}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_AspectMode: 2
+  m_AspectRatio: 1
 --- !u!1 &1116460071
 GameObject:
   m_ObjectHideFlags: 0
@@ -7202,6 +7298,24 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 1250207268}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1250207270 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1664642187462754051, guid: 08bc31bccfd004d24846b057a089c860,
+    type: 3}
+  m_PrefabInstance: {fileID: 1250207268}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1250207271
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1250207270}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb219b23cdf4b314f94a27bca3cc8012, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1264325515
 GameObject:
   m_ObjectHideFlags: 0
@@ -7872,6 +7986,7 @@ GameObject:
   - component: {fileID: 1335406307}
   - component: {fileID: 1335406306}
   - component: {fileID: 1335406305}
+  - component: {fileID: 1335406309}
   m_Layer: 5
   m_Name: Button
   m_TagString: Untagged
@@ -7896,7 +8011,7 @@ RectTransform:
   m_AnchorMin: {x: 0.7, y: 0}
   m_AnchorMax: {x: 0.8, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: -47.78868, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1335406305
 MonoBehaviour:
@@ -7992,6 +8107,20 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1335406303}
   m_CullTransparentMesh: 0
+--- !u!114 &1335406309
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1335406303}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_AspectMode: 2
+  m_AspectRatio: 1
 --- !u!224 &1336693882 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
@@ -8095,6 +8224,24 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 1405235384}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1405235386 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1664642187462754051, guid: 08bc31bccfd004d24846b057a089c860,
+    type: 3}
+  m_PrefabInstance: {fileID: 1405235384}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1405235387
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1405235386}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb219b23cdf4b314f94a27bca3cc8012, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1431962647 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 5235287849498325587, guid: b96ed1f8e21744424bcf6618ef1e699c,
@@ -8983,6 +9130,24 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 1593434312}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1593434314 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1664642187462754051, guid: 08bc31bccfd004d24846b057a089c860,
+    type: 3}
+  m_PrefabInstance: {fileID: 1593434312}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1593434315
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1593434314}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb219b23cdf4b314f94a27bca3cc8012, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!224 &1637709450 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
@@ -9546,6 +9711,24 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 1677661538}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1677661540 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1664642187462754051, guid: 08bc31bccfd004d24846b057a089c860,
+    type: 3}
+  m_PrefabInstance: {fileID: 1677661538}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1677661541
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1677661540}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb219b23cdf4b314f94a27bca3cc8012, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!224 &1690789595 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
@@ -9649,6 +9832,24 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 1697360296}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1697360298 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1664642187462754051, guid: 08bc31bccfd004d24846b057a089c860,
+    type: 3}
+  m_PrefabInstance: {fileID: 1697360296}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1697360299
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1697360298}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb219b23cdf4b314f94a27bca3cc8012, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1703073294
 GameObject:
   m_ObjectHideFlags: 0
@@ -11060,7 +11261,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: -1, y: -0.5}
   m_AnchorMax: {x: 2, y: 1.5}
-  m_AnchoredPosition: {x: 61.516846, y: 496.28125}
+  m_AnchoredPosition: {x: 54.330322, y: 0.00061035156}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1755488822
@@ -12589,6 +12790,24 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 2027894072}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &2027894074 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1664642187462754051, guid: 08bc31bccfd004d24846b057a089c860,
+    type: 3}
+  m_PrefabInstance: {fileID: 2027894072}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2027894075
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2027894074}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb219b23cdf4b314f94a27bca3cc8012, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &2089056029
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Project/Scenes/MenuSelectScene.unity
+++ b/Assets/Project/Scenes/MenuSelectScene.unity
@@ -2186,7 +2186,7 @@ PrefabInstance:
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -2246,6 +2246,24 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 422805984}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &422805986 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1664642187462754051, guid: 08bc31bccfd004d24846b057a089c860,
+    type: 3}
+  m_PrefabInstance: {fileID: 422805984}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &422805987
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 422805986}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb219b23cdf4b314f94a27bca3cc8012, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &452631590
 GameObject:
   m_ObjectHideFlags: 0
@@ -5208,7 +5226,7 @@ PrefabInstance:
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -5293,7 +5311,7 @@ PrefabInstance:
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -7124,7 +7142,7 @@ PrefabInstance:
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -8017,7 +8035,7 @@ PrefabInstance:
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -8920,7 +8938,7 @@ PrefabInstance:
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -9483,7 +9501,7 @@ PrefabInstance:
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -9571,7 +9589,7 @@ PrefabInstance:
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -11082,7 +11100,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &1769646741
 Transform:
   m_ObjectHideFlags: 0
@@ -12432,7 +12450,7 @@ RectTransform:
   m_AnchorMin: {x: 0.05, y: 0.2}
   m_AnchorMax: {x: 0.2, y: 0.8}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: -21.020023, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2004702743
 MonoBehaviour:
@@ -12511,7 +12529,7 @@ PrefabInstance:
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -12735,7 +12753,7 @@ PrefabInstance:
     - target: {fileID: 1895509404674607651, guid: 25cde20b8e9ec439ea7b6eae480a5fd6,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: -57.80821
       objectReference: {fileID: 0}
     - target: {fileID: 5011158369800850438, guid: 25cde20b8e9ec439ea7b6eae480a5fd6,
         type: 3}
@@ -12855,32 +12873,32 @@ PrefabInstance:
     - target: {fileID: 7629993261386405475, guid: 25cde20b8e9ec439ea7b6eae480a5fd6,
         type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8617964820839360578, guid: 25cde20b8e9ec439ea7b6eae480a5fd6,
         type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8617964821098804612, guid: 25cde20b8e9ec439ea7b6eae480a5fd6,
         type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8617964821259016457, guid: 25cde20b8e9ec439ea7b6eae480a5fd6,
         type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8617964821752042630, guid: 25cde20b8e9ec439ea7b6eae480a5fd6,
         type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8617964821934958503, guid: 25cde20b8e9ec439ea7b6eae480a5fd6,
         type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 25cde20b8e9ec439ea7b6eae480a5fd6, type: 3}
@@ -12909,7 +12927,7 @@ PrefabInstance:
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -12969,6 +12987,24 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 4737506518457277452}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &4737506518457277454 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1664642187462754051, guid: 08bc31bccfd004d24846b057a089c860,
+    type: 3}
+  m_PrefabInstance: {fileID: 4737506518457277452}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &4737506518457277455
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4737506518457277454}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb219b23cdf4b314f94a27bca3cc8012, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &4737506518560137100
 GameObject:
   m_ObjectHideFlags: 0
@@ -13414,7 +13450,7 @@ RectTransform:
   m_AnchorMin: {x: 0.05, y: 0.05}
   m_AnchorMax: {x: 0.55, y: 0.95}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: -121.97328, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4737506518971929310
 CanvasRenderer:
@@ -13583,7 +13619,7 @@ RectTransform:
   m_AnchorMin: {x: 0.2, y: 0.1}
   m_AnchorMax: {x: 0.4, y: 0.9}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: -62.377213, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4737506519137269894
 CanvasRenderer:
@@ -13742,7 +13778,7 @@ RectTransform:
   m_AnchorMin: {x: 0.75, y: 0.1}
   m_AnchorMax: {x: 0.9, y: 0.9}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: -17.56729}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &4737506519288575057
 GameObject:
@@ -13917,7 +13953,7 @@ PrefabInstance:
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -13982,6 +14018,24 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 4737506519379421071}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &4737506519379421073 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1664642187462754051, guid: 08bc31bccfd004d24846b057a089c860,
+    type: 3}
+  m_PrefabInstance: {fileID: 4737506519379421071}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &4737506519379421074
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4737506519379421073}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb219b23cdf4b314f94a27bca3cc8012, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!224 &4737506519428607950
 RectTransform:
   m_ObjectHideFlags: 0
@@ -14287,7 +14341,7 @@ PrefabInstance:
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -14352,6 +14406,24 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 4737506519517823562}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &4737506519517823564 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1664642187462754051, guid: 08bc31bccfd004d24846b057a089c860,
+    type: 3}
+  m_PrefabInstance: {fileID: 4737506519517823562}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &4737506519517823565
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4737506519517823564}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb219b23cdf4b314f94a27bca3cc8012, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &4737506519555198466
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -14377,7 +14449,7 @@ PrefabInstance:
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -14442,6 +14514,24 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 4737506519555198466}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &4737506519555198468 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1664642187462754051, guid: 08bc31bccfd004d24846b057a089c860,
+    type: 3}
+  m_PrefabInstance: {fileID: 4737506519555198466}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &4737506519555198469
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4737506519555198468}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb219b23cdf4b314f94a27bca3cc8012, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!224 &4737506519592329780
 RectTransform:
   m_ObjectHideFlags: 0
@@ -14459,7 +14549,7 @@ RectTransform:
   m_AnchorMin: {x: 0.2, y: 0.1}
   m_AnchorMax: {x: 0.4, y: 0.9}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: -47.502014, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &4737506519592329781
 GameObject:
@@ -14563,7 +14653,7 @@ PrefabInstance:
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -14623,6 +14713,24 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 4737506519790836998}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &4737506519790837000 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1664642187462754051, guid: 08bc31bccfd004d24846b057a089c860,
+    type: 3}
+  m_PrefabInstance: {fileID: 4737506519790836998}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &4737506519790837001
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4737506519790837000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb219b23cdf4b314f94a27bca3cc8012, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!224 &4737506520016986845 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 2196075647019294311, guid: a605ec9ee614346558f5d02cf0196b32,
@@ -14779,7 +14887,7 @@ PrefabInstance:
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -14844,6 +14952,24 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 4737506520044020163}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &4737506520044020165 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1664642187462754051, guid: 08bc31bccfd004d24846b057a089c860,
+    type: 3}
+  m_PrefabInstance: {fileID: 4737506520044020163}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &4737506520044020166
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4737506520044020165}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb219b23cdf4b314f94a27bca3cc8012, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &4737506520051993172
 GameObject:
   m_ObjectHideFlags: 0
@@ -15145,7 +15271,7 @@ RectTransform:
   m_AnchorMin: {x: 0.8, y: 0.2}
   m_AnchorMax: {x: 0.95, y: 0.8}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: -21.020023, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &4737506520254146917
 GameObject:
@@ -15607,7 +15733,7 @@ RectTransform:
   m_AnchorMin: {x: 0.2, y: 0.1}
   m_AnchorMax: {x: 0.4, y: 0.9}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: -76.68024, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4737506520501421124
 CanvasRenderer:
@@ -16126,7 +16252,7 @@ PrefabInstance:
     - target: {fileID: 2196075646878559049, guid: a605ec9ee614346558f5d02cf0196b32,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: -57.80821
       objectReference: {fileID: 0}
     - target: {fileID: 2196075647019294304, guid: a605ec9ee614346558f5d02cf0196b32,
         type: 3}
@@ -16186,7 +16312,7 @@ PrefabInstance:
     - target: {fileID: 7914824122101692169, guid: a605ec9ee614346558f5d02cf0196b32,
         type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a605ec9ee614346558f5d02cf0196b32, type: 3}
@@ -16196,3 +16322,21 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 6900928868292312250}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &6900928868292312252 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 676657140756201007, guid: a605ec9ee614346558f5d02cf0196b32,
+    type: 3}
+  m_PrefabInstance: {fileID: 6900928868292312250}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &6900928868292312253
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6900928868292312252}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb219b23cdf4b314f94a27bca3cc8012, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Project/Scenes/MenuSelectScene.unity
+++ b/Assets/Project/Scenes/MenuSelectScene.unity
@@ -1198,21 +1198,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -1371,21 +1356,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
@@ -1801,21 +1771,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
@@ -4080,21 +4035,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -4243,21 +4183,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
@@ -6252,21 +6177,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -7415,21 +7325,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
@@ -9414,21 +9309,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -10124,21 +10004,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
@@ -12547,21 +12412,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -13051,21 +12901,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
@@ -13698,21 +13533,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}

--- a/Assets/Project/Scenes/MenuSelectScene.unity
+++ b/Assets/Project/Scenes/MenuSelectScene.unity
@@ -2183,15 +2183,10 @@ PrefabInstance:
       propertyPath: _indexStr
       value: RecordToGeneralButton
       objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+    - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
+      propertyPath: m_Enabled
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -2220,57 +2215,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
@@ -11132,7 +11082,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &1769646741
 Transform:
   m_ObjectHideFlags: 0
@@ -12782,6 +12732,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 4737506518873865455}
     m_Modifications:
+    - target: {fileID: 1895509404674607651, guid: 25cde20b8e9ec439ea7b6eae480a5fd6,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 5011158369800850438, guid: 25cde20b8e9ec439ea7b6eae480a5fd6,
         type: 3}
       propertyPath: m_Name
@@ -12897,6 +12852,36 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: -100
       objectReference: {fileID: 0}
+    - target: {fileID: 7629993261386405475, guid: 25cde20b8e9ec439ea7b6eae480a5fd6,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8617964820839360578, guid: 25cde20b8e9ec439ea7b6eae480a5fd6,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8617964821098804612, guid: 25cde20b8e9ec439ea7b6eae480a5fd6,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8617964821259016457, guid: 25cde20b8e9ec439ea7b6eae480a5fd6,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8617964821752042630, guid: 25cde20b8e9ec439ea7b6eae480a5fd6,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8617964821934958503, guid: 25cde20b8e9ec439ea7b6eae480a5fd6,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 25cde20b8e9ec439ea7b6eae480a5fd6, type: 3}
 --- !u!1001 &4737506518457277452
@@ -12921,15 +12906,10 @@ PrefabInstance:
       propertyPath: _indexStr
       value: RecordToIndividualButton
       objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+    - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
+      propertyPath: m_Enabled
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -12958,57 +12938,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
@@ -13479,7 +13414,7 @@ RectTransform:
   m_AnchorMin: {x: 0.05, y: 0.05}
   m_AnchorMax: {x: 0.55, y: 0.95}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: -11.988355, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4737506518971929310
 CanvasRenderer:
@@ -13648,7 +13583,7 @@ RectTransform:
   m_AnchorMin: {x: 0.2, y: 0.1}
   m_AnchorMax: {x: 0.4, y: 0.9}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: -19.791325, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4737506519137269894
 CanvasRenderer:
@@ -13807,7 +13742,7 @@ RectTransform:
   m_AnchorMin: {x: 0.75, y: 0.1}
   m_AnchorMax: {x: 0.9, y: 0.9}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: -33.35776}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &4737506519288575057
 GameObject:
@@ -13981,18 +13916,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_FontData.m_Alignment
+      propertyPath: m_Enabled
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+    - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
+      propertyPath: m_FontData.m_Alignment
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -14021,57 +13951,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
@@ -14401,18 +14286,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
       propertyPath: m_FontData.m_Alignment
       value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -14441,57 +14321,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
@@ -14541,18 +14376,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
       propertyPath: m_FontData.m_Alignment
       value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -14581,57 +14411,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
@@ -14674,7 +14459,7 @@ RectTransform:
   m_AnchorMin: {x: 0.2, y: 0.1}
   m_AnchorMax: {x: 0.4, y: 0.9}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: -3.3746982, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &4737506519592329781
 GameObject:
@@ -14775,15 +14560,10 @@ PrefabInstance:
       propertyPath: _indexStr
       value: RecordShareButton
       objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+    - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
+      propertyPath: m_Enabled
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -14812,57 +14592,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
@@ -15043,18 +14778,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
       propertyPath: m_FontData.m_Alignment
       value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -15083,57 +14813,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
@@ -15799,16 +15484,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
       propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
@@ -15834,57 +15509,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
@@ -15977,7 +15607,7 @@ RectTransform:
   m_AnchorMin: {x: 0.2, y: 0.1}
   m_AnchorMax: {x: 0.4, y: 0.9}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: -35.576664, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4737506520501421124
 CanvasRenderer:
@@ -16493,20 +16123,15 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 4737506518726312918}
     m_Modifications:
+    - target: {fileID: 2196075646878559049, guid: a605ec9ee614346558f5d02cf0196b32,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2196075647019294304, guid: a605ec9ee614346558f5d02cf0196b32,
         type: 3}
       propertyPath: m_Name
       value: ClearStageNum
-      objectReference: {fileID: 0}
-    - target: {fileID: 2196075647019294311, guid: a605ec9ee614346558f5d02cf0196b32,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 2196075647019294311, guid: a605ec9ee614346558f5d02cf0196b32,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 2196075647019294311, guid: a605ec9ee614346558f5d02cf0196b32,
         type: 3}
@@ -16535,57 +16160,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2196075647019294311, guid: a605ec9ee614346558f5d02cf0196b32,
         type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2196075647019294311, guid: a605ec9ee614346558f5d02cf0196b32,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2196075647019294311, guid: a605ec9ee614346558f5d02cf0196b32,
-        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2196075647019294311, guid: a605ec9ee614346558f5d02cf0196b32,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2196075647019294311, guid: a605ec9ee614346558f5d02cf0196b32,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2196075647019294311, guid: a605ec9ee614346558f5d02cf0196b32,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2196075647019294311, guid: a605ec9ee614346558f5d02cf0196b32,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2196075647019294311, guid: a605ec9ee614346558f5d02cf0196b32,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2196075647019294311, guid: a605ec9ee614346558f5d02cf0196b32,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2196075647019294311, guid: a605ec9ee614346558f5d02cf0196b32,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2196075647019294311, guid: a605ec9ee614346558f5d02cf0196b32,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2196075647019294311, guid: a605ec9ee614346558f5d02cf0196b32,
@@ -16601,6 +16181,11 @@ PrefabInstance:
     - target: {fileID: 2196075647019294311, guid: a605ec9ee614346558f5d02cf0196b32,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7914824122101692169, guid: a605ec9ee614346558f5d02cf0196b32,
+        type: 3}
+      propertyPath: m_Enabled
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []

--- a/Assets/Project/Scenes/MenuSelectScene.unity
+++ b/Assets/Project/Scenes/MenuSelectScene.unity
@@ -2552,47 +2552,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
       propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
@@ -2603,41 +2563,6 @@ PrefabInstance:
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
@@ -3510,8 +3435,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.25}
   m_AnchorMax: {x: 1, y: 0.75}
-  m_AnchoredPosition: {x: -5, y: 0}
-  m_SizeDelta: {x: -20, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &670076259
 GameObject:
@@ -4720,8 +4645,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.25}
   m_AnchorMax: {x: 1, y: 0.75}
-  m_AnchoredPosition: {x: -5, y: 0}
-  m_SizeDelta: {x: -20, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &754060110
 GameObject:
@@ -4834,7 +4759,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0.5, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 10, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &779574078
 MonoBehaviour:
@@ -5333,17 +5258,7 @@ PrefabInstance:
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
       propertyPath: m_Enabled
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -5372,57 +5287,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
@@ -5470,15 +5340,10 @@ PrefabInstance:
       propertyPath: _indexStr
       value: SettingsSE
       objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+    - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
+      propertyPath: m_Enabled
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -5507,57 +5372,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
@@ -5740,7 +5560,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0.5, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 10, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &940445381
 MonoBehaviour:
@@ -7339,7 +7159,7 @@ PrefabInstance:
     - target: {fileID: 1664642187462754051, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
       propertyPath: m_Name
-      value: Base Multi Language Text
+      value: SettingsTitle
       objectReference: {fileID: 0}
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -7351,15 +7171,10 @@ PrefabInstance:
       propertyPath: _indexStr
       value: SettingsTitle
       objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+    - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
+      propertyPath: m_Enabled
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -7388,57 +7203,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
@@ -7969,7 +7739,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: -20, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1298694463
 GameObject:
@@ -8294,15 +8064,10 @@ PrefabInstance:
       propertyPath: _indexStr
       value: SettingsBGM
       objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+    - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
+      propertyPath: m_Enabled
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -8331,57 +8096,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
@@ -9071,7 +8791,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: -20, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1560756402 stripped
 GameObject:
@@ -9249,52 +8969,17 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
       propertyPath: m_FontData.m_MaxSize
       value: 80
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
       propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
@@ -9305,41 +8990,6 @@ PrefabInstance:
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
@@ -9575,16 +9225,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
       propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
@@ -9610,57 +9250,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
@@ -9937,52 +9532,17 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
       propertyPath: m_FontData.m_MaxSize
       value: 80
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
       propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
@@ -9993,41 +9553,6 @@ PrefabInstance:
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
@@ -10093,15 +9618,10 @@ PrefabInstance:
       propertyPath: _indexStr
       value: SettingsReset
       objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+    - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
+      propertyPath: m_Enabled
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -10130,57 +9650,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
@@ -11693,47 +11168,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
       propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
@@ -11744,41 +11179,6 @@ PrefabInstance:
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6792794817334903578, guid: bef1ce286d5014a08b1dda0760b28ee2,
@@ -13158,15 +12558,10 @@ PrefabInstance:
       propertyPath: _indexStr
       value: SettingsStageDetails
       objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+    - target: {fileID: 8335351129932690981, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
+      propertyPath: m_Enabled
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -13195,57 +12590,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,

--- a/Assets/Project/Scenes/MenuSelectScene.unity
+++ b/Assets/Project/Scenes/MenuSelectScene.unity
@@ -1164,7 +1164,7 @@ PrefabInstance:
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 12
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
@@ -1340,7 +1340,7 @@ PrefabInstance:
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 23
+      value: 22
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
@@ -1551,6 +1551,7 @@ GameObject:
   m_Component:
   - component: {fileID: 333497133}
   - component: {fileID: 333497134}
+  - component: {fileID: 333497135}
   m_Layer: 5
   m_Name: Record
   m_TagString: Untagged
@@ -1576,7 +1577,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0}
   m_AnchorMax: {x: 0.5, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 200, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &333497134
 MonoBehaviour:
@@ -1639,6 +1640,20 @@ MonoBehaviour:
           m_BoolArgument: 0
         m_CallState: 2
   m_IsOn: 0
+--- !u!114 &333497135
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 333497132}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_AspectMode: 2
+  m_AspectRatio: 1
 --- !u!1001 &347578284
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1750,7 +1765,7 @@ PrefabInstance:
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 22
+      value: 21
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
@@ -2175,7 +2190,7 @@ PrefabInstance:
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 10
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
@@ -3143,7 +3158,7 @@ PrefabInstance:
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
@@ -4181,7 +4196,7 @@ PrefabInstance:
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 21
+      value: 20
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
@@ -4347,7 +4362,7 @@ PrefabInstance:
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 20
+      value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
@@ -4932,7 +4947,7 @@ PrefabInstance:
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
@@ -5548,7 +5563,7 @@ PrefabInstance:
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
@@ -6503,7 +6518,7 @@ PrefabInstance:
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 19
+      value: 18
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
@@ -7288,7 +7303,7 @@ PrefabInstance:
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
@@ -7744,7 +7759,7 @@ PrefabInstance:
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 18
+      value: 17
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
@@ -8460,7 +8475,7 @@ PrefabInstance:
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 8
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
@@ -9147,6 +9162,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1457067512}
   - component: {fileID: 1457067513}
+  - component: {fileID: 1457067514}
   m_Layer: 5
   m_Name: LevelSelect
   m_TagString: Untagged
@@ -9172,7 +9188,7 @@ RectTransform:
   m_AnchorMin: {x: 0.158, y: 0}
   m_AnchorMax: {x: 0.158, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 200, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1457067513
 MonoBehaviour:
@@ -9235,6 +9251,20 @@ MonoBehaviour:
           m_BoolArgument: 0
         m_CallState: 2
   m_IsOn: 1
+--- !u!114 &1457067514
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1457067511}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_AspectMode: 2
+  m_AspectRatio: 1
 --- !u!1 &1483490499
 GameObject:
   m_ObjectHideFlags: 0
@@ -9622,7 +9652,7 @@ PrefabInstance:
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
@@ -9875,7 +9905,7 @@ PrefabInstance:
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 17
+      value: 16
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
@@ -10168,6 +10198,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1654575051}
   - component: {fileID: 1654575052}
+  - component: {fileID: 1654575053}
   m_Layer: 5
   m_Name: Config
   m_TagString: Untagged
@@ -10193,7 +10224,7 @@ RectTransform:
   m_AnchorMin: {x: 0.842, y: 0}
   m_AnchorMax: {x: 0.842, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 200, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1654575052
 MonoBehaviour:
@@ -10256,6 +10287,20 @@ MonoBehaviour:
           m_BoolArgument: 0
         m_CallState: 2
   m_IsOn: 0
+--- !u!114 &1654575053
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1654575050}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_AspectMode: 2
+  m_AspectRatio: 1
 --- !u!1001 &1665814239
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -10573,7 +10618,7 @@ PrefabInstance:
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 16
+      value: 15
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
@@ -12216,7 +12261,7 @@ PrefabInstance:
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
@@ -12412,7 +12457,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: -1, y: -0.5}
   m_AnchorMax: {x: 2, y: 1.5}
-  m_AnchoredPosition: {x: 403.38965, y: 891.52625}
+  m_AnchoredPosition: {x: 61.516846, y: 496.28125}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1755488822
@@ -12932,7 +12977,7 @@ PrefabInstance:
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 11
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
@@ -13143,7 +13188,7 @@ PrefabInstance:
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 15
+      value: 14
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
@@ -13508,7 +13553,7 @@ PrefabInstance:
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
@@ -13725,7 +13770,7 @@ PrefabInstance:
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 14
+      value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
@@ -14372,7 +14417,7 @@ PrefabInstance:
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 13
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
@@ -18142,7 +18187,7 @@ PrefabInstance:
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}

--- a/Assets/Project/Scenes/MenuSelectScene.unity
+++ b/Assets/Project/Scenes/MenuSelectScene.unity
@@ -1169,7 +1169,7 @@ PrefabInstance:
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 0.708
+      value: 0.634
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
@@ -1179,7 +1179,7 @@ PrefabInstance:
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0.56
+      value: 0.634
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
@@ -1189,21 +1189,6 @@ PrefabInstance:
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents:
@@ -1330,7 +1315,7 @@ PrefabInstance:
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 0.396
+      value: 0.323
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
@@ -1340,7 +1325,7 @@ PrefabInstance:
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0.25
+      value: 0.323
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
@@ -1354,17 +1339,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
+      propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents:
@@ -1740,7 +1715,7 @@ PrefabInstance:
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 0.414
+      value: 0.341
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
@@ -1750,7 +1725,7 @@ PrefabInstance:
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0.268
+      value: 0.341
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
@@ -1764,22 +1739,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents:
@@ -4006,7 +3966,7 @@ PrefabInstance:
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 0.424
+      value: 0.351
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
@@ -4016,7 +3976,7 @@ PrefabInstance:
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0.278
+      value: 0.351
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
@@ -4030,17 +3990,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
+      propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents:
@@ -4157,7 +4107,7 @@ PrefabInstance:
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 0.438
+      value: 0.365
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
@@ -4167,7 +4117,7 @@ PrefabInstance:
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0.292
+      value: 0.365
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
@@ -4181,17 +4131,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
+      propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents:
@@ -6148,7 +6088,7 @@ PrefabInstance:
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 0.221
+      value: 0.148
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
@@ -6158,7 +6098,7 @@ PrefabInstance:
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0.075
+      value: 0.148
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
@@ -6172,17 +6112,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
+      propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents:
@@ -7299,7 +7229,7 @@ PrefabInstance:
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 0.734
+      value: 0.661
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
@@ -7309,7 +7239,7 @@ PrefabInstance:
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0.588
+      value: 0.661
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
@@ -7319,21 +7249,6 @@ PrefabInstance:
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents:
@@ -9280,7 +9195,7 @@ PrefabInstance:
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 0.771
+      value: 0.698
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
@@ -9290,7 +9205,7 @@ PrefabInstance:
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0.625
+      value: 0.698
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
@@ -9304,17 +9219,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
+      propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents:
@@ -9978,7 +9883,7 @@ PrefabInstance:
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 0.951
+      value: 0.878
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
@@ -9988,7 +9893,7 @@ PrefabInstance:
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0.805
+      value: 0.878
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
@@ -10002,17 +9907,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
+      propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents:
@@ -12383,7 +12278,7 @@ PrefabInstance:
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 0.766
+      value: 0.693
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
@@ -12393,7 +12288,7 @@ PrefabInstance:
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0.62
+      value: 0.693
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
@@ -12407,17 +12302,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
+      propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents:
@@ -12875,7 +12760,7 @@ PrefabInstance:
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 0.952
+      value: 0.879
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
@@ -12885,7 +12770,7 @@ PrefabInstance:
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0.806
+      value: 0.879
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
@@ -12899,17 +12784,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
+      propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents:
@@ -13507,7 +13382,7 @@ PrefabInstance:
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 0.208
+      value: 0.135
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
@@ -13517,7 +13392,7 @@ PrefabInstance:
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0.062
+      value: 0.135
       objectReference: {fileID: 0}
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
@@ -13527,21 +13402,6 @@ PrefabInstance:
     - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents:

--- a/Assets/Project/Scenes/StageSelectScene/AutumnStageSelectScene.unity
+++ b/Assets/Project/Scenes/StageSelectScene/AutumnStageSelectScene.unity
@@ -737,6 +737,11 @@ PrefabInstance:
       propertyPath: _synchronizedObject
       value: 
       objectReference: {fileID: 645323351}
+    - target: {fileID: 1706829440290082588, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 1706829440290082589, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target

--- a/Assets/Project/Scenes/StageSelectScene/AutumnStageSelectScene.unity
+++ b/Assets/Project/Scenes/StageSelectScene/AutumnStageSelectScene.unity
@@ -575,7 +575,7 @@ PrefabInstance:
     - target: {fileID: 573118182058223355, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Positions.Array.data[0].y
-      value: -354.43805
+      value: -354.43802
       objectReference: {fileID: 0}
     - target: {fileID: 573118182058223355, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
@@ -590,12 +590,12 @@ PrefabInstance:
     - target: {fileID: 573118182058223355, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 2.61
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 573118182058223355, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
-      value: 2.61
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 573118182729258555, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
@@ -779,152 +779,152 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1783978663594912645, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978663609125011, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978663650769536, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978663692615616, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978663706842046, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978663793950197, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978663849243738, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978663948744303, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978663952612256, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978664052859434, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978664091411225, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978664162049977, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978664237072558, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978664484292865, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978664623811254, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978664639787118, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978664833175417, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978664955578070, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665026509430, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665165046479, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665169047296, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665183257470, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665353984083, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665395571264, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665467118575, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665508401660, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665529299690, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665594111130, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665681611473, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665697446752, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1967303504219061099, guid: 28c9fd4dd33d84b6b82b268bb586c041,
@@ -1172,6 +1172,16 @@ PrefabInstance:
       propertyPath: _treeId
       value: 2002
       objectReference: {fileID: 0}
+    - target: {fileID: 2769182992417174427, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2858480898278879926, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 2.1240053
+      objectReference: {fileID: 0}
     - target: {fileID: 3286706064571676531, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
@@ -1400,7 +1410,7 @@ PrefabInstance:
     - target: {fileID: 4916405834754185304, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Positions.Array.data[1].y
-      value: 118.145996
+      value: 118.145935
       objectReference: {fileID: 0}
     - target: {fileID: 4916405834754185304, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
@@ -1410,12 +1420,12 @@ PrefabInstance:
     - target: {fileID: 4916405834754185304, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 2.61
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 4916405834754185304, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
-      value: 2.61
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 5056174322894115338, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
@@ -1430,7 +1440,7 @@ PrefabInstance:
     - target: {fileID: 5056174322894115338, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Positions.Array.data[1].y
-      value: 118.145996
+      value: 118.145935
       objectReference: {fileID: 0}
     - target: {fileID: 5056174322894115338, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
@@ -1440,12 +1450,12 @@ PrefabInstance:
     - target: {fileID: 5056174322894115338, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 2.61
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 5056174322894115338, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
-      value: 2.61
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 5056174323207920549, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
@@ -1715,12 +1725,12 @@ PrefabInstance:
     - target: {fileID: 7250407284600580966, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Positions.Array.data[0].x
-      value: 11.24884
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7250407284600580966, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Positions.Array.data[0].y
-      value: -708.87604
+      value: -708.8761
       objectReference: {fileID: 0}
     - target: {fileID: 7250407284600580966, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
@@ -1730,7 +1740,7 @@ PrefabInstance:
     - target: {fileID: 7250407284600580966, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Positions.Array.data[1].y
-      value: -354.43805
+      value: -354.43802
       objectReference: {fileID: 0}
     - target: {fileID: 7250407284600580966, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
@@ -1740,12 +1750,162 @@ PrefabInstance:
     - target: {fileID: 7250407284600580966, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 2.61
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 7250407284600580966, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
-      value: 2.61
+      value: 1.6559999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746777471075703, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746777610462912, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746777857159023, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746777932058744, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778002951384, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778042027499, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778142020705, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778145495470, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778245258139, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778300027444, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778388053119, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778402148353, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778444125505, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778485368658, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778499449924, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778544661665, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778560234768, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778647866203, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778713079083, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778733059645, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778774727726, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778846799233, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778888001426, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746779059113151, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746779073192129, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746779076537614, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746779215869367, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746779286530327, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746779408408760, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746779601936303, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7960581567240511975, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
@@ -1845,7 +2005,7 @@ PrefabInstance:
     - target: {fileID: 8825361915958900934, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Positions.Array.data[1].y
-      value: 354.438
+      value: 354.43805
       objectReference: {fileID: 0}
     - target: {fileID: 8825361915958900934, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
@@ -1855,12 +2015,12 @@ PrefabInstance:
     - target: {fileID: 8825361915958900934, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 2.61
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 8825361915958900934, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
-      value: 2.61
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 8970548248505820349, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}

--- a/Assets/Project/Scenes/StageSelectScene/SpringStageSelectScene.unity
+++ b/Assets/Project/Scenes/StageSelectScene/SpringStageSelectScene.unity
@@ -523,6 +523,11 @@ PrefabInstance:
       propertyPath: _synchronizedObject
       value: 
       objectReference: {fileID: 1004117054}
+    - target: {fileID: 1706829440290082588, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 1706829440290082589, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
@@ -541,6 +546,11 @@ PrefabInstance:
     - target: {fileID: 1706829441294677237, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1706829441294677237, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978663594912645, guid: 28c9fd4dd33d84b6b82b268bb586c041,

--- a/Assets/Project/Scenes/StageSelectScene/SpringStageSelectScene.unity
+++ b/Assets/Project/Scenes/StageSelectScene/SpringStageSelectScene.unity
@@ -398,6 +398,26 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 573118182729258555, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_Positions.Array.data[0].y
+      value: -354.43802
+      objectReference: {fileID: 0}
+    - target: {fileID: 573118182729258555, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
+      value: 1.6559999
+      objectReference: {fileID: 0}
+    - target: {fileID: 573118182729258555, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
+      value: 1.6559999
+      objectReference: {fileID: 0}
+    - target: {fileID: 1153341331218768315, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 1706829439639562986, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
@@ -555,153 +575,223 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1783978663594912645, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978663609125011, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978663650769536, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978663692615616, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978663706842046, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978663793950197, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978663849243738, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978663948744303, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978663952612256, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978664052859434, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978664091411225, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978664162049977, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978664237072558, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978664484292865, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978664623811254, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978664639787118, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978664833175417, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978664955578070, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665026509430, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665165046479, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665169047296, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665183257470, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665353984083, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665395571264, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665467118575, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665508401660, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665529299690, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665594111130, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665681611473, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665697446752, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1967303504890121131, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
+      value: 1.6559999
+      objectReference: {fileID: 0}
+    - target: {fileID: 1967303504890121131, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
+      value: 1.6559999
+      objectReference: {fileID: 0}
+    - target: {fileID: 2769182992417174427, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2858480898278879926, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 2.1240053
+      objectReference: {fileID: 0}
+    - target: {fileID: 3286706064571676531, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
+      value: 1.6559999
+      objectReference: {fileID: 0}
+    - target: {fileID: 3286706064571676531, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
+      value: 1.6559999
+      objectReference: {fileID: 0}
+    - target: {fileID: 4672332163458530861, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
+      value: 1.6559999
+      objectReference: {fileID: 0}
+    - target: {fileID: 4672332163458530861, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
+      value: 1.6559999
+      objectReference: {fileID: 0}
+    - target: {fileID: 4916405833009375384, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_Positions.Array.data[1].y
+      value: 118.145935
+      objectReference: {fileID: 0}
+    - target: {fileID: 4916405833009375384, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
+      value: 1.6559999
+      objectReference: {fileID: 0}
+    - target: {fileID: 4916405833009375384, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
+      value: 1.6559999
+      objectReference: {fileID: 0}
+    - target: {fileID: 5056174324638999242, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_Positions.Array.data[1].y
+      value: 118.145935
+      objectReference: {fileID: 0}
+    - target: {fileID: 5056174324638999242, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
+      value: 1.6559999
+      objectReference: {fileID: 0}
+    - target: {fileID: 5056174324638999242, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 5300636564544390065, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
@@ -712,6 +802,191 @@ PrefabInstance:
         type: 3}
       propertyPath: _treeId
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6861089719375955589, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
+      value: 1.6559999
+      objectReference: {fileID: 0}
+    - target: {fileID: 6861089719375955589, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
+      value: 1.6559999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7250407284197907366, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_Positions.Array.data[0].x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7250407284197907366, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_Positions.Array.data[0].y
+      value: -708.8761
+      objectReference: {fileID: 0}
+    - target: {fileID: 7250407284197907366, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_Positions.Array.data[1].y
+      value: -354.43802
+      objectReference: {fileID: 0}
+    - target: {fileID: 7250407284197907366, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
+      value: 1.6559999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7250407284197907366, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
+      value: 1.6559999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746777471075703, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746777610462912, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746777857159023, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746777932058744, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778002951384, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778042027499, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778142020705, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778145495470, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778245258139, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778300027444, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778388053119, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778402148353, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778444125505, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778485368658, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778499449924, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778544661665, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778560234768, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778647866203, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778713079083, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778733059645, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778774727726, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778846799233, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778888001426, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746779059113151, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746779073192129, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746779076537614, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746779215869367, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746779286530327, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746779408408760, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746779601936303, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8406955804157697607, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
@@ -728,6 +1003,21 @@ PrefabInstance:
       propertyPath: _treeImage
       value: 
       objectReference: {fileID: 9195470248774931555}
+    - target: {fileID: 8825361915287783430, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_Positions.Array.data[1].y
+      value: 354.43805
+      objectReference: {fileID: 0}
+    - target: {fileID: 8825361915287783430, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
+      value: 1.6559999
+      objectReference: {fileID: 0}
+    - target: {fileID: 8825361915287783430, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
+      value: 1.6559999
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 28c9fd4dd33d84b6b82b268bb586c041, type: 3}
 --- !u!1 &1706829440728858701 stripped

--- a/Assets/Project/Scenes/StageSelectScene/SummerStageSelectScene.unity
+++ b/Assets/Project/Scenes/StageSelectScene/SummerStageSelectScene.unity
@@ -599,7 +599,7 @@ PrefabInstance:
     - target: {fileID: 573118181794230100, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Positions.Array.data[0].y
-      value: -354.43805
+      value: -354.43802
       objectReference: {fileID: 0}
     - target: {fileID: 573118181794230100, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
@@ -614,12 +614,12 @@ PrefabInstance:
     - target: {fileID: 573118181794230100, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 2.61
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 573118181794230100, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
-      value: 2.61
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 573118182058223355, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
@@ -629,7 +629,7 @@ PrefabInstance:
     - target: {fileID: 573118182058223355, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Positions.Array.data[0].y
-      value: -354.43805
+      value: -354.43802
       objectReference: {fileID: 0}
     - target: {fileID: 573118182058223355, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
@@ -644,12 +644,12 @@ PrefabInstance:
     - target: {fileID: 573118182058223355, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 2.61
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 573118182058223355, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
-      value: 2.61
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 573118182729258555, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
@@ -833,152 +833,152 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1783978663594912645, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978663609125011, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978663650769536, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978663692615616, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978663706842046, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978663793950197, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978663849243738, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978663948744303, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978663952612256, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978664052859434, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978664091411225, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978664162049977, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978664237072558, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978664484292865, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978664623811254, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978664639787118, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978664833175417, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978664955578070, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665026509430, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665165046479, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665169047296, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665183257470, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665353984083, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665395571264, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665467118575, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665508401660, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665529299690, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665594111130, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665681611473, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665697446752, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1967303504219061099, guid: 28c9fd4dd33d84b6b82b268bb586c041,
@@ -1226,6 +1226,16 @@ PrefabInstance:
       propertyPath: _treeId
       value: 1002
       objectReference: {fileID: 0}
+    - target: {fileID: 2769182992417174427, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2858480898278879926, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 2.1240053
+      objectReference: {fileID: 0}
     - target: {fileID: 3286706064571676531, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
@@ -1424,7 +1434,7 @@ PrefabInstance:
     - target: {fileID: 4916405834480751095, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Positions.Array.data[1].y
-      value: 118.145996
+      value: 118.145935
       objectReference: {fileID: 0}
     - target: {fileID: 4916405834480751095, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
@@ -1434,12 +1444,12 @@ PrefabInstance:
     - target: {fileID: 4916405834480751095, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 2.61
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 4916405834480751095, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
-      value: 2.61
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 4916405834754185304, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
@@ -1514,7 +1524,7 @@ PrefabInstance:
     - target: {fileID: 5056174323207920549, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Positions.Array.data[1].y
-      value: 118.145996
+      value: 118.145935
       objectReference: {fileID: 0}
     - target: {fileID: 5056174323207920549, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
@@ -1524,12 +1534,12 @@ PrefabInstance:
     - target: {fileID: 5056174323207920549, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 2.61
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 5056174323207920549, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
-      value: 2.61
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 5056174324638999242, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
@@ -1734,12 +1744,12 @@ PrefabInstance:
     - target: {fileID: 7250407284479222473, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Positions.Array.data[0].x
-      value: 11.252258
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7250407284479222473, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Positions.Array.data[0].y
-      value: -708.87604
+      value: -708.8761
       objectReference: {fileID: 0}
     - target: {fileID: 7250407284479222473, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
@@ -1749,7 +1759,7 @@ PrefabInstance:
     - target: {fileID: 7250407284479222473, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Positions.Array.data[1].y
-      value: -354.43805
+      value: -354.43802
       objectReference: {fileID: 0}
     - target: {fileID: 7250407284479222473, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
@@ -1759,22 +1769,22 @@ PrefabInstance:
     - target: {fileID: 7250407284479222473, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 2.61
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 7250407284479222473, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
-      value: 2.61
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 7250407284600580966, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Positions.Array.data[0].x
-      value: 11.24884
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7250407284600580966, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Positions.Array.data[0].y
-      value: -708.87604
+      value: -708.8761
       objectReference: {fileID: 0}
     - target: {fileID: 7250407284600580966, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
@@ -1784,7 +1794,7 @@ PrefabInstance:
     - target: {fileID: 7250407284600580966, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Positions.Array.data[1].y
-      value: -354.43805
+      value: -354.43802
       objectReference: {fileID: 0}
     - target: {fileID: 7250407284600580966, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
@@ -1794,12 +1804,162 @@ PrefabInstance:
     - target: {fileID: 7250407284600580966, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 2.61
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 7250407284600580966, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
-      value: 2.61
+      value: 1.6559999
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746777471075703, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746777610462912, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746777857159023, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746777932058744, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778002951384, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778042027499, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778142020705, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778145495470, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778245258139, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778300027444, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778388053119, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778402148353, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778444125505, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778485368658, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778499449924, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778544661665, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778560234768, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778647866203, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778713079083, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778733059645, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778774727726, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778846799233, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778888001426, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746779059113151, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746779073192129, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746779076537614, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746779215869367, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746779286530327, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746779408408760, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746779601936303, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7960581567240511975, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}

--- a/Assets/Project/Scenes/StageSelectScene/SummerStageSelectScene.unity
+++ b/Assets/Project/Scenes/StageSelectScene/SummerStageSelectScene.unity
@@ -791,6 +791,11 @@ PrefabInstance:
       propertyPath: _synchronizedObject
       value: 
       objectReference: {fileID: 11726113}
+    - target: {fileID: 1706829440290082588, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 1706829440290082589, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target

--- a/Assets/Project/Scenes/StageSelectScene/WinterStageSelectScene.unity
+++ b/Assets/Project/Scenes/StageSelectScene/WinterStageSelectScene.unity
@@ -786,6 +786,11 @@ PrefabInstance:
       propertyPath: _synchronizedObject
       value: 
       objectReference: {fileID: 268392212}
+    - target: {fileID: 1706829440290082588, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 1706829440290082589, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target

--- a/Assets/Project/Scenes/StageSelectScene/WinterStageSelectScene.unity
+++ b/Assets/Project/Scenes/StageSelectScene/WinterStageSelectScene.unity
@@ -648,13 +648,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 573118182729258555, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
+      propertyPath: m_Positions.Array.data[0].y
+      value: -354.43802
+      objectReference: {fileID: 0}
+    - target: {fileID: 573118182729258555, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 2.61
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 573118182729258555, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
-      value: 2.61
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 1706829439639562986, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
@@ -828,152 +833,152 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1783978663594912645, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978663609125011, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978663650769536, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978663692615616, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978663706842046, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978663793950197, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978663849243738, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978663948744303, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978663952612256, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978664052859434, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978664091411225, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978664162049977, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978664237072558, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978664484292865, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978664623811254, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978664639787118, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978664833175417, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978664955578070, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665026509430, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665165046479, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665169047296, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665183257470, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665353984083, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665395571264, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665467118575, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665508401660, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665529299690, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665594111130, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665681611473, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1783978665697446752, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
-      propertyPath: m_SizeDelta.y
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1967303504219061099, guid: 28c9fd4dd33d84b6b82b268bb586c041,
@@ -1220,6 +1225,16 @@ PrefabInstance:
         type: 3}
       propertyPath: _treeId
       value: 3002
+      objectReference: {fileID: 0}
+    - target: {fileID: 2769182992417174427, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2858480898278879926, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 2.1240053
       objectReference: {fileID: 0}
     - target: {fileID: 3286706064571676531, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
@@ -1528,13 +1543,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5056174324638999242, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
+      propertyPath: m_Positions.Array.data[1].y
+      value: 118.145935
+      objectReference: {fileID: 0}
+    - target: {fileID: 5056174324638999242, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 2.61
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 5056174324638999242, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
-      value: 2.61
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 5175807671198363697, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
@@ -1718,13 +1738,28 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7250407284197907366, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
+      propertyPath: m_Positions.Array.data[0].x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7250407284197907366, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_Positions.Array.data[0].y
+      value: -708.8761
+      objectReference: {fileID: 0}
+    - target: {fileID: 7250407284197907366, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_Positions.Array.data[1].y
+      value: -354.43802
+      objectReference: {fileID: 0}
+    - target: {fileID: 7250407284197907366, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[0].value
-      value: 2.61
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 7250407284197907366, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
-      value: 2.61
+      value: 1.6559999
       objectReference: {fileID: 0}
     - target: {fileID: 7250407284479222473, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}
@@ -1795,6 +1830,156 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Parameters.widthCurve.m_Curve.Array.data[1].value
       value: 2.61
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746777471075703, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746777610462912, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746777857159023, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746777932058744, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778002951384, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778042027499, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778142020705, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778145495470, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778245258139, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778300027444, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778388053119, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778402148353, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778444125505, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778485368658, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778499449924, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778544661665, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778560234768, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778647866203, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778713079083, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778733059645, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778774727726, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778846799233, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746778888001426, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746779059113151, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746779073192129, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746779076537614, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746779215869367, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746779286530327, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746779408408760, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576746779601936303, guid: 28c9fd4dd33d84b6b82b268bb586c041,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7960581567240511975, guid: 28c9fd4dd33d84b6b82b268bb586c041,
         type: 3}

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/Record/ClearStageNumController.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/Record/ClearStageNumController.cs
@@ -1,3 +1,4 @@
+using Treevel.Common.Utils;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -33,12 +34,14 @@ namespace Treevel.Modules.MenuSelectScene.Record
             var clearStagePercentage = (float)clearStageNum / totalStageNum;
             _clearStageGauge.fillAmount = clearStagePercentage;
 
-            var gaugeRadius = _clearStageGauge.GetComponent<RectTransform>().rect.width / 2;
+            // 画面の縦横比によって横方向、縦方向の倍率が異なるので調整する
+            var gaugeRadiusWidth = _clearStageGauge.GetComponent<RectTransform>().rect.width / 2f * Screen.width / Constants.DeviceSize.WIDTH;
+            var gaugeRadiusHeight = _clearStageGauge.GetComponent<RectTransform>().rect.height / 2f * Screen.height / Constants.DeviceSize.HEIGHT;
             var indicatorAngle = clearStagePercentage * 2 * Mathf.PI;
 
             // FIXME: 0.95 はゲージの太さを考慮するための Magic Number です
-            var indicatorX = gaugeRadius * Mathf.Sin(indicatorAngle) * 0.95f;
-            var indicatorY = gaugeRadius * Mathf.Cos(indicatorAngle) * 0.95f;
+            var indicatorX = gaugeRadiusWidth * Mathf.Sin(indicatorAngle) * 0.95f;
+            var indicatorY = gaugeRadiusHeight * Mathf.Cos(indicatorAngle) * 0.95f;
 
             _clearStageGaugeIndicator.GetComponent<RectTransform>().localPosition = new Vector3(indicatorX, indicatorY);
 

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/Record/ClearStageNumController.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/Record/ClearStageNumController.cs
@@ -35,8 +35,9 @@ namespace Treevel.Modules.MenuSelectScene.Record
             _clearStageGauge.fillAmount = clearStagePercentage;
 
             // 画面の縦横比によって横方向、縦方向の倍率が異なるので調整する
-            var gaugeRadiusWidth = _clearStageGauge.GetComponent<RectTransform>().rect.width / 2f * Screen.width / Constants.DeviceSize.WIDTH;
-            var gaugeRadiusHeight = _clearStageGauge.GetComponent<RectTransform>().rect.height / 2f * Screen.height / Constants.DeviceSize.HEIGHT;
+            var gaugeRect = _clearStageGauge.GetComponent<RectTransform>().rect;
+            var gaugeRadiusWidth = gaugeRect.width / 2f * Screen.width / Constants.DeviceSize.WIDTH;
+            var gaugeRadiusHeight = gaugeRect.height / 2f * Screen.height / Constants.DeviceSize.HEIGHT;
             var indicatorAngle = clearStagePercentage * 2 * Mathf.PI;
 
             // FIXME: 0.95 はゲージの太さを考慮するための Magic Number です

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/Record/GeneralRecordDirector.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/Record/GeneralRecordDirector.cs
@@ -193,12 +193,8 @@ namespace Treevel.Modules.MenuSelectScene.Record
 
         private void CreateFailureReasonGraphElement(EFailureReasonType type, float startPoint, float fillAmount)
         {
-            var element = Instantiate(_failureReasonGraphElementPrefab, _failureReasonGraphBackground.transform, true);
+            var element = Instantiate(_failureReasonGraphElementPrefab, _failureReasonGraphBackground.transform);
             _shouldDestroyPrefabsOnDisable.Add(element);
-
-            // 親を指定すると，localPosition や sizeDelta が prefab の時と変わるので調整する
-            element.transform.localPosition = Vector3.zero;
-            element.GetComponent<RectTransform>().sizeDelta = Vector2.zero;
 
             element.GetComponent<Image>().fillAmount = fillAmount;
 

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/Record/GraphPopupController.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/Record/GraphPopupController.cs
@@ -54,7 +54,7 @@ namespace Treevel.Modules.MenuSelectScene.Record
 
         private void Awake()
         {
-            _width = Screen.width * 0.5f;
+            _width = RuntimeConstants.ScaledCanvasSize.SIZE_DELTA.x * 0.5f;
             _height = _width * 0.5f;
             _margin = Screen.width * 0.05f;
 
@@ -77,7 +77,7 @@ namespace Treevel.Modules.MenuSelectScene.Record
             // ポップアップが表示される位置を、該当する棒グラフの位置に合わせて変える
             var rectTransform = GetComponent<RectTransform>();
             // pivot が 0.5 なので、ポップアップの横幅も考慮する
-            var margin = _margin + _width / 2;
+            var margin = _margin + _width / 2 * (Screen.width / RuntimeConstants.ScaledCanvasSize.SIZE_DELTA.x);
             var position = rectTransform.position;
             position.x = Mathf.Clamp(graphPosition.x, margin, Screen.width - margin);
             rectTransform.position = position;
@@ -86,7 +86,9 @@ namespace Treevel.Modules.MenuSelectScene.Record
             var lineRectTransform = _indicatorLine.GetComponent<RectTransform>();
             var linePosition = lineRectTransform.position;
             linePosition.x = graphPosition.x;
-            lineRectTransform.sizeDelta = new Vector2(lineRectTransform.rect.width, linePosition.y - graphPosition.y);
+            // 補助線の高さを計算する
+            var lineHeight = RuntimeConstants.ScaledCanvasSize.SIZE_DELTA.y / Screen.height * (linePosition.y - graphPosition.y);
+            lineRectTransform.sizeDelta = new Vector2(lineRectTransform.rect.width, lineHeight);
             lineRectTransform.position = linePosition;
 
             // TODO: implement PlayFab version


### PR DESCRIPTION
### 対象イシュー
Close #771

### 概要
- `AspectRatioFilter`componentを適切に配置して、キャンバスサイズを参照したオブジェクト配置を行う。
- Record画面をCanvasScalerに対応させる

### 詳細
bff4c2b : チュートリアルウィンドウの「x」ボタンを比率指定で配置
b5bc3e7 : StageSelectSceneの「←」ボタンのprefabを比率指定で配置
5078e57 : TreeCanvasに無駄な編集をしてアップデートしただけ
b13d20c : 「←」ボタンの変更をインスタンスに反映
b18dc9d : StageSelectSceneに無駄な編集をしてアップデートしただけ
f63a7ee : OverviewPopupを比率指定で配置
73d0810 : Stage prefabを比率指定で配置
de85bb9 : Stage prefabの変更をStageTree prefabに反映
355079b : StageTree prefabの変更をインスタンスに反映
8bd291f : MenuSelectのフッターを比率指定で配置
10cc56c : Roadインスタンスの各種設定値のうち、prefabと同じ値をインスタンスで上書きしていたものをprefabを反映するようにRevertした（prefabの変更がインスタンスに反映されなくなっていたので）
8326360 : TreeインスタンスもRoadと同じようにRevert
60ab42d : Treeを比率指定で配置
f3c6359 , 58b490a , dfbf028 , 4d29312 : 各種MultiLanguageTextもRoadと同じようにRevert
b9e6b6e : Record画面のポップアップをCanvasScalerに対応
2c8e352 : Record画面の失敗割合をCanvasScalerに対応
d8f81ae : Record画面のインジケータ画像の設定を修正
c49159e , 9a490db : Record画面の成功ステージ数のインジケータをCanvasScalerに対応
7250fd8 : Settings画面のボタンを比率指定で配置

#### 現実装になった経緯
特になし

#### 技術的な内容
特になし

### キャプチャ


### 動作確認方法

- [ ] 1125x2436のデバイスで一通りの画面を開き、画面崩れがないことを確認する

- [ ] 1125x2436以外のデバイスで一通りの画面を開き、画面崩れがないことを確認する

### 参考 URL
特に無し