### PR TITLE
タイムラインで道の解放を実装する

### DIFF
--- a/Assets/Project/Actors/UIs/MenuSelectScene/LevelSelect/Materials/RoadShader.shader
+++ b/Assets/Project/Actors/UIs/MenuSelectScene/LevelSelect/Materials/RoadShader.shader
@@ -1,0 +1,39 @@
+Shader "Unlit/RoadShader"
+{
+    Properties
+    {
+        _MainTex ("Texture", 2D) = "white" {}
+        _UnreleasedColor ("Unreleased Color", Color) = (0.2,0.2,0.7,1)
+        [PerRendererData] _fillAmount ("Fill Amount", Float) = 0
+    }
+    SubShader
+    {
+        Tags { "RenderType"="Opaque" }
+        LOD 100
+
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert_img
+            #pragma fragment frag
+            #include "UnityCG.cginc"
+
+            float _fillAmount;
+            
+            sampler2D _MainTex;
+            half4 _UnreleasedColor;
+
+            fixed4 frag (v2f_img i) : SV_Target
+            {
+                // sample the texture
+                fixed4 col = tex2D(_MainTex, i.uv);
+
+                if (i.uv.x < _fillAmount) {
+                    return col;
+                }
+                return col * _UnreleasedColor;
+            }
+            ENDCG
+        }
+    }
+}

--- a/Assets/Project/Actors/UIs/MenuSelectScene/LevelSelect/Materials/RoadShader.shader
+++ b/Assets/Project/Actors/UIs/MenuSelectScene/LevelSelect/Materials/RoadShader.shader
@@ -28,10 +28,13 @@ Shader "Unlit/RoadShader"
                 // sample the texture
                 fixed4 col = tex2D(_MainTex, i.uv);
 
-                if (i.uv.x < _fillAmount) {
-                    return col;
-                }
-                return col * _UnreleasedColor;
+                // if (i.uv.x < _fillAmount) {
+                //     return col;
+                // }
+                // return col * _UnreleasedColor;
+                // 高速版
+                fixed4 unreleased_color = (1 - step(_fillAmount, i.uv.x)) + step(_fillAmount, i.uv.x) * _UnreleasedColor;
+                return col * unreleased_color;
             }
             ENDCG
         }

--- a/Assets/Project/Actors/UIs/MenuSelectScene/LevelSelect/Materials/RoadShader.shader.meta
+++ b/Assets/Project/Actors/UIs/MenuSelectScene/LevelSelect/Materials/RoadShader.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 778947382a47845a295f3276fc6b8dd5
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/Actors/UIs/MenuSelectScene/LevelSelect/Materials/road.mat
+++ b/Assets/Project/Actors/UIs/MenuSelectScene/LevelSelect/Materials/road.mat
@@ -8,15 +8,14 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: road
-  m_Shader: {fileID: 211, guid: 0000000000000000f000000000000000, type: 0}
+  m_Shader: {fileID: 4800000, guid: 778947382a47845a295f3276fc6b8dd5, type: 3}
   m_ShaderKeywords: 
   m_LightmapFlags: 0
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}
-  disabledShaderPasses:
-  - ALWAYS
+  disabledShaderPasses: []
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
@@ -56,6 +55,7 @@ Material:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
+    m_Ints: []
     m_Floats:
     - _BlendOp: 0
     - _BumpScale: 1
@@ -90,9 +90,11 @@ Material:
     - _SrcBlend: 1
     - _UVSec: 0
     - _ZWrite: 1
+    - _fillAmount: 0
     m_Colors:
     - _CameraFadeParams: {r: 0, g: Infinity, b: 0, a: 0}
     - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _ColorAddSubDiff: {r: 0, g: 0, b: 0, a: 0}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _SoftParticleFadeParams: {r: 0, g: 0, b: 0, a: 0}
+  m_BuildTextureStacks: []

