### PR TITLE
`UserRecord` をリセットできるようにする

### DIFF
--- a/Assets/Project/Scripts/Common/Networks/Database/IDatabaseService.cs
+++ b/Assets/Project/Scripts/Common/Networks/Database/IDatabaseService.cs
@@ -14,6 +14,8 @@ namespace Treevel.Common.Networks.Database
 
         UniTask<bool> LoginAsync();
 
+        UniTask<bool> DeleteDataAsync(string key);
+
         UniTask<bool> DeleteListDataAsync(IEnumerable<string> keys);
     }
 

--- a/Assets/Project/Scripts/Common/Networks/Database/IDatabaseService.cs
+++ b/Assets/Project/Scripts/Common/Networks/Database/IDatabaseService.cs
@@ -14,7 +14,7 @@ namespace Treevel.Common.Networks.Database
 
         UniTask<bool> LoginAsync();
 
-        UniTask<bool> DeleteDataAsync(IEnumerable<string> keys);
+        UniTask<bool> DeleteListDataAsync(IEnumerable<string> keys);
     }
 
     public class NetworkErrorException : Exception

--- a/Assets/Project/Scripts/Common/Networks/Database/PlayFabDatabaseService.cs
+++ b/Assets/Project/Scripts/Common/Networks/Database/PlayFabDatabaseService.cs
@@ -159,7 +159,7 @@ namespace Treevel.Common.Networks.Database
             return isSuccess;
         }
 
-        public async UniTask<bool> DeleteDataAsync(IEnumerable<string> keys)
+        public async UniTask<bool> DeleteListDataAsync(IEnumerable<string> keys)
         {
             var request = new UpdateUserDataRequest {
                 KeysToRemove = keys.ToList(),

--- a/Assets/Project/Scripts/Common/Networks/Database/PlayFabDatabaseService.cs
+++ b/Assets/Project/Scripts/Common/Networks/Database/PlayFabDatabaseService.cs
@@ -159,6 +159,30 @@ namespace Treevel.Common.Networks.Database
             return isSuccess;
         }
 
+        public async UniTask<bool> DeleteDataAsync(string key)
+        {
+            var request = new UpdateUserDataRequest {
+                KeysToRemove = new List<string> { key },
+            };
+
+            try {
+                var task = PlayFabClientAPIAsync.UpdateUserDataAsync(request);
+                // UpdateUserDataResultは現状使いところがないが、念の為変数で保存しておく
+                var result = await task;
+
+                // 成功状態を返す
+                if (task.Status == UniTaskStatus.Succeeded) {
+                    return true;
+                }
+
+                return false;
+            } catch(Exception e) {
+                // ローカルに切り替えるため呼び出し先に投げる
+                Debug.LogError(e.Message + e.StackTrace);
+                throw;
+            }
+        }
+
         public async UniTask<bool> DeleteListDataAsync(IEnumerable<string> keys)
         {
             var request = new UpdateUserDataRequest {

--- a/Assets/Project/Scripts/Common/Networks/Requests/DeleteAllStageRecordRequest.cs
+++ b/Assets/Project/Scripts/Common/Networks/Requests/DeleteAllStageRecordRequest.cs
@@ -4,7 +4,7 @@ using Treevel.Common.Utils;
 
 namespace Treevel.Common.Networks.Requests
 {
-    public class DeleteAllStageRecordRequest : DeleteServerRequestBase
+    public class DeleteAllStageRecordRequest : DeleteListServerRequestBase
     {
         public DeleteAllStageRecordRequest()
         {

--- a/Assets/Project/Scripts/Common/Networks/Requests/DeleteUserRecordRequest.cs
+++ b/Assets/Project/Scripts/Common/Networks/Requests/DeleteUserRecordRequest.cs
@@ -1,0 +1,12 @@
+using Treevel.Common.Utils;
+
+namespace Treevel.Common.Networks.Requests
+{
+    public class DeleteUserRecordRequest : DeleteServerRequestBase
+    {
+        public DeleteUserRecordRequest()
+        {
+            key = Constants.PlayerPrefsKeys.USER_RECORD;
+        }
+    }
+}

--- a/Assets/Project/Scripts/Common/Networks/Requests/DeleteUserRecordRequest.cs.meta
+++ b/Assets/Project/Scripts/Common/Networks/Requests/DeleteUserRecordRequest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 72e0febdbb754b2bae294c890f51bd95
+timeCreated: 1621257783

--- a/Assets/Project/Scripts/Common/Networks/Requests/ServerRequestBase.cs
+++ b/Assets/Project/Scripts/Common/Networks/Requests/ServerRequestBase.cs
@@ -52,6 +52,16 @@ namespace Treevel.Common.Networks.Requests
         }
     }
 
+    public abstract class DeleteServerRequestBase : ServerRequestBase<bool>
+    {
+        protected string key;
+
+        public override async UniTask<bool> Execute()
+        {
+            return await remoteDatabaseService.DeleteDataAsync(key);
+        }
+    }
+
     public abstract class DeleteListServerRequestBase : ServerRequestBase<bool>
     {
         protected IEnumerable<string> keys;

--- a/Assets/Project/Scripts/Common/Networks/Requests/ServerRequestBase.cs
+++ b/Assets/Project/Scripts/Common/Networks/Requests/ServerRequestBase.cs
@@ -52,7 +52,7 @@ namespace Treevel.Common.Networks.Requests
         }
     }
 
-    public abstract class DeleteServerRequestBase : ServerRequestBase<bool>
+    public abstract class DeleteListServerRequestBase : ServerRequestBase<bool>
     {
         protected IEnumerable<string> keys;
 
@@ -61,7 +61,7 @@ namespace Treevel.Common.Networks.Requests
             var allSuccess = true;
             // PlayFabの仕様上一回のリクエストにつき10個の値しか消せないので分けてリクエストを送る
             for (var i = 0 ; i <= keys.Count() / 10 ; i++) {
-                allSuccess &= await remoteDatabaseService.DeleteDataAsync(keys.Skip(i * 10).Take(10));
+                allSuccess &= await remoteDatabaseService.DeleteListDataAsync(keys.Skip(i * 10).Take(10));
             }
             return allSuccess;
         }

--- a/Assets/Project/Scripts/Common/Utils/UserRecordService.cs
+++ b/Assets/Project/Scripts/Common/Utils/UserRecordService.cs
@@ -55,6 +55,18 @@ namespace Treevel.Common.Utils
                 });
         }
 
