### PR TITLE
フリックさせるオブジェクト、フリックさせないオブジェクトの仕分け

### DIFF
--- a/Assets/Project/Actors/Bottles/Attribute/Dark/DarkAttributePrefab.prefab
+++ b/Assets/Project/Actors/Bottles/Attribute/Dark/DarkAttributePrefab.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: -1143049788199428512}
   - component: {fileID: 8459921267124050366}
   - component: {fileID: -284567340377621959}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: DarkAttributePrefab
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Project/Actors/Bottles/Attribute/Life/LifeAttributePrefab.prefab
+++ b/Assets/Project/Actors/Bottles/Attribute/Life/LifeAttributePrefab.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 8173901480666266857}
   - component: {fileID: 8631500646673489353}
   - component: {fileID: 379948787266167587}
-  m_Layer: 8
+  m_Layer: 11
   m_Name: LifeAttributePrefab
   m_TagString: Bottle
   m_Icon: {fileID: 0}
@@ -143,7 +143,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7764255637428221765}
   - component: {fileID: 8763257028011943386}
-  m_Layer: 8
+  m_Layer: 11
   m_Name: Life_Value
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Project/Actors/Bottles/Attribute/Reverse/ReverseAttributePrefab.prefab
+++ b/Assets/Project/Actors/Bottles/Attribute/Reverse/ReverseAttributePrefab.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 4349126909494314989}
   - component: {fileID: 3126369013498768732}
   - component: {fileID: -162704476647970571}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: ReverseAttributePrefab
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Project/Actors/Bottles/Attribute/Selfish/SelfishAttributePrefab.prefab
+++ b/Assets/Project/Actors/Bottles/Attribute/Selfish/SelfishAttributePrefab.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: -7378703386771444903}
   - component: {fileID: -5874565732980710310}
   - component: {fileID: 8086853820073038369}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: SelfishAttributePrefab
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Project/Actors/Bottles/Dynamic/AttackableDummy/AttackableDummyBottlePrefab.prefab
+++ b/Assets/Project/Actors/Bottles/Dynamic/AttackableDummy/AttackableDummyBottlePrefab.prefab
@@ -17,7 +17,7 @@ GameObject:
   - component: {fileID: -9013513175073661242}
   - component: {fileID: -7042337766198875321}
   - component: {fileID: -8160892875361653244}
-  m_Layer: 11
+  m_Layer: 12
   m_Name: AttackableDummyBottlePrefab
   m_TagString: Bottle
   m_Icon: {fileID: 0}
@@ -160,8 +160,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7827729b12fc9456cb1fb13b45eb6a77, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  isInvincible:
-    value: 0
   pressGesture: {fileID: 0}
   releaseGesture: {fileID: 0}
   IsMovable: 1

--- a/Assets/Project/Actors/Bottles/Dynamic/DynamicDummy/DynamicDummyBottlePrefab.prefab
+++ b/Assets/Project/Actors/Bottles/Dynamic/DynamicDummy/DynamicDummyBottlePrefab.prefab
@@ -17,7 +17,7 @@ GameObject:
   - component: {fileID: 8018115131031875109}
   - component: {fileID: 7675137770996352934}
   - component: {fileID: 7687756714731740323}
-  m_Layer: 11
+  m_Layer: 12
   m_Name: DynamicDummyBottlePrefab
   m_TagString: Bottle
   m_Icon: {fileID: 0}

--- a/Assets/Project/Actors/Bottles/Erasable/ErasableBottlePrefab.prefab
+++ b/Assets/Project/Actors/Bottles/Erasable/ErasableBottlePrefab.prefab
@@ -10,7 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4248486251218223223}
   - component: {fileID: 6659436708170590845}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: ErasableBottle
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -99,7 +99,7 @@ GameObject:
   - component: {fileID: -1546950672185580045}
   - component: {fileID: 5393982599534609861}
   - component: {fileID: 7463468784555252759}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: ErasableBottlePrefab
   m_TagString: Bottle
   m_Icon: {fileID: 0}
@@ -343,7 +343,7 @@ GameObject:
   m_Component:
   - component: {fileID: 5000076265355128493}
   - component: {fileID: 4304224726560495246}
-  m_Layer: 11
+  m_Layer: 14
   m_Name: Rubble
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Project/Actors/Bottles/Goal/GoalBottlePrefab.prefab
+++ b/Assets/Project/Actors/Bottles/Goal/GoalBottlePrefab.prefab
@@ -21,7 +21,7 @@ GameObject:
   - component: {fileID: 199597489305304372}
   - component: {fileID: 3191877913524096823}
   - component: {fileID: -8491268406887753677}
-  m_Layer: 8
+  m_Layer: 12
   m_Name: GoalBottlePrefab
   m_TagString: Bottle
   m_Icon: {fileID: 0}
@@ -62,7 +62,7 @@ SpriteRenderer:
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 0}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/Assets/Project/Actors/Bottles/StaticDummy/StaticDummyBottlePrefab.prefab
+++ b/Assets/Project/Actors/Bottles/StaticDummy/StaticDummyBottlePrefab.prefab
@@ -12,7 +12,8 @@ GameObject:
   - component: {fileID: 212957416217724866}
   - component: {fileID: 114688854412061546}
   - component: {fileID: -4652920788660859885}
-  m_Layer: 11
+  - component: {fileID: 2621414864250755307}
+  m_Layer: 12
   m_Name: StaticDummyBottlePrefab
   m_TagString: Bottle
   m_Icon: {fileID: 0}
@@ -111,3 +112,29 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   RatioToWindowWidth: 0.209
   ImageRatio: 1
+--- !u!61 &2621414864250755307
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1218310520019280}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 216, y: 216}
+    newSize: {x: 2, y: 2}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 216, y: 216}
+  m_EdgeRadius: 0

--- a/Assets/Project/Actors/Gimmicks/AimingMeteorite/AimingMeteoritePrefab.prefab
+++ b/Assets/Project/Actors/Gimmicks/AimingMeteorite/AimingMeteoritePrefab.prefab
@@ -14,7 +14,7 @@ GameObject:
   - component: {fileID: 2192560534519944966}
   - component: {fileID: 1415040735867762399}
   - component: {fileID: 6400337209613131345}
-  m_Layer: 9
+  m_Layer: 10
   m_Name: AimingMeteoritePrefab
   m_TagString: Gimmick
   m_Icon: {fileID: 0}
@@ -46,6 +46,7 @@ SpriteRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -103,7 +104,7 @@ BoxCollider2D:
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 1.84, y: 1.72}
+    oldSize: {x: 184, y: 172}
     newSize: {x: 1.5, y: 1.5}
     adaptiveTilingThreshold: 0.5
     drawMode: 0
