### PR TITLE
[#817] 開放中の道の色変化に画面を追従させる

### DIFF
--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/LevelSelectDirector.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/LevelSelectDirector.cs
@@ -128,14 +128,5 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
             PlayerPrefsUtility.SetList(Constants.PlayerPrefsKeys.TREE_ANIMATION_STATE, releaseAnimationPlayedTrees);
             PlayerPrefsUtility.SetList(Constants.PlayerPrefsKeys.ROAD_ANIMATION_STATE, releaseAnimationPlayedRoads);
         }
-
-        /// <summary>
-        /// 道の幅の変更
-        /// </summary>
-        /// <param name="scale"> 拡大率 </param>
-        public void ScaleRoad(float scale)
-        {
-            _roads.ForEach(road => road.Scale.Value = scale);
-        }
     }
 }

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/LineControllerBase.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/LineControllerBase.cs
@@ -100,6 +100,13 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
             }
         }
 
+        public Vector3 GetPositionAtRatio(float ratio)
+        {
+            ratio = Mathf.Clamp(ratio, 0, 1);
+            var (startPointPosition, endPointPosition) = GetEdgePointPosition();
+            return CalcCubicBezierPointPosition(startPointPosition, firstControlPoint, secondControlPoint, endPointPosition, ratio);
+        }
+
         /// <summary>
         /// 3次ベジェ曲線上のある点の位置を求める
         /// </summary>

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/LineControllerBase.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/LineControllerBase.cs
@@ -53,6 +53,16 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
         /// </summary>
         public string saveKey { get; protected set; }
 
+        /// <summary>
+        /// 先端のポジション
+        /// </summary>
+        private Vector3 _startPointPosition;
+
+        /// <summary>
+        /// 末端のポジション
+        /// </summary>
+        private Vector3 _endPointPosition;
+
         protected virtual void Awake()
         {
             SetSaveKey();
@@ -67,6 +77,7 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
             firstControlPoint += SavableScrollRect.CONTENT_MARGIN;
             secondControlPoint *= SavableScrollRect.CONTENT_SCALE;
             secondControlPoint += SavableScrollRect.CONTENT_MARGIN;
+            (_startPointPosition, _endPointPosition) = GetEdgePointPosition();
             SetPointPosition();
         }
 
@@ -89,13 +100,11 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
             lineRenderer.positionCount = _middlePointNum + 2;
             lineRenderer.startWidth = lineRenderer.endWidth = Screen.width * width * Scale.Value;
 
-            var (startPointPosition, endPointPosition) = GetEdgePointPosition();
-
             // 点の位置と線の長さを求める
             for (var i = 0; i <= _middlePointNum + 1; i++) {
                 var ratio = (float)i / (_middlePointNum + 1);
-                var targetPosition = CalcCubicBezierPointPosition(startPointPosition, firstControlPoint,
-                                                                  secondControlPoint, endPointPosition, ratio);
+                var targetPosition = CalcCubicBezierPointPosition(_startPointPosition, firstControlPoint,
+                                                                  secondControlPoint, _endPointPosition, ratio);
                 lineRenderer.SetPosition(i, targetPosition);
             }
         }
@@ -103,8 +112,7 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
         public Vector3 GetPositionAtRatio(float ratio)
         {
             ratio = Mathf.Clamp(ratio, 0, 1);
-            var (startPointPosition, endPointPosition) = GetEdgePointPosition();
-            return CalcCubicBezierPointPosition(startPointPosition, firstControlPoint, secondControlPoint, endPointPosition, ratio);
+            return CalcCubicBezierPointPosition(_startPointPosition, firstControlPoint, secondControlPoint, _endPointPosition, ratio);
         }
 
         /// <summary>

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/LineControllerBase.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/LineControllerBase.cs
@@ -46,11 +46,6 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
         /// </summary>
         public ReactiveProperty<float> Scale = new ReactiveProperty<float>(1f);
 
-        /// <summary>
-        /// 道の長さ
-        /// </summary>
-        protected float lineLength = 0f;
-
         [SerializeField] protected LineRenderer lineRenderer;
 
         /// <summary>
@@ -97,14 +92,11 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
             var (startPointPosition, endPointPosition) = GetEdgePointPosition();
 
             // 点の位置と線の長さを求める
-            var preTargetPosition = lineRenderer.GetPosition(0);
             for (var i = 0; i <= _middlePointNum + 1; i++) {
                 var ratio = (float)i / (_middlePointNum + 1);
                 var targetPosition = CalcCubicBezierPointPosition(startPointPosition, firstControlPoint,
                                                                   secondControlPoint, endPointPosition, ratio);
                 lineRenderer.SetPosition(i, targetPosition);
-                lineLength += Vector2.Distance(targetPosition, preTargetPosition);
-                preTargetPosition = targetPosition;
             }
         }
 

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/RoadPlayableBehaviour.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/RoadPlayableBehaviour.cs
@@ -12,10 +12,17 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
 
         private Material _material;
 
