### PR TITLE
チュートリアル画面を閉じられるようにする

### DIFF
--- a/Assets/Project/Actors/UIs/GamePlayScene/CountDown.prefab
+++ b/Assets/Project/Actors/UIs/GamePlayScene/CountDown.prefab
@@ -30,7 +30,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 6945572549006055985}
-  m_RootOrder: 2
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.15, y: 0.42}
   m_AnchorMax: {x: 0.85, y: 0.57}
@@ -166,7 +166,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 6945572549006055985}
-  m_RootOrder: 1
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.15, y: 0.42}
   m_AnchorMax: {x: 0.85, y: 0.57}
@@ -298,7 +298,6 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 143855669278588061}
   - {fileID: 2021398201}
   - {fileID: 1586524306}
   m_Father: {fileID: 0}
@@ -328,78 +327,3 @@ Animator:
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorControllerStateOnDisable: 0
---- !u!1 &1678252324593182949
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 143855669278588061}
-  - component: {fileID: 6306624786854622529}
-  - component: {fileID: 1242161640216526720}
-  m_Layer: 5
-  m_Name: Panel
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &143855669278588061
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1678252324593182949}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 6945572549006055985}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &6306624786854622529
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1678252324593182949}
-  m_CullTransparentMesh: 1
---- !u!114 &1242161640216526720
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1678252324593182949}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0.764151, g: 0.764151, b: 0.764151, a: 0.57254905}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1

--- a/Assets/Project/Scenes/GamePlayScene.unity
+++ b/Assets/Project/Scenes/GamePlayScene.unity
@@ -254,6 +254,81 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 121837340}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &178907275
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 178907278}
+  - component: {fileID: 178907277}
+  - component: {fileID: 178907276}
+  m_Layer: 4
+  m_Name: GameMask
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &178907276
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 178907275}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.5188679, g: 0.5188679, b: 0.5188679, a: 0.5019608}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &178907277
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 178907275}
+  m_CullTransparentMesh: 1
+--- !u!224 &178907278
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 178907275}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 374185333}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &374185329
 GameObject:
   m_ObjectHideFlags: 0
@@ -345,6 +420,7 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_Children:
+  - {fileID: 178907278}
   - {fileID: 1453285406}
   - {fileID: 805035186}
   m_Father: {fileID: 0}
@@ -803,7 +879,7 @@ RectTransform:
   - {fileID: 580887583}
   - {fileID: 690764897131943412}
   m_Father: {fileID: 374185333}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -1134,7 +1210,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 374185333}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -1209,6 +1285,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _tutorialWindow: {fileID: 580887584}
+  _gameMask: {fileID: 178907275}
   _pauseBackground: {fileID: 1453285405}
   _pauseButton: {fileID: 1704684606}
   _pauseWindow: {fileID: 3798100570565638191}

--- a/Assets/Project/Scripts/Modules/GamePlayScene/GamePlayDirector.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/GamePlayDirector.cs
@@ -34,6 +34,11 @@ namespace Treevel.Modules.GamePlayScene
         [SerializeField] private GameObject _tutorialWindow;
 
         /// <summary>
+        /// ゲーム画面の手前のマスクオブジェクト
+        /// </summary>
+        [SerializeField] private GameObject _gameMask;
+
+        /// <summary>
         /// 一時停止中の背景
         /// </summary>
         [SerializeField] private GameObject _pauseBackground;
@@ -399,6 +404,9 @@ namespace Treevel.Modules.GamePlayScene
                 if (from is PausingState) return;
 
                 // TODO: ステージ準備中のアニメーションを停止する
+                // ゲーム画面のマスクを非表示にする
+                Instance._gameMask.SetActive(false);
+
                 // 時間の計測
                 _customTimer.StartTimer();
 
@@ -617,8 +625,6 @@ namespace Treevel.Modules.GamePlayScene
                     .OnStateExitAsObservable()
                     .Where(state => state.StateInfo.shortNameHash == _ANIMATOR_STATE_OPENING)
                     .Subscribe(_ => {
-                        var maskObject = _animator.transform.Find("Panel").gameObject;
-                        maskObject.SetActive(false);
                         Instance.Dispatch(EGameState.Playing);
                     }) // アニメーション再生終了後プレイステートに移行
                     .AddTo(caller);

--- a/Assets/Project/Scripts/Modules/GamePlayScene/GamePlayDirector.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/GamePlayDirector.cs
@@ -403,7 +403,6 @@ namespace Treevel.Modules.GamePlayScene
                 // 一時停止だったらそのまま処理終わる
                 if (from is PausingState) return;
 
-                // TODO: ステージ準備中のアニメーションを停止する
                 // ゲーム画面のマスクを非表示にする
                 Instance._gameMask.SetActive(false);
 


### PR DESCRIPTION
### 対象イシュー
Close #908

### 概要
チュートリアル画面の手前にオープニング画面の背景が表示され、チュートリアル画面を閉じるボタンが押せなくなっていたボタン問題を修正

### 詳細
オープニング画面の背景を削除し、ゲームが始まる前まで表示するマスクオブジェクトを作成。
ゲーム開始時にマスクオブジェクトを非表示にするように変更。
（チュートリアル画面とオープニング画面では共通して、このマスクオブジェクトを使用。）

#### 現実装になった経緯
特になし

#### 技術的な内容
特になし

### キャプチャ
https://user-images.githubusercontent.com/26213141/117483925-5d02eb80-afa1-11eb-86db-35c2c780b203.mov



### 動作確認方法

- [x] チュートリアル画面が表示されるステージ(Spring_1_1 or Spring_1_2)でプレイ。チュートリアル画面を閉じれることを確認する

- [x] オープニング画面よりも後ろにマスクオブジェクトが描画されていることを確認する

- [x] リトライ時にマスクオブジェクトが非表示のままになっていることを確認する

### 参考 URL
特になし