@@ -128,6 +129,7 @@ MonoBehaviour:
   _warningPrefab:
     m_AssetGUID: 358175ea13e4e4b71ad0826173ab32a8
     m_SubObjectName: 
+    m_SubObjectType: 
   _speed: 0.05
   _meteoriteDisplayTime: 1.5
 --- !u!50 &1415040735867762399

--- a/Assets/Project/Actors/Gimmicks/AimingMeteorite/AimingMeteoriteWarningPrefab.prefab
+++ b/Assets/Project/Actors/Gimmicks/AimingMeteorite/AimingMeteoriteWarningPrefab.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 4853091812657378}
   - component: {fileID: 7818347303455353202}
   - component: {fileID: 3620736120017674667}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: AimingMeteoriteWarningPrefab
   m_TagString: GimmickWarning
   m_Icon: {fileID: 0}
@@ -43,6 +43,7 @@ SpriteRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1

--- a/Assets/Project/Actors/Gimmicks/Erasable/ErasablePrefab.prefab
+++ b/Assets/Project/Actors/Gimmicks/Erasable/ErasablePrefab.prefab
@@ -10,7 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4467723264628291897}
   - component: {fileID: -4066585444902256335}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: ErasablePrefab
   m_TagString: Gimmick
   m_Icon: {fileID: 0}

--- a/Assets/Project/Actors/Gimmicks/Fog/FogPrefab.prefab
+++ b/Assets/Project/Actors/Gimmicks/Fog/FogPrefab.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 7465568517479401806}
   - component: {fileID: 7465568517479401807}
   - component: {fileID: -6906214641156771140}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: FogPrefab
   m_TagString: Gimmick
   m_Icon: {fileID: 0}
@@ -40,19 +40,19 @@ ParticleSystem:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7465568517479401804}
-  serializedVersion: 6
+  serializedVersion: 8
   lengthInSec: 1000
   simulationSpeed: 1
   stopAction: 2
   cullingMode: 0
   ringBufferMode: 0
   ringBufferLoopRange: {x: 0, y: 1}
+  emitterVelocityMode: 0
   looping: 0
   prewarm: 0
   playOnAwake: 0
   useUnscaledTime: 0
   autoRandomSeed: 1
-  useRigidbodyForVelocity: 1
   startDelay:
     serializedVersion: 2
     minMaxState: 0
@@ -602,6 +602,7 @@ ParticleSystem:
         m_RotationOrder: 4
     randomizeRotationDirection: 0
     maxNumParticles: 3000
+    customEmitterVelocity: {x: 0, y: 0, z: 0}
     size3D: 0
     rotation3D: 0
     gravityModifier:
@@ -3612,19 +3613,20 @@ ParticleSystem:
     range: {x: 0, y: 1}
   CollisionModule:
     enabled: 0
-    serializedVersion: 3
+    serializedVersion: 4
     type: 0
     collisionMode: 0
     colliderForce: 0
     multiplyColliderForceByParticleSize: 0
     multiplyColliderForceByParticleSpeed: 0
     multiplyColliderForceByCollisionAngle: 1
-    plane0: {fileID: 0}
-    plane1: {fileID: 0}
-    plane2: {fileID: 0}
-    plane3: {fileID: 0}
-    plane4: {fileID: 0}
-    plane5: {fileID: 0}
+    m_Planes:
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
     m_Dampen:
       serializedVersion: 2
       minMaxState: 0
@@ -3798,17 +3800,20 @@ ParticleSystem:
     interiorCollisions: 0
   TriggerModule:
     enabled: 0
-    collisionShape0: {fileID: 0}
-    collisionShape1: {fileID: 0}
-    collisionShape2: {fileID: 0}
-    collisionShape3: {fileID: 0}
-    collisionShape4: {fileID: 0}
-    collisionShape5: {fileID: 0}
+    serializedVersion: 2
     inside: 1
     outside: 0
     enter: 0
     exit: 0
+    colliderQueryMode: 0
     radiusScale: 1
+    primitives:
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
   SubModule:
     serializedVersion: 2
     enabled: 0
@@ -4759,6 +4764,7 @@ ParticleSystemRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0

--- a/Assets/Project/Actors/Gimmicks/GustWind/GustWindPrefab.prefab
+++ b/Assets/Project/Actors/Gimmicks/GustWind/GustWindPrefab.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 1488077701041527112}
   - component: {fileID: 7894972585210036848}
   - component: {fileID: 5854696154825769141}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Core
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -44,6 +44,7 @@ SpriteRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -102,7 +103,7 @@ BoxCollider2D:
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 0.39, y: 1.28}
+    oldSize: {x: 39, y: 128}
     newSize: {x: 0.39, y: 1.28}
     adaptiveTilingThreshold: 0.5
     drawMode: 0
@@ -136,7 +137,7 @@ GameObject:
   - component: {fileID: 2461613542187426270}
   - component: {fileID: 7753444328174355427}
   - component: {fileID: 3105503167032761670}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: Warning
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -168,6 +169,7 @@ SpriteRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -235,7 +237,7 @@ GameObject:
   - component: {fileID: -8155380594342631949}
   - component: {fileID: 6050347131260975815}
   - component: {fileID: -1970821014657745717}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: GustWindPrefab
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Project/Actors/Gimmicks/Meteorite/MeteoritePrefab.prefab
+++ b/Assets/Project/Actors/Gimmicks/Meteorite/MeteoritePrefab.prefab
@@ -14,7 +14,7 @@ GameObject:
   - component: {fileID: 2192560534519944966}
   - component: {fileID: 1415040735867762399}
   - component: {fileID: -5713041707575738716}
-  m_Layer: 9
+  m_Layer: 10
   m_Name: MeteoritePrefab
   m_TagString: Gimmick
   m_Icon: {fileID: 0}
@@ -46,6 +46,7 @@ SpriteRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -103,7 +104,7 @@ BoxCollider2D:
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 1.84, y: 1.72}
+    oldSize: {x: 184, y: 172}
     newSize: {x: 1.5, y: 1.5}
     adaptiveTilingThreshold: 0.5
     drawMode: 0
@@ -128,6 +129,7 @@ MonoBehaviour:
   _warningPrefab:
     m_AssetGUID: 0ed45840e88a448cfa0eb64fd45d7ad6
     m_SubObjectName: 
+    m_SubObjectType: 
   _speed: 0.05
   _meteoriteDisplayTime: 1.5
 --- !u!50 &1415040735867762399