+        private ScaleContent _scaleContent;
         /// <summary>
         /// 解放時のテクスチャの占領比率(1.0だと全解放)
         /// </summary>
         private static readonly int _SHADER_PARAM_FILL_AMOUNT = Shader.PropertyToID("_fillAmount");
+
+        public override void OnPlayableCreate(Playable playable)
+        {
+            base.OnPlayableCreate(playable);
+            _scaleContent = Object.FindObjectOfType<ScaleContent>();
+        }
 
         // フレーム毎の処理
         // 非ランタイムでも呼ばれるので注意！
@@ -30,6 +37,8 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
             var progress = (float)(playable.GetTime() / playable.GetDuration());
 
             _material.SetFloat(_SHADER_PARAM_FILL_AMOUNT, Mathf.Lerp(0, 1, progress));
+            // 道の色変化するところを追従する
+            _scaleContent.FocusAtScreenPosition(roadController.GetPositionAtRatio(progress));
         }
     }
 }

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/RoadPlayableBehaviour.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/RoadPlayableBehaviour.cs
@@ -19,10 +19,30 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
         /// </summary>
         private static readonly int _SHADER_PARAM_FILL_AMOUNT = Shader.PropertyToID("_fillAmount");
 
+        /// <summary>
+        /// 演出中の拡大率
+        /// </summary>
+        private const float _SCALE_IN_ANIMATION = 1.5f;
+
+        /// <summary>
+        /// 演出前の拡大率
+        /// </summary>
+        private float _originalScale;
+
         public override void OnPlayableCreate(Playable playable)
         {
             base.OnPlayableCreate(playable);
             _scaleContent = Object.FindObjectOfType<ScaleContent>();
+            // 拡大させる
+            _originalScale = _scaleContent.GetCurrentScale();
+            _scaleContent.ScaleContents(_SCALE_IN_ANIMATION);
+        }
+
+        public override void OnPlayableDestroy(Playable playable)
+        {
+            base.OnPlayableDestroy(playable);
+            // 拡大率を戻す
+            _scaleContent.ScaleContents(_originalScale);
         }
 
         // フレーム毎の処理

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/RoadPlayableBehaviour.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/RoadPlayableBehaviour.cs
@@ -37,7 +37,7 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
             var progress = (float)(playable.GetTime() / playable.GetDuration());
 
             _material.SetFloat(_SHADER_PARAM_FILL_AMOUNT, Mathf.Lerp(0, 1, progress));
-            // 道の色変化するところを追従する
+            // 道の色が変化するところを追従する
             _scaleContent.FocusAtScreenPosition(roadController.GetPositionAtRatio(progress));
         }
     }

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/RoadPlayableBehaviour.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/RoadPlayableBehaviour.cs
@@ -13,6 +13,7 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
         private Material _material;
 
         private ScaleContent _scaleContent;
+
         /// <summary>
         /// 解放時のテクスチャの占領比率(1.0だと全解放)
         /// </summary>

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/ScaleContent.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/ScaleContent.cs
@@ -1,4 +1,6 @@
-﻿using TouchScript.Gestures;
+﻿using System.Collections.Generic;
+using System.Linq;
+using TouchScript.Gestures;
 using TouchScript.Gestures.TransformGestures;
 using Treevel.Common.Entities;
 using Treevel.Common.Utils;