--- a/Assets/Project/Actors/UIs/MenuSelectScene/LevelSelect/UnlockTreeTimeline.meta
+++ b/Assets/Project/Actors/UIs/MenuSelectScene/LevelSelect/UnlockTreeTimeline.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 63de700ea35ce4ff1a1160c9c6d51623
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/Actors/UIs/MenuSelectScene/LevelSelect/UnlockTreeTimeline/UnlockNewLevel.playable
+++ b/Assets/Project/Actors/UIs/MenuSelectScene/LevelSelect/UnlockTreeTimeline/UnlockNewLevel.playable
@@ -1,0 +1,130 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bfda56da833e2384a9677cd3c976a436, type: 3}
+  m_Name: UnlockNewLevel
+  m_EditorClassIdentifier: 
+  m_Version: 0
+  m_Tracks:
+  - {fileID: 2326175080837584714}
+  m_FixedDuration: 0
+  m_EditorSettings:
+    m_Framerate: 60
+    m_ScenePreview: 1
+  m_DurationMode: 0
+  m_MarkerTrack: {fileID: 0}
+--- !u!114 &2326175080837584714
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 82cd92ffc29383742932b27ca414c80f, type: 3}
+  m_Name: Release Road
+  m_EditorClassIdentifier: 
+  m_Version: 3
+  m_AnimClip: {fileID: 0}
+  m_Locked: 0
+  m_Muted: 0
+  m_CustomPlayableFullTypename: 
+  m_Curves: {fileID: 0}
+  m_Parent: {fileID: 11400000}
+  m_Children: []
+  m_Clips:
+  - m_Version: 1
+    m_Start: 0
+    m_ClipIn: 0
+    m_Asset: {fileID: 8618533810037784934}
+    m_Duration: 5
+    m_TimeScale: 1
+    m_ParentTrack: {fileID: 2326175080837584714}
+    m_EaseInDuration: 0
+    m_EaseOutDuration: 0
+    m_BlendInDuration: -1
+    m_BlendOutDuration: -1
+    m_MixInCurve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 1
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    m_MixOutCurve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 1
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    m_BlendInCurveMode: 0
+    m_BlendOutCurveMode: 0
+    m_ExposedParameterNames: []
+    m_AnimationCurves: {fileID: 0}
+    m_Recordable: 0
+    m_PostExtrapolationMode: 0
+    m_PreExtrapolationMode: 0
+    m_PostExtrapolationTime: 0
+    m_PreExtrapolationTime: 0
+    m_DisplayName: RoadPlayableAsset
+  m_Markers:
+    m_Objects: []
+--- !u!114 &8618533810037784934
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d315102967b2d4679a2a020852ffce3e, type: 3}
+  m_Name: RoadPlayableAsset
+  m_EditorClassIdentifier: 
+  _roadController:
+    exposedName: 87b37a0706def4339800d3e56a9c15eb
+    defaultValue: {fileID: 0}

--- a/Assets/Project/Actors/UIs/MenuSelectScene/LevelSelect/UnlockTreeTimeline/UnlockNewLevel.playable.meta
+++ b/Assets/Project/Actors/UIs/MenuSelectScene/LevelSelect/UnlockTreeTimeline/UnlockNewLevel.playable.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 674fc47c109ff49b89b6b4e892e349ae
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/Scenes/MenuSelectScene.unity
+++ b/Assets/Project/Scenes/MenuSelectScene.unity
@@ -5926,6 +5926,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   releaseAnimationPlayedRoads: []
   releaseAnimationPlayedTrees: 
+  UnlockLevelDirector: {fileID: 1284822221}
 --- !u!1 &146333933
 GameObject:
   m_ObjectHideFlags: 0
@@ -6454,6 +6455,105 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 749823726}
   m_PrefabAsset: {fileID: 0}