--- a/Assets/Project/Actors/Gimmicks/Meteorite/MeteoriteWarningPrefab.prefab
+++ b/Assets/Project/Actors/Gimmicks/Meteorite/MeteoriteWarningPrefab.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 4853091812657378}
   - component: {fileID: 7818347303455353202}
   - component: {fileID: 8841465545679328930}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: MeteoriteWarningPrefab
   m_TagString: GimmickWarning
   m_Icon: {fileID: 0}
@@ -43,6 +43,7 @@ SpriteRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1

--- a/Assets/Project/Actors/Gimmicks/Powder/PowderPrefab.prefab
+++ b/Assets/Project/Actors/Gimmicks/Powder/PowderPrefab.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 7117462649650840972}
   - component: {fileID: 7792507300261705594}
   - component: {fileID: 1427797130001237422}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: PowderPrefab
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -77,7 +77,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4839869934210916188}
   - component: {fileID: 8730703421957391138}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: background
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -109,6 +109,7 @@ SpriteRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -160,7 +161,7 @@ GameObject:
   - component: {fileID: 5619682588287887918}
   - component: {fileID: 7394291851525064284}
   - component: {fileID: 5457558849041379454}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: UpperParticle
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -188,19 +189,19 @@ ParticleSystem:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6311083900650383077}
-  serializedVersion: 6
+  serializedVersion: 8
   lengthInSec: 5
   simulationSpeed: 1
   stopAction: 0
   cullingMode: 0
   ringBufferMode: 0
   ringBufferLoopRange: {x: 0, y: 1}
+  emitterVelocityMode: 0
   looping: 1
   prewarm: 0
   playOnAwake: 0
   useUnscaledTime: 0
   autoRandomSeed: 1
-  useRigidbodyForVelocity: 1
   startDelay:
     serializedVersion: 2
     minMaxState: 0
@@ -750,6 +751,7 @@ ParticleSystem:
         m_RotationOrder: 4
     randomizeRotationDirection: 0
     maxNumParticles: 2000
+    customEmitterVelocity: {x: 0, y: 0, z: 0}
     size3D: 0
     rotation3D: 0
     gravityModifier:
@@ -3760,19 +3762,20 @@ ParticleSystem:
     range: {x: 0, y: 1}
   CollisionModule:
     enabled: 0
-    serializedVersion: 3
+    serializedVersion: 4
     type: 0
     collisionMode: 0
     colliderForce: 0
     multiplyColliderForceByParticleSize: 0
     multiplyColliderForceByParticleSpeed: 0
     multiplyColliderForceByCollisionAngle: 1
-    plane0: {fileID: 0}
-    plane1: {fileID: 0}
-    plane2: {fileID: 0}
-    plane3: {fileID: 0}
-    plane4: {fileID: 0}
-    plane5: {fileID: 0}
+    m_Planes:
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
     m_Dampen:
       serializedVersion: 2
       minMaxState: 0
@@ -3946,17 +3949,20 @@ ParticleSystem:
     interiorCollisions: 0
   TriggerModule:
     enabled: 0
-    collisionShape0: {fileID: 0}
-    collisionShape1: {fileID: 0}
-    collisionShape2: {fileID: 0}
-    collisionShape3: {fileID: 0}
-    collisionShape4: {fileID: 0}
-    collisionShape5: {fileID: 0}
+    serializedVersion: 2
     inside: 1
     outside: 0
     enter: 0
     exit: 0
+    colliderQueryMode: 0
     radiusScale: 1
+    primitives:
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
   SubModule:
     serializedVersion: 2
     enabled: 0
@@ -4907,6 +4913,7 @@ ParticleSystemRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
@@ -4972,7 +4979,7 @@ GameObject:
   - component: {fileID: 4319950772771779470}
   - component: {fileID: 3159453280092069536}
   - component: {fileID: 7045330670989047657}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: LowerParticle
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5000,19 +5007,19 @@ ParticleSystem:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7737153643505541402}
-  serializedVersion: 6
+  serializedVersion: 8
   lengthInSec: 5
   simulationSpeed: 1
   stopAction: 0
   cullingMode: 0
   ringBufferMode: 0
   ringBufferLoopRange: {x: 0, y: 1}
+  emitterVelocityMode: 0
   looping: 1
   prewarm: 0
   playOnAwake: 0
   useUnscaledTime: 0
   autoRandomSeed: 1
-  useRigidbodyForVelocity: 1
   startDelay:
     serializedVersion: 2
     minMaxState: 0
@@ -5562,6 +5569,7 @@ ParticleSystem:
         m_RotationOrder: 4
     randomizeRotationDirection: 0
     maxNumParticles: 2000
+    customEmitterVelocity: {x: 0, y: 0, z: 0}
     size3D: 0
     rotation3D: 0
     gravityModifier:
@@ -8572,19 +8580,20 @@ ParticleSystem:
     range: {x: 0, y: 1}
   CollisionModule:
     enabled: 0
-    serializedVersion: 3
+    serializedVersion: 4
     type: 0
     collisionMode: 0
     colliderForce: 0
     multiplyColliderForceByParticleSize: 0
     multiplyColliderForceByParticleSpeed: 0
     multiplyColliderForceByCollisionAngle: 1
-    plane0: {fileID: 0}
-    plane1: {fileID: 0}
-    plane2: {fileID: 0}
-    plane3: {fileID: 0}
-    plane4: {fileID: 0}
-    plane5: {fileID: 0}
+    m_Planes:
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
     m_Dampen:
       serializedVersion: 2
       minMaxState: 0
@@ -8758,17 +8767,20 @@ ParticleSystem:
     interiorCollisions: 0
   TriggerModule:
     enabled: 0
-    collisionShape0: {fileID: 0}
-    collisionShape1: {fileID: 0}
-    collisionShape2: {fileID: 0}
-    collisionShape3: {fileID: 0}
-    collisionShape4: {fileID: 0}
-    collisionShape5: {fileID: 0}
+    serializedVersion: 2
     inside: 1
     outside: 0
     enter: 0
     exit: 0
+    colliderQueryMode: 0
     radiusScale: 1
+    primitives:
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
   SubModule:
     serializedVersion: 2
     enabled: 0
@@ -9719,6 +9731,7 @@ ParticleSystemRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0

--- a/Assets/Project/Actors/Gimmicks/Powder/SandPiledUpPowderPrefab.prefab
+++ b/Assets/Project/Actors/Gimmicks/Powder/SandPiledUpPowderPrefab.prefab
@@ -12,8 +12,8 @@ GameObject:
   - component: {fileID: 7640712185948031821}
   - component: {fileID: -1839672642548211350}
   - component: {fileID: 8488855785613460534}