@@ -8,10 +10,16 @@ using UnityEngine.UI;
 
 namespace Treevel.Modules.MenuSelectScene.LevelSelect
 {
+    [DefaultExecutionOrder(-50)]
     public class ScaleContent : MonoBehaviour
     {
         private TransformGesture _transformGesture;
         private RectTransform _contentRect;
+
+        /// <summary>
+        /// 道
+        /// </summary>
+        private List<RoadController> _roads;
 
         /// <summary>
         /// タッチした2点
@@ -53,6 +61,7 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
         private void Awake()
         {
             _contentRect = GetComponent<ScrollRect>().content;
+            _roads = GameObject.FindGameObjectsWithTag(Constants.TagName.ROAD).Select(road => road.GetComponent<RoadController>()).ToList();
             _transformGesture = GetComponent<TransformGesture>();
             _scaledCanvas = RuntimeConstants.SCALED_CANVAS_SIZE;
 
@@ -65,9 +74,7 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
         private void OnEnable()
         {
             _preScale = UserSettings.Instance.LevelSelectCanvasScale;
-            _contentRect.localScale = new Vector2(_preScale, _preScale);
-            // 道の拡大縮小
-            LevelSelectDirector.Instance.ScaleRoad(_preScale);
+            ScaleContents(_preScale);
         }
 
         private void OnDisable()
@@ -98,19 +105,14 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
             var newScale = _preScale * newScreenDist / _preScreenDist;
             // 拡大率を閾値内に抑える
             newScale = Mathf.Clamp(newScale, _SCALE_MIN, _SCALE_MAX);
-            // Contentの拡大縮小
-            _contentRect.localScale = new Vector2(newScale, newScale);
-            // 道の拡大縮小
-            LevelSelectDirector.Instance.ScaleRoad(newScale);
+            ScaleContents(newScale);
 
             // 拡大縮小前の中点を拡大縮小後の中点に合わせるようにContentの平行移動量を求める
             var preContentPoint = ConvertFromScreenToContent(_preMeanPoint, _preScale);
             var newContentPoint = ConvertFromScreenToContent(newMeanPoint, _preScale);
             // Content空間での2点の差分
             var moveAmount = newContentPoint - preContentPoint * newScale / _preScale;
-            moveAmount = KeepInContent(moveAmount, newScale);
-            // Contentの平行移動
-            _contentRect.transform.localPosition += new Vector3(moveAmount.x, moveAmount.y, 0);
+            TransformContents(moveAmount);
 
             // 値の更新
             _prePoint1 = newPoint1;
@@ -118,6 +120,37 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
             _preScreenDist = newScreenDist;
             _preMeanPoint = newMeanPoint;
             _preScale = newScale;
+        }
+
+        /// <summary>
+        /// コンテンツの平行移動
+        /// </summary>
+        /// <param name="transformVector"> 移動ベクトル </param>
+        private void TransformContents(Vector2 transformVector)
+        {
+            var moveAmount = KeepInContent(transformVector, _contentRect.localScale.x);
+            _contentRect.transform.localPosition += new Vector3(moveAmount.x, moveAmount.y, 0);
+        }
+
+        /// <summary>
+        /// コンテンツを拡大縮小する
+        /// </summary>
+        /// <param name="scale"> 拡大率、縮小率（絶対値）</param>
+        public void ScaleContents(float scale)
+        {
+            // Contentの拡大縮小
+            _contentRect.localScale = new Vector2(scale, scale);
+            // 道の拡大縮小
+            ScaleRoads(scale);
+        }
+
+        /// <summary>
+        /// 道の幅の変更
+        /// </summary>
+        /// <param name="scale"> 拡大率 </param>
+        private void ScaleRoads(float scale)
+        {
+            _roads.ForEach(road => road.Scale.Value = scale);
         }
 
         /// <summary>

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/ScaleContent.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/ScaleContent.cs
@@ -10,7 +10,6 @@ using UnityEngine.UI;
 
 namespace Treevel.Modules.MenuSelectScene.LevelSelect
 {
-    [DefaultExecutionOrder(-50)]
     public class ScaleContent : MonoBehaviour
     {
         private TransformGesture _transformGesture;
@@ -120,6 +119,15 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
             _preScreenDist = newScreenDist;
             _preMeanPoint = newMeanPoint;
             _preScale = newScale;
+        }
+
+        /// <summary>
+        /// 特定の位置を中心までにコンテンツ全体を移動する
+        /// </summary>
+        /// <param name="focusWorldPosition"> 中止にしたい位置 </param>
+        public void FocusAtScreenPosition(Vector3 focusWorldPosition)
+        {
+            TransformContents((focusWorldPosition * -1) - _contentRect.transform.localPosition);
         }
 
         /// <summary>

--- a/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/ScaleContent.cs
+++ b/Assets/Project/Scripts/Modules/MenuSelectScene/LevelSelect/ScaleContent.cs
@@ -10,6 +10,7 @@ using UnityEngine.UI;
 
 namespace Treevel.Modules.MenuSelectScene.LevelSelect
 {
+    [DefaultExecutionOrder(-50)]
     public class ScaleContent : MonoBehaviour
     {
         private TransformGesture _transformGesture;
@@ -150,6 +151,14 @@ namespace Treevel.Modules.MenuSelectScene.LevelSelect
             _contentRect.localScale = new Vector2(scale, scale);
             // 道の拡大縮小
             ScaleRoads(scale);
+        }
+
+        /// <summary>
+        /// 現在の拡大率
+        /// </summary>
+        public float GetCurrentScale()
+        {
+            return _contentRect.localScale.x;
         }
 
         /// <summary>


### PR DESCRIPTION
### 対象イシュー
ref: #817

### 概要
木の解放演出中道の色変化を追從するように

### 詳細

#### 現実装になった経緯
* `ScaleCanvas`にて特定の座標にフォカスを当てる関数を実装
* `LineControllerBase`にベジェ曲線上の特定位置の座標を取得できる関数を実装
* `RoadPlayableBehaviour`の`ProcessFrame`で道の開放と同時にScaleCanvasを通してフォーカスを当てるように実装


#### 技術的な内容
[PlayableBehviourの各関数について](https://scrapbox.io/treevel/Unity_Timeline#60bfa2feac0add0000deefcd)

### キャプチャ

https://user-images.githubusercontent.com/17778395/121228048-4238d500-c8c7-11eb-839c-84d685a7eb9f.mov


### 動作確認方法
- [x] データをリセットし、Spring-1-1の任意のステージをクリアして演出を発生させる

### 参考 URL