+--- !u!21 &291647434
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: road (Instance)
+  m_Shader: {fileID: 4800000, guid: 778947382a47845a295f3276fc6b8dd5, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 0
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 2800000, guid: a94e70fbd252344e1bd84a7a9b47c735, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _BlendOp: 0
+    - _BumpScale: 1
+    - _CameraFadingEnabled: 0
+    - _CameraFarFadeDistance: 2
+    - _CameraNearFadeDistance: 1
+    - _ColorMode: 0
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DistortionBlend: 0.5
+    - _DistortionEnabled: 0
+    - _DistortionStrength: 1
+    - _DistortionStrengthScaled: 0
+    - _DstBlend: 0
+    - _EmissionEnabled: 0
+    - _FlipbookMode: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _InvFade: 1
+    - _LightingEnabled: 0
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SoftParticlesEnabled: 0
+    - _SoftParticlesFarFadeDistance: 1
+    - _SoftParticlesNearFadeDistance: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    - _fillAmount: 0
+    m_Colors:
+    - _CameraFadeParams: {r: 0, g: Infinity, b: 0, a: 0}
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _ColorAddSubDiff: {r: 0, g: 0, b: 0, a: 0}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SoftParticleFadeParams: {r: 0, g: 0, b: 0, a: 0}
+    - _UnreleasedColor: {r: 0.2, g: 0.2, b: 0.7, a: 1}
+  m_BuildTextureStacks: []
 --- !u!224 &294312317 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 7367111263612083138, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
@@ -22936,6 +23036,54 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1284822220
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1284822222}
+  - component: {fileID: 1284822221}
+  m_Layer: 0
+  m_Name: UnlockNewLevel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!320 &1284822221
+PlayableDirector:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1284822220}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_PlayableAsset: {fileID: 11400000, guid: 674fc47c109ff49b89b6b4e892e349ae, type: 2}
+  m_InitialState: 0
+  m_WrapMode: 2
+  m_DirectorUpdateMode: 1
+  m_InitialTime: 0
+  m_SceneBindings: []
+  m_ExposedReferences:
+    m_References: []
+--- !u!4 &1284822222
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1284822220}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1298694463
 GameObject:
   m_ObjectHideFlags: 0
@@ -25201,6 +25349,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3838137885523574259, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
         type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 291647434}
+    - target: {fileID: 3838137885523574259, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
+        type: 3}
       propertyPath: m_Positions.Array.data[0].x
       value: -597.375
       objectReference: {fileID: 0}
@@ -26457,6 +26610,46 @@ LineRenderer:
     type: 3}
   m_PrefabInstance: {fileID: 1703320558}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1703320561 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6435458436284193576, guid: 80d3585f332184b7c9fdc5aaccdfa93a,
+    type: 3}
+  m_PrefabInstance: {fileID: 1703320558}
+  m_PrefabAsset: {fileID: 0}
+--- !u!95 &1703320562
+Animator:
+  serializedVersion: 3
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1703320561}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 0}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorControllerStateOnDisable: 0
+--- !u!114 &1703320563
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1703320561}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e52de21a22b6dd44c9cc19f810c65059, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Events:
+    m_Signals: []
+    m_Events: []
 --- !u!1 &1704228717
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Project/Scripts/Common/Utils/Constants.cs
+++ b/Assets/Project/Scripts/Common/Utils/Constants.cs
@@ -255,5 +255,10 @@ namespace Treevel.Common.Utils
         /// 一季節が許容できる木の数
         /// </summary>
         public const int MAX_TREE_NUM_IN_SEASON = 1000;