-  m_Layer: 0
-  m_Name: PiledUpPowderPrefab
+  m_Layer: 9
+  m_Name: SandPiledUpPowderPrefab
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -76,6 +76,7 @@ SpriteRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1

--- a/Assets/Project/Actors/Gimmicks/SolarBeam/SolarBeamPrefab.prefab
+++ b/Assets/Project/Actors/Gimmicks/SolarBeam/SolarBeamPrefab.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 470725229216023298}
   - component: {fileID: 470725229216023297}
   - component: {fileID: 4520938434004662593}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: Sun
   m_TagString: Gimmick
   m_Icon: {fileID: 0}
@@ -44,6 +44,7 @@ SpriteRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -110,7 +111,7 @@ GameObject:
   - component: {fileID: 470725229250988589}
   - component: {fileID: 3103886746939451858}
   - component: {fileID: 5334517000982426671}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Beam
   m_TagString: Gimmick
   m_Icon: {fileID: 0}
@@ -142,6 +143,7 @@ SpriteRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -241,7 +243,7 @@ GameObject:
   - component: {fileID: 470725230576813244}
   - component: {fileID: 470725230576813245}
   - component: {fileID: 470725230576813246}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: SolarBeamPrefab
   m_TagString: Gimmick
   m_Icon: {fileID: 0}

--- a/Assets/Project/Actors/Gimmicks/Thunder/ThunderPrefab.prefab
+++ b/Assets/Project/Actors/Gimmicks/Thunder/ThunderPrefab.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 1252275918}
   - component: {fileID: 1252275919}
   - component: {fileID: 2490255250417828685}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: Cloud
   m_TagString: Gimmick
   m_Icon: {fileID: 0}
@@ -43,6 +43,7 @@ SpriteRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -110,7 +111,7 @@ GameObject:
   - component: {fileID: 2798508139326069883}
   - component: {fileID: 2202089891535575663}
   - component: {fileID: 6924343976475138377}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Thunder
   m_TagString: Gimmick
   m_Icon: {fileID: 0}
@@ -142,6 +143,7 @@ SpriteRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -236,7 +238,7 @@ GameObject:
   - component: {fileID: 8954458054731302080}
   - component: {fileID: 3899458119821525949}
   - component: {fileID: 3914408215352850826}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: ThunderPrefab
   m_TagString: Gimmick
   m_Icon: {fileID: 0}

--- a/Assets/Project/Actors/Gimmicks/Tornado/TornadoWarningPrefab.prefab
+++ b/Assets/Project/Actors/Gimmicks/Tornado/TornadoWarningPrefab.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 4853091812657378}
   - component: {fileID: 212792818627832022}
   - component: {fileID: 5902578088751177669}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: TornadoWarningPrefab
   m_TagString: GimmickWarning
   m_Icon: {fileID: 0}
@@ -43,6 +43,7 @@ SpriteRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1

--- a/Assets/Project/Actors/Tiles/Goal/GoalTilePrefab.prefab
+++ b/Assets/Project/Actors/Tiles/Goal/GoalTilePrefab.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 4104404946434494885}
   - component: {fileID: -9055332818116020086}
   - component: {fileID: 808286055539361411}
-  m_Layer: 12
+  m_Layer: 13
   m_Name: GoalTilePrefab
   m_TagString: Tile
   m_Icon: {fileID: 0}
@@ -47,6 +47,7 @@ SpriteRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -144,7 +145,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2106953408155653470}
   - component: {fileID: 531644605705325901}
-  m_Layer: 12
+  m_Layer: 13
   m_Name: Wound
   m_TagString: Tile
   m_Icon: {fileID: 0}
@@ -181,6 +182,7 @@ SpriteRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -231,7 +233,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1085035765100363750}
   - component: {fileID: 677855441096426752}
-  m_Layer: 12
+  m_Layer: 13
   m_Name: MainColorLayer
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -268,6 +270,7 @@ SpriteRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1

--- a/Assets/Project/Actors/Tiles/Holy/HolyTilePrefab.prefab
+++ b/Assets/Project/Actors/Tiles/Holy/HolyTilePrefab.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 6650673804721058915}
   - component: {fileID: 1423629175187906828}
   - component: {fileID: -1656817891040609873}
-  m_Layer: 12
+  m_Layer: 13
   m_Name: HolyTilePrefab
   m_TagString: Tile
   m_Icon: {fileID: 0}
@@ -44,6 +44,7 @@ SpriteRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1

--- a/Assets/Project/Actors/Tiles/Ice/IceTilePrefab.prefab
+++ b/Assets/Project/Actors/Tiles/Ice/IceTilePrefab.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 1025009851747015073}
   - component: {fileID: 7924455655039089364}
   - component: {fileID: 8704918159495494997}
-  m_Layer: 12
+  m_Layer: 13
   m_Name: IceTilePrefab
   m_TagString: Tile
   m_Icon: {fileID: 0}
@@ -123,7 +123,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1704909949277245576}
   - component: {fileID: 3127360171530219873}
-  m_Layer: 12
+  m_Layer: 13
   m_Name: IceLayer
   m_TagString: Tile
   m_Icon: {fileID: 0}

--- a/Assets/Project/Actors/Tiles/Normal/NormalTilePrefab.prefab
+++ b/Assets/Project/Actors/Tiles/Normal/NormalTilePrefab.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 212720884470728028}
   - component: {fileID: 114202185148520404}
   - component: {fileID: 2991992710737140570}
-  m_Layer: 12
+  m_Layer: 13
   m_Name: NormalTilePrefab
   m_TagString: Tile
   m_Icon: {fileID: 0}
@@ -44,6 +44,7 @@ SpriteRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1

--- a/Assets/Project/Actors/Tiles/Spiderweb/SpiderwebTilePrefab.prefab
+++ b/Assets/Project/Actors/Tiles/Spiderweb/SpiderwebTilePrefab.prefab
@@ -10,7 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 5465598831281009146}
   - component: {fileID: 6342839703379482488}
-  m_Layer: 12
+  m_Layer: 13
   m_Name: SpiderwebLayer
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -96,7 +96,7 @@ GameObject:
   - component: {fileID: 6023233291268266555}
   - component: {fileID: 1490116916845845161}
   - component: {fileID: 7788963662244586979}
-  m_Layer: 12
+  m_Layer: 13
   m_Name: SpiderwebTilePrefab
   m_TagString: Tile
   m_Icon: {fileID: 0}

--- a/Assets/Project/Actors/Tiles/Warp/WarpTilePrefab.prefab
+++ b/Assets/Project/Actors/Tiles/Warp/WarpTilePrefab.prefab
@@ -10,7 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 957508379597345922}
   - component: {fileID: 8350893800382395972}