+        public async UniTask ResetAsync()
+        {
+            await NetworkService.Execute(new DeleteUserRecordRequest())
+                .ContinueWith(isSuccess => {
+                    if (isSuccess) {
+                        // データのリセットに成功したら、PlayerPrefs をリセットし、初期化を行う
+                        PlayerPrefs.DeleteKey(Constants.PlayerPrefsKeys.USER_RECORD);
+                        SaveAsync(new UserRecord(1, DateTime.Today)).Forget();
+                    }
+                });
+        }
+
         /// <summary>
         /// 最終起動日に応じて，起動日数を更新する
         /// </summary>

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/Record/GeneralRecordDirector.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/Record/GeneralRecordDirector.cs
@@ -132,6 +132,7 @@ namespace Treevel.Modules.MenuSelectScene.Record
         private void OnEnable()
         {
             _model.FetchStageRecordArray();
+            _model.FetchUserRecord();
         }
 
         private void OnDisable()

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/Settings/ResetController.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/Settings/ResetController.cs
@@ -40,6 +40,9 @@ namespace Treevel.Modules.MenuSelectScene.Settings
             // 全ステージをリセット
             StageRecordService.Instance.ResetAsync().Forget();
 
+            // ユーザ情報をリセット
+            UserRecordService.Instance.ResetAsync().Forget();
+
             // ステージ選択画面のブランチをリセット
             PlayerPrefs.DeleteKey(Constants.PlayerPrefsKeys.BRANCH_STATE);
         }


### PR DESCRIPTION
### 対象イシュー
Close #904 

### 概要
- `key` が単体の場合の `delete` リクエストを作成する
- 上記に伴い、`key` がリストの場合の `delete` リクエストをリネームする
- `UserRecord` を消すためのリクエストを作成する
- リセットボタンが押下された際に、`UserRecord` を消すためのリクエストを呼ぶ
- `UserRecord` がリセットされた際に記録画面のデータが反映されるようにする

### 動作確認方法
- [x] リセットボタンを押した場合に、`UserRecord` が `startupDays = 1, lastStartupDate = DateTime.Today` に初期化され、記録画面にも反映される
