### PR TITLE
バックグラウンドから復帰時も `UserRecord` の更新を試みる

### DIFF
--- a/Assets/Project/Scripts/Common/Entities/UserRecord.cs
+++ b/Assets/Project/Scripts/Common/Entities/UserRecord.cs
@@ -1,12 +1,10 @@
 using System;
-using UniRx;
 using UnityEngine;
-using UnityEngine.Serialization;
 
 namespace Treevel.Common.Entities
 {
     [Serializable]
-    public class UserRecord
+    public struct UserRecord
     {
         /// <summary>
         /// 起動日数
@@ -27,10 +25,10 @@ namespace Treevel.Common.Entities
             set => stringLastStartupDate = $"{value:yyyyMMddHHmmss}";
         }
 
-        public UserRecord()
+        public UserRecord(int startupDays, DateTime lastStartupDate)
         {
-            startupDays = 1;
-            LastStartupDate = DateTime.Today;
+            this.startupDays = startupDays;
+            stringLastStartupDate = $"{lastStartupDate:yyyyMMddHHmmss}";
         }
     }
 }

--- a/Assets/Project/Scripts/Common/Utils/UserRecordService.cs
+++ b/Assets/Project/Scripts/Common/Utils/UserRecordService.cs
@@ -30,7 +30,7 @@ namespace Treevel.Common.Utils
                 _cachedUserRecord = await NetworkService.Execute(new GetUserRecordRequest());
             } catch {
                 _cachedUserRecord = PlayerPrefsUtility.GetObjectOrDefault(Constants.PlayerPrefsKeys.USER_RECORD,
-                                                                          new UserRecord());
+                                                                          new UserRecord(1, DateTime.Today));
                 // リモートにまだデータがない場合には、保存する
                 await SaveAsync(_cachedUserRecord);
             }

--- a/Assets/Project/Scripts/Common/Utils/UserRecordService.cs
+++ b/Assets/Project/Scripts/Common/Utils/UserRecordService.cs
@@ -3,19 +3,13 @@ using Cysharp.Threading.Tasks;
 using Treevel.Common.Entities;
 using Treevel.Common.Networks;
 using Treevel.Common.Networks.Requests;
+using Treevel.Common.Patterns.Singleton;
+using UnityEngine;
 
 namespace Treevel.Common.Utils
 {
-    public sealed class UserRecordService
+    public sealed class UserRecordService : SingletonObjectBase<UserRecordService>
     {
-        // For Singleton
-        private UserRecordService() { }
-
-        /// <summary>
-        /// インスタンス
-        /// </summary>
-        public static readonly UserRecordService Instance = new UserRecordService();
-
         /// <summary>
         /// オンメモリに UserRecord を保持する
         /// </summary>
@@ -74,6 +68,13 @@ namespace Treevel.Common.Utils
                 newUserRecord.LastStartupDate = DateTime.Today;
 
                 await SaveAsync(newUserRecord);
+            }
+        }
+
+        private void OnApplicationFocus(bool hasFocus)
+        {
+            if (hasFocus) {
+                UpdateStartupDaysAsync().Forget();
             }
         }
     }


### PR DESCRIPTION
### 対象イシュー
Close #735 

### 概要
- バックグラウンドから復帰時（`OnApplicationFocus`）に `UserRecord` の更新を試みる
- `UserRecord` を構造体にすることで、 https://github.com/LITO-apps/Treevel-client/pull/915#issuecomment-839879277 などで議論した問題をついでに解決した

### 詳細

#### 現実装になった経緯
- 本当はアプリ起動中も常に時間を監視して `UserRecord` の更新を試みようとしていたが、実装コストの割に得られる効能が少ないと判断し、バックグラウンドから復帰時に更新を試みる機能の追加のみをするようにした。リリース版もこれで良いと思っている。厳密なログインボーナスの配布などを検討した場合には、修正が必要になるかもしれない

#### 技術的な内容
- `OnApplicationPause` の動作が不安定だったので（経緯: https://lito-apps.slack.com/archives/CBVRTRRBK/p1621055671001900 ）、同様のハンドリングができる `OnApplicationFocus` を利用している

### 動作確認方法
- [ ] バックグラウンドから復帰時も `UserRecord` の更新を試みていること