-  m_Layer: 12
+  m_Layer: 13
   m_Name: WhirlpoolEffect
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -42,6 +42,7 @@ SpriteRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -99,7 +100,7 @@ GameObject:
   - component: {fileID: 7313158193465358665}
   - component: {fileID: 9077478467019510265}
   - component: {fileID: 15381658534830463}
-  m_Layer: 12
+  m_Layer: 13
   m_Name: WarpTilePrefab
   m_TagString: Tile
   m_Icon: {fileID: 0}
@@ -133,6 +134,7 @@ SpriteRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -170,7 +172,7 @@ SpriteRenderer:
   m_Size: {x: 200, y: 200}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
+  m_WasSpriteAssigned: 0
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
 --- !u!114 &5948350988835539850
@@ -208,19 +210,19 @@ ParticleSystem:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2281809373051226156}
-  serializedVersion: 6
+  serializedVersion: 8
   lengthInSec: 0.5
   simulationSpeed: 1
   stopAction: 0
   cullingMode: 0
   ringBufferMode: 0
   ringBufferLoopRange: {x: 0, y: 1}
+  emitterVelocityMode: 0
   looping: 0
   prewarm: 0
   playOnAwake: 0
   useUnscaledTime: 0
   autoRandomSeed: 1
-  useRigidbodyForVelocity: 1
   startDelay:
     serializedVersion: 2
     minMaxState: 0
@@ -770,6 +772,7 @@ ParticleSystem:
         m_RotationOrder: 4
     randomizeRotationDirection: 0
     maxNumParticles: 1000
+    customEmitterVelocity: {x: 0, y: 0, z: 0}
     size3D: 0
     rotation3D: 0
     gravityModifier:
@@ -3780,19 +3783,20 @@ ParticleSystem:
     range: {x: 0, y: 1}
   CollisionModule:
     enabled: 0
-    serializedVersion: 3
+    serializedVersion: 4
     type: 0
     collisionMode: 0
     colliderForce: 0
     multiplyColliderForceByParticleSize: 0
     multiplyColliderForceByParticleSpeed: 0
     multiplyColliderForceByCollisionAngle: 1
-    plane0: {fileID: 0}
-    plane1: {fileID: 0}
-    plane2: {fileID: 0}
-    plane3: {fileID: 0}
-    plane4: {fileID: 0}
-    plane5: {fileID: 0}
+    m_Planes:
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
     m_Dampen:
       serializedVersion: 2
       minMaxState: 0
@@ -3966,17 +3970,20 @@ ParticleSystem:
     interiorCollisions: 0
   TriggerModule:
     enabled: 0
-    collisionShape0: {fileID: 0}
-    collisionShape1: {fileID: 0}
-    collisionShape2: {fileID: 0}
-    collisionShape3: {fileID: 0}
-    collisionShape4: {fileID: 0}
-    collisionShape5: {fileID: 0}
+    serializedVersion: 2
     inside: 1
     outside: 0
     enter: 0
     exit: 0
+    colliderQueryMode: 0
     radiusScale: 1
+    primitives:
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
   SubModule:
     serializedVersion: 2
     enabled: 0
@@ -4927,6 +4934,7 @@ ParticleSystemRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
@@ -4936,7 +4944,6 @@ ParticleSystemRenderer:
   m_RendererPriority: 0
   m_Materials:
   - {fileID: 10301, guid: 0000000000000000f000000000000000, type: 0}
-  - {fileID: 0}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -5012,6 +5019,7 @@ SpriteRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -5049,7 +5057,7 @@ SpriteRenderer:
   m_Size: {x: 200, y: 200}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
+  m_WasSpriteAssigned: 0
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
 --- !u!114 &15381658534830463
@@ -5075,7 +5083,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 7550037492694459932}
-  m_Layer: 12
+  m_Layer: 13
   m_Name: WarpTarget
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Project/Actors/UIs/Common/ErrorMessageBox.prefab
+++ b/Assets/Project/Actors/UIs/Common/ErrorMessageBox.prefab
@@ -35,7 +35,7 @@ GameObject:
   - component: {fileID: 7956675395369221791}
   - component: {fileID: 7956675395369221789}
   - component: {fileID: 7956675395369221788}
-  m_Layer: 0
+  m_Layer: 5
   m_Name: Panel
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -111,7 +111,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7956675395439376296}
   - component: {fileID: 7956675395439376297}
-  m_Layer: 0
+  m_Layer: 5
   m_Name: ErrorMessageBox
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -163,7 +163,7 @@ GameObject:
   - component: {fileID: 7956675396127543296}
   - component: {fileID: 7956675396127543299}
   - component: {fileID: 7956675396127543298}
-  m_Layer: 0
+  m_Layer: 5
   m_Name: Button
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -242,6 +242,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -312,6 +313,51 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -324,6 +370,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -342,12 +393,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_RootOrder
+      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
@@ -364,56 +415,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.9
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 08bc31bccfd004d24846b057a089c860, type: 3}
@@ -453,6 +454,51 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -465,6 +511,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
@@ -483,12 +534,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
         type: 3}
-      propertyPath: m_RootOrder
+      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
@@ -505,56 +556,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.9
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.9
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8585351667659277243, guid: 08bc31bccfd004d24846b057a089c860,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 08bc31bccfd004d24846b057a089c860, type: 3}

--- a/Assets/Project/Actors/UIs/StageSelectScene/BackgroundCanvas.prefab
+++ b/Assets/Project/Actors/UIs/StageSelectScene/BackgroundCanvas.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 9195470247874693213}
   - component: {fileID: 9195470247874693155}
   - component: {fileID: 9195470247874693154}
-  m_Layer: 13
+  m_Layer: 6
   m_Name: Content
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -91,7 +91,7 @@ GameObject:
   - component: {fileID: 9195470248455732924}
   - component: {fileID: 9195470248455732927}
   - component: {fileID: 9195470248455732867}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: BackgroundCanvas
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -161,6 +161,7 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
 --- !u!114 &9195470248455732927
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -199,8 +200,8 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 5236298760021292508, guid: f63d3d96315f94e4b8f10b547fae3cae,
         type: 3}
-      propertyPath: m_Color.r
-      value: 1
+      propertyPath: m_Color.b
+      value: 0.9931888
       objectReference: {fileID: 0}
     - target: {fileID: 5236298760021292508, guid: f63d3d96315f94e4b8f10b547fae3cae,
         type: 3}
@@ -209,8 +210,58 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5236298760021292508, guid: f63d3d96315f94e4b8f10b547fae3cae,
         type: 3}
