### PR TITLE
実機と `Simulator` でシングルタップがダブルタップになってしまう問題を修正する

### DIFF
--- a/Assets/Project/Scenes/StartUpScene.unity
+++ b/Assets/Project/Scenes/StartUpScene.unity
@@ -933,7 +933,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1857380286}
   - component: {fileID: 1857380285}
-  - component: {fileID: 1857380284}
   m_Layer: 0
   m_Name: EventSystem
   m_TagString: Untagged
@@ -941,25 +940,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!114 &1857380284
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1857380283}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_HorizontalAxis: Horizontal
-  m_VerticalAxis: Vertical
-  m_SubmitButton: Submit
-  m_CancelButton: Cancel
-  m_InputActionsPerSecond: 10
-  m_RepeatDelay: 0.5
-  m_ForceModuleActive: 0
 --- !u!114 &1857380285
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
### 対象イシュー
Close #954 

### 概要
- タイトルまま

### 詳細

#### 現実装になった経緯
`Standalone Input Module` があることにより `Touch Script` とタップイベントが被り、2回タップされていた判定になっていたよう。なぜ実機や `Simulator` だけで起こっていたかまでは調査していない

### 動作確認方法
※ `feature/#945-build-with-Xcode` をベースにしているので、実機での動作確認が可能
※ ダブルタップかどうかの判定は、ボタンタップ時のサウンドエフェクトが2回聞こえるなどがある

- [x] `Simulator` でシングルタップがダブルタップになっていないこと
- [x] 実機でシングルタップがダブルタップになっていないこと