+
+        public static class TimelineReferenceKey
+        {
+            public const string ROAD_TO_RELEASE = "RoadToRelease";
+        }
     }
 }

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/LevelSelectDirector.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/LevelSelectDirector.cs
@@ -98,7 +98,7 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
             while (waitForReleaseRoads.Count > 0) {
                 // 道を解放する演出を再生
                 var releaseRoad = waitForReleaseRoads[0];
-                UnlockLevelDirector.SetReferenceValue("ReleaseRoad", releaseRoad);
+                UnlockLevelDirector.SetReferenceValue(Constants.TimelineReferenceKey.ROAD_TO_RELEASE, releaseRoad);
                 UnlockLevelDirector.Play();
 
                 // 演出終了まで待つ

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/LineControllerBase.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/LineControllerBase.cs
@@ -1,5 +1,4 @@
-﻿using Cysharp.Threading.Tasks;
-using UniRx;
+﻿using UniRx;
 using UnityEngine;
 
 namespace Treevel.Modules.MenuSelectScene.LevelSelect
@@ -57,7 +56,7 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
         /// <summary>
         /// データを保存するときのキー
         /// </summary>
-        protected string saveKey;
+        public string saveKey { get; protected set; }
 
         protected virtual void Awake()
         {
@@ -78,7 +77,7 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
 
         protected abstract void SetSaveKey();
 
-        public abstract UniTask UpdateStateAsync();
+        public abstract void UpdateState();
 
         /// <summary>
         /// 曲線の通過点の位置を求める

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/LineControllerBase.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/LineControllerBase.cs
@@ -85,7 +85,7 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
         /// </summary>
         public void SetPointPosition()
         {
-            if (lineRenderer == null) return;
+            if (lineRenderer == null || startObject == null || endObject == null) return;
             lineRenderer.positionCount = _middlePointNum + 2;
             lineRenderer.startWidth = lineRenderer.endWidth = Screen.width * width * Scale.Value;
 

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/RoadController.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/RoadController.cs
@@ -1,10 +1,6 @@
-﻿using System.Threading;
-using Cysharp.Threading.Tasks;
-using Treevel.Common.Entities;
+﻿using Treevel.Common.Entities;
 using Treevel.Common.Managers;
 using Treevel.Common.Utils;
-using UniRx;
-using UniRx.Triggers;
 using UnityEngine;
 
 namespace Treevel.Modules.MenuSelectScene.LevelSelect
@@ -46,11 +42,26 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
             PlayerPrefs.DeleteKey(saveKey);
         }
 
+        /// <summary>
+        /// 解放できるか
+        /// </summary>
+        /// <returns>
+        /// 末端の木に解放条件がない(初期解放)ならfalse
+        /// 末端の木に条件がありかつ条件クリアしたらtrue
+        /// </returns>
+        public bool CanBeReleased()
+        {
+            var treeData = GameDataManager.GetTreeData(_endObjectController.treeId);
+            if (treeData.constraintTrees.Count == 0)
+                return false;
+
+            return _endObjectController.state == ETreeState.Released;
+        }
 
         /// <summary>
         /// 道の状態の更新
         /// </summary>
-        public override async UniTask UpdateStateAsync()
+        public override void UpdateState()
         {
             var endTreeData = GameDataManager.GetTreeData(_endObjectController.treeId);
 
@@ -66,21 +77,6 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
             } else if (LevelSelectDirector.Instance.releaseAnimationPlayedRoads.Contains(saveKey)) {
                 // 演出を再生したことがあればそのまま解放
                 _material.SetFloat(_SHADER_PARAM_FILL_AMOUNT, 1.0f);
-            } else {
-                // 演出開始
-                // 画面切り替える際に強制的に終わらせる
-                var cancelTokenSource = new CancellationTokenSource();
-                this.OnDisableAsObservable()
-                    .Subscribe(_ => {
-                        cancelTokenSource.Cancel();
-                    })
-                    .AddTo(cancelTokenSource.Token);
-
-                // 道が非解放状態から解放状態に変わった時
-                await ReleaseEndObjectAsync(cancelTokenSource.Token);
-
-                // 再生状態を保存
-                LevelSelectDirector.Instance.releaseAnimationPlayedRoads.Add(saveKey);
             }
         }
 
@@ -88,20 +84,8 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
         /// 道が非解放状態から解放状態に変わった時のアニメーション(100フレームで色を変化させる)
         /// </summary>
         /// <returns></returns>
-        private async UniTask ReleaseEndObjectAsync(CancellationToken cancelToken)
+        public void ReleaseEndObject()
         {
-            // 終点の木の状態の更新
-            _endObjectController.state = ETreeState.Released;
-
-            // 道の更新アニメーション
-            for (var i = 0; i < _CLEAR_ANIMATION_FRAMES; i++) {
-                if (cancelToken.IsCancellationRequested) break;
-
-                // 先端から末端まで明るくなる
-                _material.SetFloat(_SHADER_PARAM_FILL_AMOUNT, Mathf.Lerp(0, 1, (float)i / _CLEAR_ANIMATION_FRAMES));
-                await UniTask.Yield(PlayerLoopTiming.FixedUpdate);
-            }
-
             // 終点の木の状態の更新アニメーション
             _endObjectController.ReflectTreeState();
             // 木の解放演出見たことを記録する

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/RoadController.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/RoadController.cs
@@ -19,26 +19,20 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
         private const int _CLEAR_ANIMATION_FRAMES = 200;
 
         /// <summary>
-        /// 解放時の道の色
+        /// 解放時のテクスチャの占領比率(1.0だと全解放)
         /// </summary>
-        private static readonly Color _ROAD_RELEASED_COLOR = Color.white;
+        private static readonly int _SHADER_PARAM_FILL_AMOUNT = Shader.PropertyToID("_fillAmount");
 
         /// <summary>
-        /// 非解放時の道の色
+        /// LineRendererのマテリアル
         /// </summary>
-        /// <returns></returns>
-        private static readonly Color _ROAD_UNRELEASED_COLOR = new Color(0.2f, 0.2f, 0.7f);
+        private Material _material;
 
         protected override void Awake()
         {
             base.Awake();
             _endObjectController = endObject.GetComponentInParent<LevelTreeController>();
-        }
-
-        protected override void Start()
-        {
-            base.Start();
-            lineRenderer.material.SetTextureScale("_MainTex", new Vector2(8 / lineLength, 1f));
+            _material = lineRenderer.material;
         }
 
         protected override void SetSaveKey()
@@ -52,6 +46,7 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
             PlayerPrefs.DeleteKey(saveKey);
         }
 
+
         /// <summary>
         /// 道の状態の更新
         /// </summary>
@@ -61,16 +56,16 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
 
             if (endTreeData.constraintTrees.Count == 0) {
                 // 初期解放
-                lineRenderer.startColor = lineRenderer.endColor = _ROAD_RELEASED_COLOR;
+                _material.SetFloat(_SHADER_PARAM_FILL_AMOUNT, 1.0f);
                 return;
             }
 
             if (_endObjectController.state == ETreeState.Unreleased) {
                 // 未解放
-                lineRenderer.startColor = lineRenderer.endColor = _ROAD_UNRELEASED_COLOR;
+                _material.SetFloat(_SHADER_PARAM_FILL_AMOUNT, 0.0f);
             } else if (LevelSelectDirector.Instance.releaseAnimationPlayedRoads.Contains(saveKey)) {
                 // 演出を再生したことがあればそのまま解放
-                lineRenderer.startColor = lineRenderer.endColor = _ROAD_RELEASED_COLOR;
+                _material.SetFloat(_SHADER_PARAM_FILL_AMOUNT, 1.0f);
             } else {
                 // 演出開始
                 // 画面切り替える際に強制的に終わらせる
@@ -102,9 +97,8 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
             for (var i = 0; i < _CLEAR_ANIMATION_FRAMES; i++) {
                 if (cancelToken.IsCancellationRequested) break;
 
-                // 非解放状態から解放状態まで線形補間
-                lineRenderer.startColor = lineRenderer.endColor =
-                    Color.Lerp(_ROAD_UNRELEASED_COLOR, _ROAD_RELEASED_COLOR, (float)i / _CLEAR_ANIMATION_FRAMES);
+                // 先端から末端まで明るくなる
+                _material.SetFloat(_SHADER_PARAM_FILL_AMOUNT, Mathf.Lerp(0, 1, (float)i / _CLEAR_ANIMATION_FRAMES));
                 await UniTask.Yield(PlayerLoopTiming.FixedUpdate);
             }
 

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/RoadController.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/RoadController.cs
@@ -10,11 +10,6 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
         private LevelTreeController _endObjectController;
 
         /// <summary>
-        /// 道の解放アニメーションのフレーム数
-        /// </summary>
-        private const int _CLEAR_ANIMATION_FRAMES = 200;
-
-        /// <summary>
         /// 解放時のテクスチャの占領比率(1.0だと全解放)
         /// </summary>
         private static readonly int _SHADER_PARAM_FILL_AMOUNT = Shader.PropertyToID("_fillAmount");

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/RoadPlayableAsset.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/RoadPlayableAsset.cs
@@ -22,7 +22,7 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
             // PlayableBehaviourを取得する
             var behaviour = playable.GetBehaviour();
             // 参照を解決する
-            behaviour.RoadController = (RoadController) graph.GetResolver().GetReferenceValue(Constants.TimelineReferenceKey.ROAD_TO_RELEASE, out var isValid);
+            behaviour.roadController = (RoadController) graph.GetResolver().GetReferenceValue(Constants.TimelineReferenceKey.ROAD_TO_RELEASE, out var isValid);
             Debug.Assert(isValid, $"Unable to resolve reference {Constants.TimelineReferenceKey.ROAD_TO_RELEASE}");
 
             return playable;

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/RoadPlayableAsset.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/RoadPlayableAsset.cs
@@ -1,0 +1,30 @@
+using UnityEngine;
+using UnityEngine.Playables;
+
+namespace Treevel.Modules.MenuSelectScene.LevelSelect
+{
+    /// <summary>
+    /// レベルセレクトシーンのロードを制御するためのカスタマイズトラックアセット
+    /// </summary>
+    public class RoadPlayableAsset : PlayableAsset
+    {
+        /// <summary>
+        /// Playableが再生された時（Playが呼ばれた時）に呼ばれる関数
+        /// ここで変数をカスタマイズトラックに渡すことができる
+        /// </summary>
+        /// <param name="graph"></param>
+        /// <param name="owner">このPlayableAssetを使っているPlayable Directorがアタッチしているゲームオブジェクト</param>
+        public override Playable CreatePlayable(PlayableGraph graph, GameObject owner)
+        {
+            // PlayableBehaviourを元にPlayableを作る
+            var playable = ScriptPlayable<RoadPlayableBehaviour>.Create(graph);
+            // PlayableBehaviourを取得する
+            var behaviour = playable.GetBehaviour();
+            // 参照を解決する
+            bool isValid;
+            behaviour.RoadController = (RoadController) graph.GetResolver().GetReferenceValue("ReleaseRoad", out isValid);
+
+            return playable;
+        }
+    }
+}

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/RoadPlayableAsset.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/RoadPlayableAsset.cs
@@ -22,8 +22,8 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
             // PlayableBehaviourを取得する
             var behaviour = playable.GetBehaviour();
             // 参照を解決する
-            bool isValid;
-            behaviour.RoadController = (RoadController) graph.GetResolver().GetReferenceValue(Constants.TimelineReferenceKey.ROAD_TO_RELEASE, out isValid);
+            behaviour.RoadController = (RoadController) graph.GetResolver().GetReferenceValue(Constants.TimelineReferenceKey.ROAD_TO_RELEASE, out var isValid);
+            Debug.Assert(isValid, $"Unable to resolve reference {Constants.TimelineReferenceKey.ROAD_TO_RELEASE}");
 
             return playable;
         }

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/RoadPlayableAsset.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/RoadPlayableAsset.cs
@@ -1,3 +1,4 @@
+using Treevel.Common.Utils;
 using UnityEngine;
 using UnityEngine.Playables;
 
@@ -22,7 +23,7 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
             var behaviour = playable.GetBehaviour();
             // 参照を解決する
             bool isValid;
-            behaviour.RoadController = (RoadController) graph.GetResolver().GetReferenceValue("ReleaseRoad", out isValid);
+            behaviour.RoadController = (RoadController) graph.GetResolver().GetReferenceValue(Constants.TimelineReferenceKey.ROAD_TO_RELEASE, out isValid);
 
             return playable;
         }

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/RoadPlayableAsset.cs.meta
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/RoadPlayableAsset.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d315102967b2d4679a2a020852ffce3e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/RoadPlayableBehaviour.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/RoadPlayableBehaviour.cs
@@ -8,7 +8,7 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
     /// </summary>
     public class RoadPlayableBehaviour : PlayableBehaviour
     {
-        public RoadController RoadController { get; set; }
+        public RoadController roadController;
 
         private Material _material;
 
@@ -21,8 +21,8 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
         // 非ランタイムでも呼ばれるので注意！
         public override void ProcessFrame(Playable playable, FrameData info, object playerData)
         {
-            if (_material == null && RoadController != null) {
-                _material = RoadController.GetComponent<LineRenderer>().sharedMaterial;
+            if (_material == null && roadController != null) {
+                _material = roadController.GetComponent<LineRenderer>().sharedMaterial;
             }
             if (_material == null) {
                 return;

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/RoadPlayableBehaviour.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/RoadPlayableBehaviour.cs
@@ -1,0 +1,35 @@
+using UnityEngine;
+using UnityEngine.Playables;
+
+namespace Treevel.Modules.MenuSelectScene.LevelSelect
+{
+    /// <summary>
+    /// レベルセレクトシーンのロードを制御するためのカスタマイズトラックインスタンス
+    /// </summary>
+    public class RoadPlayableBehaviour : PlayableBehaviour
+    {
+        public RoadController RoadController { get; set; }
+
+        private Material _material;
+
+        /// <summary>
+        /// 解放時のテクスチャの占領比率(1.0だと全解放)
+        /// </summary>
+        private static readonly int _SHADER_PARAM_FILL_AMOUNT = Shader.PropertyToID("_fillAmount");
+
+        // フレーム毎の処理
+        // 非ランタイムでも呼ばれるので注意！
+        public override void ProcessFrame(Playable playable, FrameData info, object playerData)
+        {
+            if (_material == null && RoadController != null) {
+                _material = RoadController.GetComponent<LineRenderer>().sharedMaterial;
+            }
+            if (_material == null) {
+                return;
+            }
+            var progress = (float)(playable.GetTime() / playable.GetDuration());
+
+            _material.SetFloat(_SHADER_PARAM_FILL_AMOUNT, Mathf.Lerp(0, 1, progress));
+        }
+    }
+}

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/RoadPlayableBehaviour.cs.meta
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/RoadPlayableBehaviour.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e50ec80aebf1c429b80853272e114a83
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/Scripts/Modules/StageSelectScene/BranchController.cs
+++ b/Assets/Project/Scripts/Modules/StageSelectScene/BranchController.cs
@@ -1,11 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Cysharp.Threading.Tasks;
 using Treevel.Common.Entities;
-using Treevel.Common.Entities.GameDatas;
 using Treevel.Common.Managers;
-using Treevel.Common.Networks;
-using Treevel.Common.Networks.Requests;
 using Treevel.Common.Utils;
 using Treevel.Modules.MenuSelectScene.LevelSelect;
 using UnityEngine;
@@ -33,7 +29,7 @@ namespace Treevel.Modules.StageSelectScene
         /// <summary>
         /// 枝の状態の更新
         /// </summary>
-        public override async UniTask UpdateStateAsync()
+        public override void UpdateState()
         {
             var constraintStageData = GameDataManager.GetStage(_treeId, endObject.GetComponent<StageController>().stageNumber);
             var constraintStages = constraintStageData.ConstraintStages;

--- a/Assets/Project/Scripts/Modules/StageSelectScene/StageSelectDirector.cs
+++ b/Assets/Project/Scripts/Modules/StageSelectScene/StageSelectDirector.cs
@@ -122,7 +122,7 @@ namespace Treevel.Modules.StageSelectScene
         {
             SoundManager.Instance.PlayBGM(seasonId.GetStageSelectBGM());
 
-            _branches.ForEach(branch => branch.UpdateStateAsync().Forget());
+            _branches.ForEach(branch => branch.UpdateState());
             _trees.ForEach(tree => tree.UpdateState());
         }
 

--- a/ProjectSettings/TimelineSettings.asset
+++ b/ProjectSettings/TimelineSettings.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 61
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a287be6c49135cd4f9b2b8666c39d999, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  assetDefaultFramerate: 60


### PR DESCRIPTION
### 対象イシュー
#817
※design/#817-main-branchを作成し、マージ対象とした。#817 での作業が一通り終わったら、design/#817-main-branchからdevelopへのPRを出し、クローズとするのでここではCloseつけない


### 概要
* 道の解放アニメーション変更（キャプチャを参照）
* 解放できる道を一斉解放→一つ一つ解放
* 解放アニメーションはマテリアルの色の制御 → シェーダーのパラメータ制御
* 解放アニメーションはコルチーンによる実装 → `Timeline` による実装

### 詳細

#### 技術的な内容

### `Timelineの設定`

1. タイムラインのアセット作成 ( `Assets/Project/Actors/UIs/MenuSelectScene/LevelSelect/UnlockTreeTimeline/UnlockNewLevel.playable`）
2. MenuSelectSceneに作成したタイムラインアセットをドラッグ＆ドロップし、インスタンスを作成
3. `RoadPlayableAsset.cs` と `RoadPlayableBehaviour.cs` を作成、実装
4. 1.で作成したアセットをダブルクリックし、Timeline エディタを開く
5. `Playable Track` を追加する
![image](https://user-images.githubusercontent.com/17778395/120223201-2fe1ea00-c27c-11eb-8956-82acfa28908b.png)
6. `Add Road Playable Asset` を追加
![image](https://user-images.githubusercontent.com/17778395/120223260-4d16b880-c27c-11eb-8bee-a64f710f9e6b.png)

以上で設定完了です。
あとはLevelSelectDirectorの実装次第で動かせるだけ。
Timelineについてのノーハウは [Scrapbox](https://scrapbox.io/treevel/Unity_Timeline)
に順次追記予定
 
[ITimelineControlをRoadControllerに実装させる](https://light11.hatenadiary.com/entry/2019/05/22/003523#ITimeControlを実装するだけで既存クラスがTimelineに対応)も一つの方法ですが、
この方法だとクリップの長さを取得できないので、今回の実装では向いていない。

### キャプチャ

* 変更前 

https://user-images.githubusercontent.com/17778395/120216084-839b0600-c271-11eb-8218-a01a2c370d09.mov  

* 変更後

https://user-images.githubusercontent.com/17778395/120216120-90b7f500-c271-11eb-95e8-4e9a8e5055cb.mov 

* Timeline設定（ここからカメラや木の解放用のクリップを追加していく予定）
![image](https://user-images.githubusercontent.com/17778395/120220476-bb0cb100-c277-11eb-9495-8c4251c7c41e.png)


### 動作確認方法

### 参考 URL
[カスタムクリップの作り方](https://light11.hatenadiary.com/entry/2019/05/16/214328)
[カスタムクリップでオブジェクトのプロパティを制御する方法](https://light11.hatenadiary.com/entry/2019/05/22/003523)
[カスタムクリップの制御対象を動的に変える方法](http://tsubakit1.hateblo.jp/entry/2017/04/26/221548)