-      propertyPath: m_Color.b
-      value: 0.9931888
+      propertyPath: m_Color.r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5236298760021292510, guid: f63d3d96315f94e4b8f10b547fae3cae,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.3333
+      objectReference: {fileID: 0}
+    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
         type: 3}
@@ -229,6 +280,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
@@ -244,12 +300,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
         type: 3}
-      propertyPath: m_RootOrder
+      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
@@ -267,60 +323,15 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.3333
-      objectReference: {fileID: 0}
-    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
     - target: {fileID: 5236298760411526577, guid: f63d3d96315f94e4b8f10b547fae3cae,
         type: 3}
       propertyPath: m_Name
       value: Tree1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5236298760411526577, guid: f63d3d96315f94e4b8f10b547fae3cae,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 5236298760766947201, guid: f63d3d96315f94e4b8f10b547fae3cae,
         type: 3}
@@ -328,6 +339,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300000, guid: 1cd9df25ca45c452485540049f69cf55,
         type: 3}
+    - target: {fileID: 5236298760766947203, guid: f63d3d96315f94e4b8f10b547fae3cae,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f63d3d96315f94e4b8f10b547fae3cae, type: 3}
 --- !u!224 &8257927537921062765 stripped
@@ -345,13 +361,63 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 5236298760021292508, guid: f63d3d96315f94e4b8f10b547fae3cae,
         type: 3}
-      propertyPath: m_Color.g
-      value: 0.9843137
+      propertyPath: m_Color.b
+      value: 0.79607844
       objectReference: {fileID: 0}
     - target: {fileID: 5236298760021292508, guid: f63d3d96315f94e4b8f10b547fae3cae,
         type: 3}
-      propertyPath: m_Color.b
-      value: 0.79607844
+      propertyPath: m_Color.g
+      value: 0.9843137
+      objectReference: {fileID: 0}
+    - target: {fileID: 5236298760021292510, guid: f63d3d96315f94e4b8f10b547fae3cae,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.6666
+      objectReference: {fileID: 0}
+    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.3333
+      objectReference: {fileID: 0}
+    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
         type: 3}
@@ -370,6 +436,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
@@ -385,13 +456,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
         type: 3}
-      propertyPath: m_RootOrder
-      value: 1
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
         type: 3}
@@ -408,60 +479,15 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.3333
-      objectReference: {fileID: 0}
-    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.6666
-      objectReference: {fileID: 0}
-    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
     - target: {fileID: 5236298760411526577, guid: f63d3d96315f94e4b8f10b547fae3cae,
         type: 3}
       propertyPath: m_Name
       value: Tree2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5236298760411526577, guid: f63d3d96315f94e4b8f10b547fae3cae,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 5236298760766947201, guid: f63d3d96315f94e4b8f10b547fae3cae,
         type: 3}
@@ -469,6 +495,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300000, guid: 4bb6492b24b924a3cb1b9ef6607419d0,
         type: 3}
+    - target: {fileID: 5236298760766947203, guid: f63d3d96315f94e4b8f10b547fae3cae,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f63d3d96315f94e4b8f10b547fae3cae, type: 3}
 --- !u!224 &86576659025170261 stripped
@@ -486,13 +517,63 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 5236298760021292508, guid: f63d3d96315f94e4b8f10b547fae3cae,
         type: 3}
-      propertyPath: m_Color.g
-      value: 0.85490197
+      propertyPath: m_Color.b
+      value: 0.9529412
       objectReference: {fileID: 0}
     - target: {fileID: 5236298760021292508, guid: f63d3d96315f94e4b8f10b547fae3cae,
         type: 3}
-      propertyPath: m_Color.b
-      value: 0.9529412
+      propertyPath: m_Color.g
+      value: 0.85490197
+      objectReference: {fileID: 0}
+    - target: {fileID: 5236298760021292510, guid: f63d3d96315f94e4b8f10b547fae3cae,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.6666
+      objectReference: {fileID: 0}
+    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
         type: 3}
@@ -511,6 +592,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
@@ -526,13 +612,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
         type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
+      propertyPath: m_AnchoredPosition.x
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
         type: 3}
-      propertyPath: m_RootOrder
-      value: 2
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
         type: 3}
@@ -549,60 +635,15 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.6666
-      objectReference: {fileID: 0}
-    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5236298760411526576, guid: f63d3d96315f94e4b8f10b547fae3cae,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
     - target: {fileID: 5236298760411526577, guid: f63d3d96315f94e4b8f10b547fae3cae,
         type: 3}
       propertyPath: m_Name
       value: Tree3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5236298760411526577, guid: f63d3d96315f94e4b8f10b547fae3cae,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 5236298760766947201, guid: f63d3d96315f94e4b8f10b547fae3cae,
         type: 3}
@@ -610,6 +651,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 21300000, guid: ef002935685ed4f88809c51352951f79,
         type: 3}
+    - target: {fileID: 5236298760766947203, guid: f63d3d96315f94e4b8f10b547fae3cae,
+        type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f63d3d96315f94e4b8f10b547fae3cae, type: 3}
 --- !u!224 &387613186137719591 stripped

--- a/Assets/Project/Actors/UIs/StageSelectScene/BackgroundTree.prefab
+++ b/Assets/Project/Actors/UIs/StageSelectScene/BackgroundTree.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 5236298760021292509}
   - component: {fileID: 5236298760021292483}
   - component: {fileID: 5236298760021292508}
-  m_Layer: 13
+  m_Layer: 6
   m_Name: Background
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -86,7 +86,7 @@ GameObject:
   - component: {fileID: 5236298760411526576}
   - component: {fileID: 5236298760411526582}
   - component: {fileID: 5236298760411526583}
-  m_Layer: 13
+  m_Layer: 6
   m_Name: BackgroundTree
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -163,7 +163,7 @@ GameObject:
   - component: {fileID: 5236298760766947202}
   - component: {fileID: 5236298760766947200}
   - component: {fileID: 5236298760766947201}
-  m_Layer: 13
+  m_Layer: 6
   m_Name: TreeImage
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Project/Scenes/GamePlayScene.unity
+++ b/Assets/Project/Scenes/GamePlayScene.unity
@@ -641,7 +641,7 @@ MonoBehaviour:
   hitScreenSpaceUI: 1
   layerMask:
     serializedVersion: 2
-    m_Bits: 4294967295
+    m_Bits: 4294955048
   useHitFilters: 0
 --- !u!1001 &580887582
 PrefabInstance:

