### PR TITLE
エラー発生時タイトルに戻る際の処理修正

### DIFF
--- a/Assets/Project/Scripts/Common/Components/UIs/ErrorMessageBox.cs
+++ b/Assets/Project/Scripts/Common/Components/UIs/ErrorMessageBox.cs
@@ -3,6 +3,8 @@ using Treevel.Common.Managers;
 using Treevel.Common.Utils;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
+using UnityEngine.EventSystems;
+using UnityEngine.SceneManagement;
 
 namespace Treevel.Common.Components.UIs
 {
@@ -55,6 +57,11 @@ namespace Treevel.Common.Components.UIs
         public void OnReturnToTitleButtonClicked()
         {
             SoundManager.Instance.PlaySE(ESEKey.UI_Dropdown_Close);
+
+            // StartUpSceneで予め置いているオブジェクトは複数にならないようにDontDestroyOnLoadから今のシーンに置く。そうするとシーンの遷移で自然に消えてくれる
+            SceneManager.MoveGameObjectToScene(FindObjectOfType<EventSystem>().gameObject, SceneManager.GetActiveScene());
+            SceneManager.MoveGameObjectToScene(SoundManager.Instance.gameObject, SceneManager.GetActiveScene());
+            SceneManager.MoveGameObjectToScene(UIManager.Instance.gameObject, SceneManager.GetActiveScene());
 
             // スプラッシュ画面に変える
             AddressableAssetManager.LoadScene(Constants.SceneName.START_UP_SCENE);

--- a/Assets/Project/Scripts/Common/Managers/GameDataManager.cs
+++ b/Assets/Project/Scripts/Common/Managers/GameDataManager.cs
@@ -9,27 +9,36 @@ namespace Treevel.Common.Managers
 {
     public static class GameDataManager
     {
+        /// <summary>
+        /// 初期化済みか
+        /// </summary>
+        private static bool _initialized;
+
         private static readonly Dictionary<string, StageData> _stageDataMap = new Dictionary<string, StageData>();
         private static readonly Dictionary<ETreeId, TreeData> _treeDataMap = new Dictionary<ETreeId, TreeData>();
         public static async UniTask InitializeAsync()
         {
-            // Stageラベルがついてる全てのアセットのアドレスを取得
-            var locations = await Addressables.LoadResourceLocationsAsync("Stage").ToUniTask();
+            if (!_initialized) {
+                // Stageラベルがついてる全てのアセットのアドレスを取得
+                var locations = await Addressables.LoadResourceLocationsAsync("Stage").ToUniTask();
 
-            var stageDataList =
-                await UniTask.WhenAll(locations.Select(loc => Addressables.LoadAssetAsync<StageData>(loc).ToUniTask()));
-            foreach (var stage in stageDataList) {
-                _stageDataMap.Add(StageData.EncodeStageIdKey(stage.TreeId, stage.StageNumber), stage);
-            }
+                var stageDataList =
+                    await UniTask.WhenAll(locations.Select(loc => Addressables.LoadAssetAsync<StageData>(loc).ToUniTask()));
+                foreach (var stage in stageDataList) {
+                    _stageDataMap.Add(StageData.EncodeStageIdKey(stage.TreeId, stage.StageNumber), stage);
+                }
 
-            // Treeラベルがついてる全てのアセットのアドレスを取得
-            locations = await Addressables.LoadResourceLocationsAsync("Tree").ToUniTask();
+                // Treeラベルがついてる全てのアセットのアドレスを取得
+                locations = await Addressables.LoadResourceLocationsAsync("Tree").ToUniTask();
 
-            var treeDataList =
-                await UniTask.WhenAll(locations.Select(loc => Addressables.LoadAssetAsync<TreeData>(loc).ToUniTask()));
-            foreach (var tree in treeDataList) {
-                tree.stages = _stageDataMap.Values.Where(stage => stage.TreeId == tree.id).ToList();
-                _treeDataMap.Add(tree.id, tree);
+                var treeDataList =
+                    await UniTask.WhenAll(locations.Select(loc => Addressables.LoadAssetAsync<TreeData>(loc).ToUniTask()));
+                foreach (var tree in treeDataList) {
+                    tree.stages = _stageDataMap.Values.Where(stage => stage.TreeId == tree.id).ToList();
+                    _treeDataMap.Add(tree.id, tree);
+                }
+
+                _initialized = true;
             }
         }
 

--- a/Assets/Project/Scripts/Common/Managers/GameDataManager.cs
+++ b/Assets/Project/Scripts/Common/Managers/GameDataManager.cs
@@ -18,28 +18,28 @@ namespace Treevel.Common.Managers
         private static readonly Dictionary<ETreeId, TreeData> _treeDataMap = new Dictionary<ETreeId, TreeData>();
         public static async UniTask InitializeAsync()
         {
-            if (!_initialized) {
-                // Stageラベルがついてる全てのアセットのアドレスを取得
-                var locations = await Addressables.LoadResourceLocationsAsync("Stage").ToUniTask();
+            if (_initialized) return;
 
-                var stageDataList =
-                    await UniTask.WhenAll(locations.Select(loc => Addressables.LoadAssetAsync<StageData>(loc).ToUniTask()));
-                foreach (var stage in stageDataList) {
-                    _stageDataMap.Add(StageData.EncodeStageIdKey(stage.TreeId, stage.StageNumber), stage);
-                }
+            // Stageラベルがついてる全てのアセットのアドレスを取得
+            var locations = await Addressables.LoadResourceLocationsAsync("Stage").ToUniTask();
 
-                // Treeラベルがついてる全てのアセットのアドレスを取得
-                locations = await Addressables.LoadResourceLocationsAsync("Tree").ToUniTask();
-
-                var treeDataList =
-                    await UniTask.WhenAll(locations.Select(loc => Addressables.LoadAssetAsync<TreeData>(loc).ToUniTask()));
-                foreach (var tree in treeDataList) {
-                    tree.stages = _stageDataMap.Values.Where(stage => stage.TreeId == tree.id).ToList();
-                    _treeDataMap.Add(tree.id, tree);
-                }
-
-                _initialized = true;
+            var stageDataList =
+                await UniTask.WhenAll(locations.Select(loc => Addressables.LoadAssetAsync<StageData>(loc).ToUniTask()));
+            foreach (var stage in stageDataList) {
+                _stageDataMap.Add(StageData.EncodeStageIdKey(stage.TreeId, stage.StageNumber), stage);
             }
+
+            // Treeラベルがついてる全てのアセットのアドレスを取得
+            locations = await Addressables.LoadResourceLocationsAsync("Tree").ToUniTask();
+
+            var treeDataList =
+                await UniTask.WhenAll(locations.Select(loc => Addressables.LoadAssetAsync<TreeData>(loc).ToUniTask()));
+            foreach (var tree in treeDataList) {
+                tree.stages = _stageDataMap.Values.Where(stage => stage.TreeId == tree.id).ToList();
+                _treeDataMap.Add(tree.id, tree);
+            }
+
+            _initialized = true;
         }
 
         public static StageData GetStage(ETreeId treeId, int stageNumber)


### PR DESCRIPTION
### 対象イシュー
Close #921 

### 概要
エラー発生時にタイトルに戻るときに大量警告とエラーが発生する問題を修正

### 詳細

#### 現実装になった経緯
警告の内容は主に二つ：

1. GameDataManagerが二重初期化され、辞書に既にあるキーを追加しようとするエラー
    * b963cbe : 初期化フラグを持たせることで対応

2. EventSystem、SoundListenerが複数ある警告
    * b272f79: StartUpSceneに予め配置しているSoundManager, UIManager, EventSystem をタイトルに戻る直前に DontDestroyOnLoadを解除させ、シーンをロードするときにシステムに破壊させる


### 動作確認方法
- [x] 適当に `UIManager.Instance.ShowErrorMessageAsync(EErrorCode.UnknownError).Forget();` を仕込んでタイトルに戻る際にエラー、警告が出ないこととゲームを再度進行できることを確認。

### 参考 URL
[DonyDestroyOnLoadを解除する方法](https://qiita.com/ELIXIR/items/72b8684adddabbe594e3)