--- a/Assets/Project/Scenes/StageSelectScene/AutumnStageSelectScene.unity
+++ b/Assets/Project/Scenes/StageSelectScene/AutumnStageSelectScene.unity
@@ -174,7 +174,7 @@ Camera:
   m_Depth: -1
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 7479
+    m_Bits: 16311
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_TargetDisplay: 0
@@ -280,7 +280,7 @@ Camera:
   m_Depth: -2
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 7479
+    m_Bits: 64
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_TargetDisplay: 0
@@ -2039,24 +2039,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 28c9fd4dd33d84b6b82b268bb586c041, type: 3}
---- !u!1 &1071083819 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1706829439639562984, guid: 28c9fd4dd33d84b6b82b268bb586c041,
-    type: 3}
-  m_PrefabInstance: {fileID: 1071083818}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1071083820 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1706829440555125870, guid: 28c9fd4dd33d84b6b82b268bb586c041,
-    type: 3}
-  m_PrefabInstance: {fileID: 1071083818}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1071083821 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 483595305205046658, guid: 28c9fd4dd33d84b6b82b268bb586c041,
-    type: 3}
-  m_PrefabInstance: {fileID: 1071083818}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1071083822 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 6566690580109683887, guid: 28c9fd4dd33d84b6b82b268bb586c041,
@@ -2079,24 +2061,6 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6932f1a34c024666855c23fc1636104e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &1071083825 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 3591550205515086092, guid: 28c9fd4dd33d84b6b82b268bb586c041,
-    type: 3}
-  m_PrefabInstance: {fileID: 1071083818}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1071083826
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1071083825}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cb219b23cdf4b314f94a27bca3cc8012, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &1242689480
@@ -2131,9 +2095,6 @@ MonoBehaviour:
   _overviewPopup: {fileID: 1071083824}
   _loadingBackground: {fileID: 1071083823}
   _loading: {fileID: 1071083822}
-  _treeName: {fileID: 1071083821}
-  _leftButton: {fileID: 1071083820}
-  _rightButton: {fileID: 1071083819}
 --- !u!4 &1242689482
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Project/Scenes/StageSelectScene/SpringStageSelectScene.unity
+++ b/Assets/Project/Scenes/StageSelectScene/SpringStageSelectScene.unity
@@ -218,7 +218,7 @@ Camera:
   m_Depth: -1
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 7479
+    m_Bits: 16311
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_TargetDisplay: 0
@@ -290,9 +290,6 @@ MonoBehaviour:
   _overviewPopup: {fileID: 247634139}
   _loadingBackground: {fileID: 1097520118}
   _loading: {fileID: 1318188736}
-  _treeName: {fileID: 1635637785}
-  _leftButton: {fileID: 4569299528056800684}
-  _rightButton: {fileID: 7067239023526580892}
 --- !u!1 &1004117054 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 9195470247874693212, guid: c6733626b48d94c81b786ca25f272b31,
@@ -308,12 +305,6 @@ GameObject:
 --- !u!1 &1318188736 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 6566690580109683887, guid: 28c9fd4dd33d84b6b82b268bb586c041,
-    type: 3}
-  m_PrefabInstance: {fileID: 1706829440728858700}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1635637785 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 483595305205046658, guid: 28c9fd4dd33d84b6b82b268bb586c041,
     type: 3}
   m_PrefabInstance: {fileID: 1706829440728858700}
   m_PrefabAsset: {fileID: 0}
@@ -365,7 +356,7 @@ Camera:
   m_Depth: -2
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 7479
+    m_Bits: 64
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_TargetDisplay: 0
@@ -1020,36 +1011,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 28c9fd4dd33d84b6b82b268bb586c041, type: 3}
---- !u!1 &1706829440728858701 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 3591550205515086092, guid: 28c9fd4dd33d84b6b82b268bb586c041,
-    type: 3}
-  m_PrefabInstance: {fileID: 1706829440728858700}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1706829440728858702
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1706829440728858701}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cb219b23cdf4b314f94a27bca3cc8012, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &4569299528056800684 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1706829440555125870, guid: 28c9fd4dd33d84b6b82b268bb586c041,
-    type: 3}
-  m_PrefabInstance: {fileID: 1706829440728858700}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &7067239023526580892 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1706829439639562984, guid: 28c9fd4dd33d84b6b82b268bb586c041,
-    type: 3}
-  m_PrefabInstance: {fileID: 1706829440728858700}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &9195470248774931554
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Project/Scenes/StageSelectScene/SummerStageSelectScene.unity
+++ b/Assets/Project/Scenes/StageSelectScene/SummerStageSelectScene.unity
@@ -386,7 +386,7 @@ Camera:
   m_Depth: -2
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 7479
+    m_Bits: 64
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_TargetDisplay: 0
@@ -462,7 +462,7 @@ Camera:
   m_Depth: -1
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 7479
+    m_Bits: 16311
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_TargetDisplay: 0
@@ -552,9 +552,6 @@ MonoBehaviour:
   _overviewPopup: {fileID: 1811972883}
   _loadingBackground: {fileID: 1811972882}
   _loading: {fileID: 1811972881}
-  _treeName: {fileID: 1811972880}
-  _leftButton: {fileID: 1811972879}
-  _rightButton: {fileID: 1811972878}
 --- !u!4 &1590084814
 Transform:
   m_ObjectHideFlags: 0
@@ -2093,24 +2090,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 28c9fd4dd33d84b6b82b268bb586c041, type: 3}
---- !u!1 &1811972878 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1706829439639562984, guid: 28c9fd4dd33d84b6b82b268bb586c041,
-    type: 3}
-  m_PrefabInstance: {fileID: 1811972877}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1811972879 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1706829440555125870, guid: 28c9fd4dd33d84b6b82b268bb586c041,
-    type: 3}
-  m_PrefabInstance: {fileID: 1811972877}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1811972880 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 483595305205046658, guid: 28c9fd4dd33d84b6b82b268bb586c041,
-    type: 3}
-  m_PrefabInstance: {fileID: 1811972877}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1811972881 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 6566690580109683887, guid: 28c9fd4dd33d84b6b82b268bb586c041,
@@ -2133,23 +2112,5 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6932f1a34c024666855c23fc1636104e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &1811972884 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 3591550205515086092, guid: 28c9fd4dd33d84b6b82b268bb586c041,
-    type: 3}
-  m_PrefabInstance: {fileID: 1811972877}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1811972885
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1811972884}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cb219b23cdf4b314f94a27bca3cc8012, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 

--- a/Assets/Project/Scenes/StageSelectScene/WinterStageSelectScene.unity
+++ b/Assets/Project/Scenes/StageSelectScene/WinterStageSelectScene.unity
@@ -174,7 +174,7 @@ Camera:
   m_Depth: -1
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 7479
+    m_Bits: 16311
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_TargetDisplay: 0
@@ -473,9 +473,6 @@ MonoBehaviour:
   _overviewPopup: {fileID: 1627007783}
   _loadingBackground: {fileID: 1627007782}
   _loading: {fileID: 1627007781}
-  _treeName: {fileID: 1627007780}
-  _leftButton: {fileID: 1627007779}
-  _rightButton: {fileID: 1627007778}
 --- !u!4 &492828239
 Transform:
   m_ObjectHideFlags: 0
@@ -538,7 +535,7 @@ Camera:
   m_Depth: -2
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 7479
+    m_Bits: 64
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_TargetDisplay: 0
@@ -2113,24 +2110,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 28c9fd4dd33d84b6b82b268bb586c041, type: 3}
---- !u!1 &1627007778 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1706829439639562984, guid: 28c9fd4dd33d84b6b82b268bb586c041,
-    type: 3}
-  m_PrefabInstance: {fileID: 1627007777}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1627007779 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1706829440555125870, guid: 28c9fd4dd33d84b6b82b268bb586c041,
-    type: 3}
-  m_PrefabInstance: {fileID: 1627007777}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1627007780 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 483595305205046658, guid: 28c9fd4dd33d84b6b82b268bb586c041,
-    type: 3}
-  m_PrefabInstance: {fileID: 1627007777}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1627007781 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 6566690580109683887, guid: 28c9fd4dd33d84b6b82b268bb586c041,
@@ -2153,23 +2132,5 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6932f1a34c024666855c23fc1636104e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1 &1627007784 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 3591550205515086092, guid: 28c9fd4dd33d84b6b82b268bb586c041,
-    type: 3}
-  m_PrefabInstance: {fileID: 1627007777}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1627007785
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1627007784}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cb219b23cdf4b314f94a27bca3cc8012, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 

--- a/ProjectSettings/Physics2DSettings.asset
+++ b/ProjectSettings/Physics2DSettings.asset
@@ -53,4 +53,4 @@ Physics2DSettings:
   m_ColliderAsleepColor: {r: 0.5686275, g: 0.95686275, b: 0.54509807, a: 0.36078432}
   m_ColliderContactColor: {r: 1, g: 0, b: 1, a: 0.6862745}
   m_ColliderAABBColor: {r: 1, g: 1, b: 0, a: 0.2509804}
-  m_LayerCollisionMatrix: ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff91ffffff91ffffff81ffffff87ffffff81ffffff81ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+  m_LayerCollisionMatrix: 3ff8ffff3ff8ffff3ff8ffffffffffff3ff8ffff3ff8ffff0880ffff0880ffff0880ffff0890ffff0890ffff3f80ffff3f86ffff3f80ffff3f80ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff

--- a/ProjectSettings/Physics2DSettings.asset
+++ b/ProjectSettings/Physics2DSettings.asset
@@ -3,7 +3,7 @@
 --- !u!19 &1
 Physics2DSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 4
+  serializedVersion: 5
   m_Gravity: {x: 0, y: -9.81}
   m_DefaultMaterial: {fileID: 0}
   m_VelocityIterations: 8
@@ -38,7 +38,7 @@ Physics2DSettings:
     m_IslandSolverJointCostScale: 10
     m_IslandSolverBodiesPerJob: 50
     m_IslandSolverContactsPerJob: 50
-  m_AutoSimulation: 1
+  m_SimulationMode: 0
   m_QueriesHitTriggers: 1
   m_QueriesStartInColliders: 1
   m_CallbacksOnDisable: 1
@@ -53,4 +53,4 @@ Physics2DSettings:
   m_ColliderAsleepColor: {r: 0.5686275, g: 0.95686275, b: 0.54509807, a: 0.36078432}
   m_ColliderContactColor: {r: 1, g: 0, b: 1, a: 0.6862745}
   m_ColliderAABBColor: {r: 1, g: 1, b: 0, a: 0.2509804}
-  m_LayerCollisionMatrix: ffffffffffffffffffffffffffffffffffffffffffbfffffffffffffffffffffffa6ffffffe9ffffffe9ffffffa6ffffffa0ffffffbfffffdf86ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+  m_LayerCollisionMatrix: ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff91ffffff91ffffff81ffffff87ffffff81ffffff81ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -20,15 +20,15 @@ TagManager:
   - 
   - Water
   - UI
-  - 
-  - 
+  - Background
   - SpriteGlow
-  - 
+  - GimmickWarning
+  - Gimmick
   - Meteorite
+  - BottleAttribute
   - Bottle
   - Tile
-  - Background
-  - 
+  - ErasableBottle
   - 
   - 
   - 


### PR DESCRIPTION
### 対象イシュー
Close #935

### 概要
- GamePlaySceneでGimmickがBottleのgestureを奪う問題の対処

### 詳細
- Gimmick, GimmickWarning, Bottle, BottleAttribute, Tileなど必要なLayerを改めて追加
-  全てのprefabに適切にLayerを設定
- GamePlaySceneのCameraのみLayerMaskを設定し、UI, Bottle, ErasableBottle以外はGestureが反応しないように設定(技術的な内容１)
- StageSelectSceneのCullingMaskを改めて設定(技術的な内容２)(Layerの順序が崩れたので再設定しただけ、元から行っていた設定)


#### 現実装になった経緯
特になし

#### 技術的な内容
##### 1
GamePlaySceneのMain Cameraを以下のように設定し、Raycastに反応するLayerを制限。
ErasableBottleをBottle Layerにしてしまうと、GimmickとErasableBottleの衝突判定が起きてしまうので、
ErasableBottleは例外的に専用のLayerを用意
<img width="441" alt="スクリーンショット 2021-06-08 23 22 43" src="https://user-images.githubusercontent.com/26213141/121204000-8620df80-c8b1-11eb-8357-73347e71e589.png">

###### 2
（再説明）StageSeletSceneはBackgroundの画像だけを映すBackgroundCameraとそれ以外を映すMainCameraの２つの映像を重ねて描画している。
その制御はLayerで行っており、今回のLayer追加でindexがずれたので以下の場所で再設定。
<img width="444" alt="スクリーンショット 2021-06-08 23 27 34" src="https://user-images.githubusercontent.com/26213141/121204056-90db7480-c8b1-11eb-8bb2-82f9948fd312.png">


### キャプチャ
https://user-images.githubusercontent.com/26213141/121203924-73a6a600-c8b1-11eb-9efb-27394c68c78c.mov


### 動作確認方法

- [ ] Spring_1_6をプレイ。Bottleの無敵中、かつ、TornadoがBottleの手前に被っている時でもBottleをフリックできる。

### 参考 URL
