### PR TITLE
`StartupScene` で `KeyNotFoundException` が出る問題を修正する

### DIFF
--- a/Assets/AddressableAssetsData/AssetGroups/Schemas/Tiles_BundledAssetGroupSchema.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Schemas/Tiles_BundledAssetGroupSchema.asset
@@ -1,0 +1,41 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e5d17a21594effb4e9591490b009e7aa, type: 3}
+  m_Name: Tiles_BundledAssetGroupSchema
+  m_EditorClassIdentifier: 
+  m_Group: {fileID: 0}
+  m_Compression: 1
+  m_IncludeAddressInCatalog: 1
+  m_IncludeGUIDInCatalog: 1
+  m_IncludeLabelsInCatalog: 1
+  m_InternalIdNamingMode: 0
+  m_IncludeInBuild: 1
+  m_BundledAssetProviderType:
+    m_AssemblyName: 
+    m_ClassName: 
+  m_ForceUniqueProvider: 0
+  m_UseAssetBundleCache: 1
+  m_UseAssetBundleCrc: 1
+  m_UseAssetBundleCrcForCachedBundles: 1
+  m_Timeout: 0
+  m_ChunkedTransfer: 0
+  m_RedirectLimit: -1
+  m_RetryCount: 0
+  m_BuildPath:
+    m_Id: 
+  m_LoadPath:
+    m_Id: 
+  m_BundleMode: 0
+  m_AssetBundleProviderType:
+    m_AssemblyName: 
+    m_ClassName: 
+  m_BundleNaming: 0

--- a/Assets/AddressableAssetsData/AssetGroups/Schemas/Tiles_BundledAssetGroupSchema.asset.meta
+++ b/Assets/AddressableAssetsData/AssetGroups/Schemas/Tiles_BundledAssetGroupSchema.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5e3cbd6dbdbd6438c8cd3aef82bf5aef
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AddressableAssetsData/AssetGroups/Schemas/Tiles_ContentUpdateGroupSchema.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Schemas/Tiles_ContentUpdateGroupSchema.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5834b5087d578d24c926ce20cd31e6d6, type: 3}
+  m_Name: Tiles_ContentUpdateGroupSchema
+  m_EditorClassIdentifier: 
+  m_Group: {fileID: 0}
+  m_StaticContent: 0

--- a/Assets/AddressableAssetsData/AssetGroups/Schemas/Tiles_ContentUpdateGroupSchema.asset.meta
+++ b/Assets/AddressableAssetsData/AssetGroups/Schemas/Tiles_ContentUpdateGroupSchema.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 948b83f8fa0294e95aea572439012210
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AddressableAssetsData/AssetGroups/Schemas/Trees_BundledAssetGroupSchema.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Schemas/Trees_BundledAssetGroupSchema.asset
@@ -1,0 +1,41 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e5d17a21594effb4e9591490b009e7aa, type: 3}
+  m_Name: Trees_BundledAssetGroupSchema
+  m_EditorClassIdentifier: 
+  m_Group: {fileID: 0}
+  m_Compression: 1
+  m_IncludeAddressInCatalog: 1
+  m_IncludeGUIDInCatalog: 1
+  m_IncludeLabelsInCatalog: 1
+  m_InternalIdNamingMode: 0
+  m_IncludeInBuild: 1
+  m_BundledAssetProviderType:
+    m_AssemblyName: 
+    m_ClassName: 
+  m_ForceUniqueProvider: 0
+  m_UseAssetBundleCache: 1
+  m_UseAssetBundleCrc: 1
+  m_UseAssetBundleCrcForCachedBundles: 1
+  m_Timeout: 0
+  m_ChunkedTransfer: 0
+  m_RedirectLimit: -1
+  m_RetryCount: 0
+  m_BuildPath:
+    m_Id: 
+  m_LoadPath:
+    m_Id: 
+  m_BundleMode: 0
+  m_AssetBundleProviderType:
+    m_AssemblyName: 
+    m_ClassName: 
+  m_BundleNaming: 0

--- a/Assets/AddressableAssetsData/AssetGroups/Schemas/Trees_BundledAssetGroupSchema.asset.meta
+++ b/Assets/AddressableAssetsData/AssetGroups/Schemas/Trees_BundledAssetGroupSchema.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 859088b7d47e04478bc5692b746a4294
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AddressableAssetsData/AssetGroups/Schemas/Trees_ContentUpdateGroupSchema.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Schemas/Trees_ContentUpdateGroupSchema.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5834b5087d578d24c926ce20cd31e6d6, type: 3}
+  m_Name: Trees_ContentUpdateGroupSchema
+  m_EditorClassIdentifier: 
+  m_Group: {fileID: 0}
+  m_StaticContent: 0

--- a/Assets/AddressableAssetsData/AssetGroups/Schemas/Trees_ContentUpdateGroupSchema.asset.meta
+++ b/Assets/AddressableAssetsData/AssetGroups/Schemas/Trees_ContentUpdateGroupSchema.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d84b170957a6c4d3aa167b0464397966
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AddressableAssetsData/AssetGroups/Sound.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Sound.asset
@@ -18,84 +18,84 @@ MonoBehaviour:
   m_GUID: 27b072720a54542608f471210e52c9cb
   m_SerializeEntries:
   - m_GUID: 15038fe8963ac4c33a7dcb6df7aecacd
-    m_Address: Assets/Project/SoundClips/BGM/12-GamePlayScene-Difficult.mp3
+    m_Address: 12-GamePlayScene-Difficult
     m_ReadOnly: 0
     m_SerializedLabels:
     - Sound/BGM
     m_MainAsset: {fileID: 8300000, guid: 15038fe8963ac4c33a7dcb6df7aecacd, type: 3}
     m_TargetAsset: {fileID: 8300000, guid: 15038fe8963ac4c33a7dcb6df7aecacd, type: 3}
   - m_GUID: 163b412967a1840f4ab92e37c7802478
-    m_Address: Assets/Project/SoundClips/BGM/09-GamePlayScene-Summer.mp3
+    m_Address: 09-GamePlayScene-Summer
     m_ReadOnly: 0
     m_SerializedLabels:
     - Sound/BGM
     m_MainAsset: {fileID: 8300000, guid: 163b412967a1840f4ab92e37c7802478, type: 3}
     m_TargetAsset: {fileID: 8300000, guid: 163b412967a1840f4ab92e37c7802478, type: 3}
   - m_GUID: 23abc637ff4cc41a385d5203dd6c58f0
-    m_Address: Assets/Project/SoundClips/BGM/11-GamePlayScene-Winter.mp3
+    m_Address: 11-GamePlayScene-Winter
     m_ReadOnly: 0
     m_SerializedLabels:
     - Sound/BGM
     m_MainAsset: {fileID: 8300000, guid: 23abc637ff4cc41a385d5203dd6c58f0, type: 3}
     m_TargetAsset: {fileID: 8300000, guid: 23abc637ff4cc41a385d5203dd6c58f0, type: 3}
   - m_GUID: 2577a738e15ce48cd8a11293b3dfc559
-    m_Address: Assets/Project/SoundClips/BGM/10-GamePlayScene-Autumn.mp3
+    m_Address: 10-GamePlayScene-Autumn
     m_ReadOnly: 0
     m_SerializedLabels:
     - Sound/BGM
     m_MainAsset: {fileID: 8300000, guid: 2577a738e15ce48cd8a11293b3dfc559, type: 3}
     m_TargetAsset: {fileID: 8300000, guid: 2577a738e15ce48cd8a11293b3dfc559, type: 3}
   - m_GUID: 2aa9d2c100d50463ea3a6c1dc9e38200
-    m_Address: Assets/Project/SoundClips/BGM/07-GamePlayScene-Tutorial.mp3
+    m_Address: 07-GamePlayScene-Tutorial
     m_ReadOnly: 0
     m_SerializedLabels:
     - Sound/BGM
     m_MainAsset: {fileID: 8300000, guid: 2aa9d2c100d50463ea3a6c1dc9e38200, type: 3}
     m_TargetAsset: {fileID: 8300000, guid: 2aa9d2c100d50463ea3a6c1dc9e38200, type: 3}
   - m_GUID: 42ad310814bee48c482ce92687ccd760
-    m_Address: Assets/Project/SoundClips/BGM/05-StageSelectScene-Autumn.mp3
+    m_Address: 05-StageSelectScene-Autumn
     m_ReadOnly: 0
     m_SerializedLabels:
     - Sound/BGM
     m_MainAsset: {fileID: 8300000, guid: 42ad310814bee48c482ce92687ccd760, type: 3}
     m_TargetAsset: {fileID: 8300000, guid: 42ad310814bee48c482ce92687ccd760, type: 3}
   - m_GUID: 8b87d88e103da4e3aa62b42f0c69aa6c
-    m_Address: Assets/Project/SoundClips/BGM/01-StartUpScene.mp3
+    m_Address: 01-StartUpScene
     m_ReadOnly: 0
     m_SerializedLabels:
     - Sound/BGM
     m_MainAsset: {fileID: 8300000, guid: 8b87d88e103da4e3aa62b42f0c69aa6c, type: 3}
     m_TargetAsset: {fileID: 8300000, guid: 8b87d88e103da4e3aa62b42f0c69aa6c, type: 3}
   - m_GUID: 9401413272092485694385fa21b6535f
-    m_Address: Assets/Project/SoundClips/BGM/03-StageSelectScene-Spring.mp3
+    m_Address: 03-StageSelectScene-Spring
     m_ReadOnly: 0
     m_SerializedLabels:
     - Sound/BGM
     m_MainAsset: {fileID: 8300000, guid: 9401413272092485694385fa21b6535f, type: 3}
     m_TargetAsset: {fileID: 8300000, guid: 9401413272092485694385fa21b6535f, type: 3}
   - m_GUID: a177119c94cc0444eb759017ecc3448e
-    m_Address: Assets/Project/SoundClips/BGM/08-GamePlayScene-Spring.mp3
+    m_Address: 08-GamePlayScene-Spring
     m_ReadOnly: 0
     m_SerializedLabels:
     - Sound/BGM
     m_MainAsset: {fileID: 8300000, guid: a177119c94cc0444eb759017ecc3448e, type: 3}
     m_TargetAsset: {fileID: 8300000, guid: a177119c94cc0444eb759017ecc3448e, type: 3}
   - m_GUID: a8b849cb89ac24f24a41518158f3e679
-    m_Address: Assets/Project/SoundClips/BGM/04-StageSelectScene-Summer.mp3
+    m_Address: 04-StageSelectScene-Summer
     m_ReadOnly: 0
     m_SerializedLabels:
     - Sound/BGM
     m_MainAsset: {fileID: 8300000, guid: a8b849cb89ac24f24a41518158f3e679, type: 3}
     m_TargetAsset: {fileID: 8300000, guid: a8b849cb89ac24f24a41518158f3e679, type: 3}
   - m_GUID: b85db55e534704b8c8cc5af8bb3cd250
-    m_Address: Assets/Project/SoundClips/BGM/06-StageSelectScene-Winter.mp3
+    m_Address: 06-StageSelectScene-Winter
     m_ReadOnly: 0
     m_SerializedLabels:
     - Sound/BGM
     m_MainAsset: {fileID: 8300000, guid: b85db55e534704b8c8cc5af8bb3cd250, type: 3}
     m_TargetAsset: {fileID: 8300000, guid: b85db55e534704b8c8cc5af8bb3cd250, type: 3}
   - m_GUID: f120d17b287174885a2f4236eefce4a2
-    m_Address: Assets/Project/SoundClips/BGM/02-MenuSelectScene.mp3
+    m_Address: 02-MenuSelectScene
     m_ReadOnly: 0
     m_SerializedLabels:
     - Sound/BGM

--- a/Assets/AddressableAssetsData/AssetGroups/Stages.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Stages.asset
@@ -18,840 +18,840 @@ MonoBehaviour:
   m_GUID: 2b2251e623299487b87d014c2b34fc72
   m_SerializeEntries:
   - m_GUID: 000f70e99e9e744fc85197b904552947
-    m_Address: Assets/Project/Resources_moved/GameDatas/Stages/Spring_1/2.asset
+    m_Address: Spring_1/2
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 000f70e99e9e744fc85197b904552947, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 000f70e99e9e744fc85197b904552947, type: 2}
   - m_GUID: 01f93f152261349ae881c2ca6a33b25e
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/6.asset
+    m_Address: Autumn_2/6
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 01f93f152261349ae881c2ca6a33b25e, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 01f93f152261349ae881c2ca6a33b25e, type: 2}
   - m_GUID: 02de8ace75fcc4965890ae9f94f3a684
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/3.asset
+    m_Address: Summer_2/3
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 02de8ace75fcc4965890ae9f94f3a684, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 02de8ace75fcc4965890ae9f94f3a684, type: 2}
   - m_GUID: 037fdc96989f249339fc86425cee7575
-    m_Address: Assets/Project/Resources_moved/GameDatas/Stages/Spring_2/3.asset
+    m_Address: Spring_2/3
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 037fdc96989f249339fc86425cee7575, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 037fdc96989f249339fc86425cee7575, type: 2}
   - m_GUID: 0803662de3aa547e18c189c71cf1bfb4
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/4.asset
+    m_Address: Spring_3/4
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 0803662de3aa547e18c189c71cf1bfb4, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 0803662de3aa547e18c189c71cf1bfb4, type: 2}
   - m_GUID: 0bc92b8a7da1e45efbf4679a09dc061c
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/5.asset
+    m_Address: Autumn_2/5
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 0bc92b8a7da1e45efbf4679a09dc061c, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 0bc92b8a7da1e45efbf4679a09dc061c, type: 2}
   - m_GUID: 0bd474522d9ca4d1db47f29462e3b38e
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/9.asset
+    m_Address: Autumn_2/9
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 0bd474522d9ca4d1db47f29462e3b38e, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 0bd474522d9ca4d1db47f29462e3b38e, type: 2}
   - m_GUID: 0d4ae34c0c5f94dd18575192c4afb966
-    m_Address: Assets/Project/Resources_moved/GameDatas/Stages/Spring_2/5.asset
+    m_Address: Spring_2/5
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 0d4ae34c0c5f94dd18575192c4afb966, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 0d4ae34c0c5f94dd18575192c4afb966, type: 2}
   - m_GUID: 0de39bb1cabf246aab07596b1072bf21
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/1.asset
+    m_Address: Winter_3/1
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 0de39bb1cabf246aab07596b1072bf21, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 0de39bb1cabf246aab07596b1072bf21, type: 2}
   - m_GUID: 0e581ecef079943e18b670c5764dec27
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/6.asset
+    m_Address: Winter_3/6
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 0e581ecef079943e18b670c5764dec27, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 0e581ecef079943e18b670c5764dec27, type: 2}
   - m_GUID: 0f32f060f67b642cd9faa81cbbcd9b44
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/3.asset
+    m_Address: Autumn_2/3
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 0f32f060f67b642cd9faa81cbbcd9b44, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 0f32f060f67b642cd9faa81cbbcd9b44, type: 2}
   - m_GUID: 107509ec6a7aa488ab7c029317f1aa49
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/2.asset
+    m_Address: Autumn_2/2
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 107509ec6a7aa488ab7c029317f1aa49, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 107509ec6a7aa488ab7c029317f1aa49, type: 2}
   - m_GUID: 10c44a0932bf9425eae65ee4e416f8e4
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/5.asset
+    m_Address: Summer_1/5
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 10c44a0932bf9425eae65ee4e416f8e4, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 10c44a0932bf9425eae65ee4e416f8e4, type: 2}
   - m_GUID: 15f93d76cf77b43c08372ec474a2b09c
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/6.asset
+    m_Address: Summer_2/6
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 15f93d76cf77b43c08372ec474a2b09c, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 15f93d76cf77b43c08372ec474a2b09c, type: 2}
   - m_GUID: 1635a896ae6c24e4c8dd4bb047ed1a07
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/1.asset
+    m_Address: Autumn_1/1
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 1635a896ae6c24e4c8dd4bb047ed1a07, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 1635a896ae6c24e4c8dd4bb047ed1a07, type: 2}
   - m_GUID: 1a71fda93879742fd80ac2996775f5f6
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/2.asset
+    m_Address: Summer_3/2
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 1a71fda93879742fd80ac2996775f5f6, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 1a71fda93879742fd80ac2996775f5f6, type: 2}
   - m_GUID: 1b5e2d1cda1e24f7f854f687e3e9ed21
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/4.asset
+    m_Address: Summer_3/4
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 1b5e2d1cda1e24f7f854f687e3e9ed21, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 1b5e2d1cda1e24f7f854f687e3e9ed21, type: 2}
   - m_GUID: 1d155e30b0ef04023bdd2068ebf80cfe
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/2.asset
+    m_Address: Autumn_1/2
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 1d155e30b0ef04023bdd2068ebf80cfe, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 1d155e30b0ef04023bdd2068ebf80cfe, type: 2}
   - m_GUID: 22620e28274b34eb5a6adee4ad8d978f
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Spring_2/8.asset
+    m_Address: Spring_2/8
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 22620e28274b34eb5a6adee4ad8d978f, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 22620e28274b34eb5a6adee4ad8d978f, type: 2}
   - m_GUID: 22f7806eb7ae946fbafa303cabb4c9d6
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/9.asset
+    m_Address: Summer_3/9
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 22f7806eb7ae946fbafa303cabb4c9d6, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 22f7806eb7ae946fbafa303cabb4c9d6, type: 2}
   - m_GUID: 255877b8fcb134e278a0ce9db6790033
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/5.asset
+    m_Address: Winter_1/5
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 255877b8fcb134e278a0ce9db6790033, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 255877b8fcb134e278a0ce9db6790033, type: 2}
   - m_GUID: 2745de03d7ff643ee95a086856467d66
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/8.asset
+    m_Address: Autumn_1/8
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 2745de03d7ff643ee95a086856467d66, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 2745de03d7ff643ee95a086856467d66, type: 2}
   - m_GUID: 2b0f0ed5e8f584538a96202e6c80c1dd
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Spring_2/6.asset
+    m_Address: Spring_2/6
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 2b0f0ed5e8f584538a96202e6c80c1dd, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 2b0f0ed5e8f584538a96202e6c80c1dd, type: 2}
   - m_GUID: 2b6133b0009a74657b01d3d67d3eba5a
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/6.asset
+    m_Address: Summer_3/6
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 2b6133b0009a74657b01d3d67d3eba5a, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 2b6133b0009a74657b01d3d67d3eba5a, type: 2}
   - m_GUID: 2c2a97f3c0270410a9637014bec103a1
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/8.asset
+    m_Address: Winter_1/8
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 2c2a97f3c0270410a9637014bec103a1, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 2c2a97f3c0270410a9637014bec103a1, type: 2}
   - m_GUID: 2f545b4136ab948c4afda14881b0af7a
-    m_Address: Assets/Project/Resources_moved/GameDatas/Stages/Spring_1/10.asset
+    m_Address: Spring_1/10
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 2f545b4136ab948c4afda14881b0af7a, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 2f545b4136ab948c4afda14881b0af7a, type: 2}
   - m_GUID: 3579b68e982814daaa1098677b713ef9
-    m_Address: Assets/Project/Resources_moved/GameDatas/Stages/Spring_1/6.asset
+    m_Address: Spring_1/6
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 3579b68e982814daaa1098677b713ef9, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 3579b68e982814daaa1098677b713ef9, type: 2}
   - m_GUID: 37514a6ee75ca4331bdd27786759857c
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/8.asset
+    m_Address: Winter_2/8
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 37514a6ee75ca4331bdd27786759857c, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 37514a6ee75ca4331bdd27786759857c, type: 2}
   - m_GUID: 37d4ea8bb421849a08aa1a0100c209ab
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/2.asset
+    m_Address: Winter_3/2
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 37d4ea8bb421849a08aa1a0100c209ab, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 37d4ea8bb421849a08aa1a0100c209ab, type: 2}
   - m_GUID: 39c057e840ea0430694ebaaaed8181eb
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Spring_2/10.asset
+    m_Address: Spring_2/10
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 39c057e840ea0430694ebaaaed8181eb, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 39c057e840ea0430694ebaaaed8181eb, type: 2}
   - m_GUID: 3da906b1e1316489b82a2a3627e6b8fd
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/7.asset
+    m_Address: Summer_2/7
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 3da906b1e1316489b82a2a3627e6b8fd, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 3da906b1e1316489b82a2a3627e6b8fd, type: 2}
   - m_GUID: 3fdcf0ca585b4447c9174093d38d2b9e
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/7.asset
+    m_Address: Autumn_3/7
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 3fdcf0ca585b4447c9174093d38d2b9e, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 3fdcf0ca585b4447c9174093d38d2b9e, type: 2}
   - m_GUID: 3ff1c067532fd47d8ba97dc8f33db3fb
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/2.asset
+    m_Address: Summer_1/2
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 3ff1c067532fd47d8ba97dc8f33db3fb, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 3ff1c067532fd47d8ba97dc8f33db3fb, type: 2}
   - m_GUID: 40c99fbdab68644d1a2d673f6b8b6ff3
-    m_Address: Assets/Project/Resources_moved/GameDatas/Stages/Spring_1/8.asset
+    m_Address: Spring_1/8
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 40c99fbdab68644d1a2d673f6b8b6ff3, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 40c99fbdab68644d1a2d673f6b8b6ff3, type: 2}
   - m_GUID: 41508d46f250849c5b82ab30f2e925b9
-    m_Address: Assets/Project/Resources_moved/GameDatas/Stages/Spring_2/2.asset
+    m_Address: Spring_2/2
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 41508d46f250849c5b82ab30f2e925b9, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 41508d46f250849c5b82ab30f2e925b9, type: 2}
   - m_GUID: 42be2fc124fca48bc92f392791afd6b6
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/7.asset
+    m_Address: Winter_2/7
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 42be2fc124fca48bc92f392791afd6b6, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 42be2fc124fca48bc92f392791afd6b6, type: 2}
   - m_GUID: 44671f370928842fd911445471f8fdd9
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/10.asset
+    m_Address: Summer_2/10
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 44671f370928842fd911445471f8fdd9, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 44671f370928842fd911445471f8fdd9, type: 2}
   - m_GUID: 46cb4002c76c746a1a9c146866fd5fac
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/1.asset
+    m_Address: Summer_3/1
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 46cb4002c76c746a1a9c146866fd5fac, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 46cb4002c76c746a1a9c146866fd5fac, type: 2}
   - m_GUID: 47e8649d5d99c4c3db9095c7ad35d33e
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/1.asset
+    m_Address: Autumn_2/1
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 47e8649d5d99c4c3db9095c7ad35d33e, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 47e8649d5d99c4c3db9095c7ad35d33e, type: 2}
   - m_GUID: 4cebcc594ae334ca1ac94f3718723332
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/9.asset
+    m_Address: Summer_2/9
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 4cebcc594ae334ca1ac94f3718723332, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 4cebcc594ae334ca1ac94f3718723332, type: 2}
   - m_GUID: 4d5678a326a7c47eaaf1f6759ac5dcb2
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/8.asset
+    m_Address: Summer_1/8
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 4d5678a326a7c47eaaf1f6759ac5dcb2, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 4d5678a326a7c47eaaf1f6759ac5dcb2, type: 2}
   - m_GUID: 4df4aa6dd529b48039a1eb1231d3f654
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/6.asset
+    m_Address: Autumn_1/6
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 4df4aa6dd529b48039a1eb1231d3f654, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 4df4aa6dd529b48039a1eb1231d3f654, type: 2}
   - m_GUID: 4e0e93b0cd7a24564a088dea7f86125e
-    m_Address: Assets/Project/Resources_moved/GameDatas/Stages/Spring_1/5.asset
+    m_Address: Spring_1/5
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 4e0e93b0cd7a24564a088dea7f86125e, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 4e0e93b0cd7a24564a088dea7f86125e, type: 2}
   - m_GUID: 519a9319c35b74864b1760b7faabc2eb
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/5.asset
+    m_Address: Winter_3/5
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 519a9319c35b74864b1760b7faabc2eb, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 519a9319c35b74864b1760b7faabc2eb, type: 2}
   - m_GUID: 54f8e229f3ff541b8a4b2d0d3f0a32e0
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/7.asset
+    m_Address: Winter_3/7
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 54f8e229f3ff541b8a4b2d0d3f0a32e0, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 54f8e229f3ff541b8a4b2d0d3f0a32e0, type: 2}
   - m_GUID: 593284e23d93347f3bbc345c2031f39c
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/4.asset
+    m_Address: Summer_1/4
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 593284e23d93347f3bbc345c2031f39c, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 593284e23d93347f3bbc345c2031f39c, type: 2}
   - m_GUID: 5954053c1dee24736ac5d1261fe66c8c
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/5.asset
+    m_Address: Spring_3/5
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 5954053c1dee24736ac5d1261fe66c8c, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 5954053c1dee24736ac5d1261fe66c8c, type: 2}
   - m_GUID: 5c646d14ee06b4f689b0767b774e8b23
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/8.asset
+    m_Address: Autumn_2/8
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 5c646d14ee06b4f689b0767b774e8b23, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 5c646d14ee06b4f689b0767b774e8b23, type: 2}
   - m_GUID: 5c896da2728f24608a7e3b408609203d
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/3.asset
+    m_Address: Winter_3/3
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 5c896da2728f24608a7e3b408609203d, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 5c896da2728f24608a7e3b408609203d, type: 2}
   - m_GUID: 5dee2bf1b62de46c399d5c540a0d8f2c
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/6.asset
+    m_Address: Winter_1/6
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 5dee2bf1b62de46c399d5c540a0d8f2c, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 5dee2bf1b62de46c399d5c540a0d8f2c, type: 2}
   - m_GUID: 638f993409edd4f18a269ff1c961a453
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/6.asset
+    m_Address: Autumn_3/6
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 638f993409edd4f18a269ff1c961a453, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 638f993409edd4f18a269ff1c961a453, type: 2}
   - m_GUID: 64e87db2e3e4f49069576bdaabb32f8c
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/7.asset
+    m_Address: Winter_1/7
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 64e87db2e3e4f49069576bdaabb32f8c, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 64e87db2e3e4f49069576bdaabb32f8c, type: 2}
   - m_GUID: 66c5cfbb0b8a54b47b288282e5d43e38
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/5.asset
+    m_Address: Winter_2/5
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 66c5cfbb0b8a54b47b288282e5d43e38, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 66c5cfbb0b8a54b47b288282e5d43e38, type: 2}
   - m_GUID: 66d0b097da911496e98faded93097c3b
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/6.asset
+    m_Address: Summer_1/6
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 66d0b097da911496e98faded93097c3b, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 66d0b097da911496e98faded93097c3b, type: 2}
   - m_GUID: 67444d8f28a8b436c9d544498b78c664
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/2.asset
+    m_Address: Autumn_3/2
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 67444d8f28a8b436c9d544498b78c664, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 67444d8f28a8b436c9d544498b78c664, type: 2}
   - m_GUID: 6767feede47fa447895f936387c733b2
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/3.asset
+    m_Address: Summer_1/3
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 6767feede47fa447895f936387c733b2, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 6767feede47fa447895f936387c733b2, type: 2}
   - m_GUID: 6a99dfe5f28cf4380a4a312c37164512
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/4.asset
+    m_Address: Winter_1/4
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 6a99dfe5f28cf4380a4a312c37164512, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 6a99dfe5f28cf4380a4a312c37164512, type: 2}
   - m_GUID: 6dd5c24d546c3489e906302864d84759
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/9.asset
+    m_Address: Autumn_1/9
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 6dd5c24d546c3489e906302864d84759, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 6dd5c24d546c3489e906302864d84759, type: 2}
   - m_GUID: 6dd5cfe9944624b678fb99c7380b524a
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/1.asset
+    m_Address: Summer_1/1
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 6dd5cfe9944624b678fb99c7380b524a, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 6dd5cfe9944624b678fb99c7380b524a, type: 2}
   - m_GUID: 70a133ec213be46db9f7e3a2ec81ec09
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/1.asset
+    m_Address: Winter_2/1
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 70a133ec213be46db9f7e3a2ec81ec09, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 70a133ec213be46db9f7e3a2ec81ec09, type: 2}
   - m_GUID: 73c6d2cc828044739965edb261ec08a6
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/9.asset
+    m_Address: Spring_3/9
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 73c6d2cc828044739965edb261ec08a6, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 73c6d2cc828044739965edb261ec08a6, type: 2}
   - m_GUID: 75470e5c8713f440392214dfd5422ac0
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/4.asset
+    m_Address: Autumn_3/4
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 75470e5c8713f440392214dfd5422ac0, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 75470e5c8713f440392214dfd5422ac0, type: 2}
   - m_GUID: 7b63ba282b68f4977bef8087a803b813
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/8.asset
+    m_Address: Spring_3/8
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 7b63ba282b68f4977bef8087a803b813, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 7b63ba282b68f4977bef8087a803b813, type: 2}
   - m_GUID: 80dc1685ee6b842a6a716ce2b54627d7
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/9.asset
+    m_Address: Winter_2/9
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 80dc1685ee6b842a6a716ce2b54627d7, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 80dc1685ee6b842a6a716ce2b54627d7, type: 2}
   - m_GUID: 80f965afa4a944ee99d79343061962bc
-    m_Address: Assets/Project/Resources_moved/GameDatas/Stages/Spring_2/4.asset
+    m_Address: Spring_2/4
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 80f965afa4a944ee99d79343061962bc, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 80f965afa4a944ee99d79343061962bc, type: 2}
   - m_GUID: 83d546bb709d74d2884c0489f2b21fb3
-    m_Address: Assets/Project/Resources_moved/GameDatas/Stages/Spring_1/1.asset
+    m_Address: Spring_1/1
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 83d546bb709d74d2884c0489f2b21fb3, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 83d546bb709d74d2884c0489f2b21fb3, type: 2}
   - m_GUID: 846fed9e6cebf49db83b42158bda1051
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/10.asset
+    m_Address: Winter_2/10
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 846fed9e6cebf49db83b42158bda1051, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 846fed9e6cebf49db83b42158bda1051, type: 2}
   - m_GUID: 8537a36ba6cc74b45b6909bb2479c1f2
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/3.asset
+    m_Address: Winter_1/3
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 8537a36ba6cc74b45b6909bb2479c1f2, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 8537a36ba6cc74b45b6909bb2479c1f2, type: 2}
   - m_GUID: 860af3096abcb42edad422e0edf79846
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/7.asset
+    m_Address: Autumn_2/7
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 860af3096abcb42edad422e0edf79846, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 860af3096abcb42edad422e0edf79846, type: 2}
   - m_GUID: 865c2189a27be4db9956bed81b53922f
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/8.asset
+    m_Address: Summer_3/8
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 865c2189a27be4db9956bed81b53922f, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 865c2189a27be4db9956bed81b53922f, type: 2}
   - m_GUID: 87080ce8bc261462aa473fe21edf9672
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/4.asset
+    m_Address: Winter_3/4
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 87080ce8bc261462aa473fe21edf9672, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 87080ce8bc261462aa473fe21edf9672, type: 2}
   - m_GUID: 8be6cd1b7bede413fb81c03c009e3c92
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/9.asset
+    m_Address: Autumn_3/9
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 8be6cd1b7bede413fb81c03c009e3c92, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 8be6cd1b7bede413fb81c03c009e3c92, type: 2}
   - m_GUID: 8e69704b96440464fb5c027b168f300b
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/2.asset
+    m_Address: Winter_1/2
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 8e69704b96440464fb5c027b168f300b, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 8e69704b96440464fb5c027b168f300b, type: 2}
   - m_GUID: 94b1083c8238c4064ba0c1202108a94c
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/10.asset
+    m_Address: Summer_3/10
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 94b1083c8238c4064ba0c1202108a94c, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 94b1083c8238c4064ba0c1202108a94c, type: 2}
   - m_GUID: 985ec3dab43e94dbea1689fe49f66600
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/6.asset
+    m_Address: Winter_2/6
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 985ec3dab43e94dbea1689fe49f66600, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 985ec3dab43e94dbea1689fe49f66600, type: 2}
   - m_GUID: 9c088d6b675084fbfb88981ed18708fd
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/5.asset
+    m_Address: Summer_3/5
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 9c088d6b675084fbfb88981ed18708fd, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 9c088d6b675084fbfb88981ed18708fd, type: 2}
   - m_GUID: 9d6ae666156454c6a976f9feaa8f200f
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/5.asset
+    m_Address: Autumn_3/5
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 9d6ae666156454c6a976f9feaa8f200f, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 9d6ae666156454c6a976f9feaa8f200f, type: 2}
   - m_GUID: 9edf445148c0c43c5b2785031f734e68
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/1.asset
+    m_Address: Summer_2/1
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 9edf445148c0c43c5b2785031f734e68, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 9edf445148c0c43c5b2785031f734e68, type: 2}
   - m_GUID: 9f2e7496db24c4fa1954e0c1276aa7aa
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/1.asset
+    m_Address: Spring_3/1
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: 9f2e7496db24c4fa1954e0c1276aa7aa, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 9f2e7496db24c4fa1954e0c1276aa7aa, type: 2}
   - m_GUID: a21354950a4994e52b7d942f44b3d68f
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/10.asset
+    m_Address: Autumn_1/10
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: a21354950a4994e52b7d942f44b3d68f, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: a21354950a4994e52b7d942f44b3d68f, type: 2}
   - m_GUID: a35f83a63b9b9421f9d8f009d61c07ba
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Spring_2/9.asset
+    m_Address: Spring_2/9
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: a35f83a63b9b9421f9d8f009d61c07ba, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: a35f83a63b9b9421f9d8f009d61c07ba, type: 2}
   - m_GUID: a4c285a06fb704ddcb1661f4622c9e4c
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/3.asset
+    m_Address: Summer_3/3
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: a4c285a06fb704ddcb1661f4622c9e4c, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: a4c285a06fb704ddcb1661f4622c9e4c, type: 2}
   - m_GUID: a64f65de02a324d48bdbc19a57c0ea4f
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/4.asset
+    m_Address: Summer_2/4
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: a64f65de02a324d48bdbc19a57c0ea4f, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: a64f65de02a324d48bdbc19a57c0ea4f, type: 2}
   - m_GUID: a7a6a41bb079542d4a0791b36fefc6de
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/5.asset
+    m_Address: Summer_2/5
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: a7a6a41bb079542d4a0791b36fefc6de, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: a7a6a41bb079542d4a0791b36fefc6de, type: 2}
   - m_GUID: a913b10988de840918ce0995b119516e
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/10.asset
+    m_Address: Autumn_2/10
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: a913b10988de840918ce0995b119516e, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: a913b10988de840918ce0995b119516e, type: 2}
   - m_GUID: ac7221acbe82e485d8193755ce2f090f
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/10.asset
+    m_Address: Spring_3/10
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: ac7221acbe82e485d8193755ce2f090f, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: ac7221acbe82e485d8193755ce2f090f, type: 2}
   - m_GUID: acee77a57f90c4fa4bc17feeb3d06408
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/3.asset
+    m_Address: Spring_3/3
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: acee77a57f90c4fa4bc17feeb3d06408, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: acee77a57f90c4fa4bc17feeb3d06408, type: 2}
   - m_GUID: ad926578eea2f483a8da483c1d64d635
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/5.asset
+    m_Address: Autumn_1/5
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: ad926578eea2f483a8da483c1d64d635, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: ad926578eea2f483a8da483c1d64d635, type: 2}
   - m_GUID: af9f42a0ed4534934aaa351a44ee0df5
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/8.asset
+    m_Address: Summer_2/8
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: af9f42a0ed4534934aaa351a44ee0df5, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: af9f42a0ed4534934aaa351a44ee0df5, type: 2}
   - m_GUID: b0347b35cd68b4a7e8705fb8719fd404
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/10.asset
+    m_Address: Summer_1/10
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: b0347b35cd68b4a7e8705fb8719fd404, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: b0347b35cd68b4a7e8705fb8719fd404, type: 2}
   - m_GUID: b148658ecfcfb438796a1246dee965b5
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/6.asset
+    m_Address: Spring_3/6
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: b148658ecfcfb438796a1246dee965b5, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: b148658ecfcfb438796a1246dee965b5, type: 2}
   - m_GUID: b6d22d1ea2625477291111bc178a1657
-    m_Address: Assets/Project/Resources_moved/GameDatas/Stages/Spring_1/3.asset
+    m_Address: Spring_1/3
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: b6d22d1ea2625477291111bc178a1657, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: b6d22d1ea2625477291111bc178a1657, type: 2}
   - m_GUID: bf003bc8360714572bbdab850fcad22e
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/4.asset
+    m_Address: Winter_2/4
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: bf003bc8360714572bbdab850fcad22e, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: bf003bc8360714572bbdab850fcad22e, type: 2}
   - m_GUID: bf32fc30ea73b4e44a79608b59e34e63
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/9.asset
+    m_Address: Winter_3/9
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: bf32fc30ea73b4e44a79608b59e34e63, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: bf32fc30ea73b4e44a79608b59e34e63, type: 2}
   - m_GUID: c191ae0a9719a45d49ea772613c36572
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/1.asset
+    m_Address: Autumn_3/1
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: c191ae0a9719a45d49ea772613c36572, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: c191ae0a9719a45d49ea772613c36572, type: 2}
   - m_GUID: c2363a3eb41fa4088a49c7b73fc91206
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/2.asset
+    m_Address: Winter_2/2
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: c2363a3eb41fa4088a49c7b73fc91206, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: c2363a3eb41fa4088a49c7b73fc91206, type: 2}
   - m_GUID: c627d08c8667f4028b4d10424305b2a4
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_3/7.asset
+    m_Address: Summer_3/7
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: c627d08c8667f4028b4d10424305b2a4, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: c627d08c8667f4028b4d10424305b2a4, type: 2}
   - m_GUID: c9952998f0e0541418a2664f0b1308f1
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/7.asset
+    m_Address: Autumn_1/7
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: c9952998f0e0541418a2664f0b1308f1, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: c9952998f0e0541418a2664f0b1308f1, type: 2}
   - m_GUID: cb13d7c03238440d1b9f4e8e485c4340
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_2/4.asset
+    m_Address: Autumn_2/4
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: cb13d7c03238440d1b9f4e8e485c4340, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: cb13d7c03238440d1b9f4e8e485c4340, type: 2}
   - m_GUID: cfe7580bcfa1348879c13bdc01392681
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_2/3.asset
+    m_Address: Winter_2/3
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: cfe7580bcfa1348879c13bdc01392681, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: cfe7580bcfa1348879c13bdc01392681, type: 2}
   - m_GUID: d284cbb70be204acf9acc5d0041dff80
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/8.asset
+    m_Address: Winter_3/8
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: d284cbb70be204acf9acc5d0041dff80, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: d284cbb70be204acf9acc5d0041dff80, type: 2}
   - m_GUID: d30bd3747984042a5933df5a0c60a883
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/7.asset
+    m_Address: Summer_1/7
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: d30bd3747984042a5933df5a0c60a883, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: d30bd3747984042a5933df5a0c60a883, type: 2}
   - m_GUID: d94bba782b00848c48b6d1f04bc3718a
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/8.asset
+    m_Address: Autumn_3/8
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: d94bba782b00848c48b6d1f04bc3718a, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: d94bba782b00848c48b6d1f04bc3718a, type: 2}
   - m_GUID: dbebf5f2a97f24a66892f38c1c6dcd54
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/1.asset
+    m_Address: Winter_1/1
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: dbebf5f2a97f24a66892f38c1c6dcd54, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: dbebf5f2a97f24a66892f38c1c6dcd54, type: 2}
   - m_GUID: e46985f3520824d2eaad1ed05e41d722
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/7.asset
+    m_Address: Spring_3/7
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: e46985f3520824d2eaad1ed05e41d722, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: e46985f3520824d2eaad1ed05e41d722, type: 2}
   - m_GUID: e5202320c685048f78a2c19cc66fa5ee
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Spring_3/2.asset
+    m_Address: Spring_3/2
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: e5202320c685048f78a2c19cc66fa5ee, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: e5202320c685048f78a2c19cc66fa5ee, type: 2}
   - m_GUID: e7adfa3f7376c4acba0e84d33dbff57c
-    m_Address: Assets/Project/Resources_moved/GameDatas/Stages/Spring_1/4.asset
+    m_Address: Spring_1/4
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: e7adfa3f7376c4acba0e84d33dbff57c, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: e7adfa3f7376c4acba0e84d33dbff57c, type: 2}
   - m_GUID: e82174cd0ea9a44d09a9ee3bdcc3bd6d
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/10.asset
+    m_Address: Winter_1/10
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: e82174cd0ea9a44d09a9ee3bdcc3bd6d, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: e82174cd0ea9a44d09a9ee3bdcc3bd6d, type: 2}
   - m_GUID: e9e66da04ddfa4b8ab048dbb6ec0a7f9
-    m_Address: Assets/Project/Resources_moved/GameDatas/Stages/Spring_2/1.asset
+    m_Address: Spring_2/1
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: e9e66da04ddfa4b8ab048dbb6ec0a7f9, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: e9e66da04ddfa4b8ab048dbb6ec0a7f9, type: 2}
   - m_GUID: ea87323e3cc994fe49fa3a80582a3696
-    m_Address: Assets/Project/Resources_moved/GameDatas/Stages/Spring_1/7.asset
+    m_Address: Spring_1/7
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: ea87323e3cc994fe49fa3a80582a3696, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: ea87323e3cc994fe49fa3a80582a3696, type: 2}
   - m_GUID: eac00d282222242b68e4a7cdfde4465d
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_1/9.asset
+    m_Address: Winter_1/9
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: eac00d282222242b68e4a7cdfde4465d, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: eac00d282222242b68e4a7cdfde4465d, type: 2}
   - m_GUID: ec16ecf08577f41b8bd1acbbb8191cd6
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/4.asset
+    m_Address: Autumn_1/4
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: ec16ecf08577f41b8bd1acbbb8191cd6, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: ec16ecf08577f41b8bd1acbbb8191cd6, type: 2}
   - m_GUID: ef2a4b639786f44a69226527362b3bf6
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_2/2.asset
+    m_Address: Summer_2/2
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: ef2a4b639786f44a69226527362b3bf6, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: ef2a4b639786f44a69226527362b3bf6, type: 2}
   - m_GUID: eff3398753b0d4b7481fd4404f4fafbf
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_1/3.asset
+    m_Address: Autumn_1/3
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: eff3398753b0d4b7481fd4404f4fafbf, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: eff3398753b0d4b7481fd4404f4fafbf, type: 2}
   - m_GUID: f1f274f7d95914fb3837ed486594f6dd
-    m_Address: Assets/Project/Resources_moved/GameDatas/Stages/Spring_1/9.asset
+    m_Address: Spring_1/9
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: f1f274f7d95914fb3837ed486594f6dd, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: f1f274f7d95914fb3837ed486594f6dd, type: 2}
   - m_GUID: f34525bb49daa4dbe8120f5c7c7bb4fe
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Spring_2/7.asset
+    m_Address: Spring_2/7
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: f34525bb49daa4dbe8120f5c7c7bb4fe, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: f34525bb49daa4dbe8120f5c7c7bb4fe, type: 2}
   - m_GUID: f4eafd6ad27cc4199927a936493093d5
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Summer_1/9.asset
+    m_Address: Summer_1/9
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: f4eafd6ad27cc4199927a936493093d5, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: f4eafd6ad27cc4199927a936493093d5, type: 2}
   - m_GUID: f592616422c624095be2fb3a061e50eb
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/3.asset
+    m_Address: Autumn_3/3
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: f592616422c624095be2fb3a061e50eb, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: f592616422c624095be2fb3a061e50eb, type: 2}
   - m_GUID: faf473801664d49a5b4b9389a413566b
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Winter_3/10.asset
+    m_Address: Winter_3/10
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage
     m_MainAsset: {fileID: 11400000, guid: faf473801664d49a5b4b9389a413566b, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: faf473801664d49a5b4b9389a413566b, type: 2}
   - m_GUID: fc2bcd08488d24d90ad4e760226867e3
-    m_Address: Assets/Project/AddressableResources/GameDatas/Stages/Autumn_3/10.asset
+    m_Address: Autumn_3/10
     m_ReadOnly: 0
     m_SerializedLabels:
     - Stage

--- a/Assets/AddressableAssetsData/AssetGroups/Tiles.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Tiles.asset
@@ -50,8 +50,8 @@ MonoBehaviour:
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tile
-    m_MainAsset: {fileID: 2800000, guid: 3b2b830c7c8e64ccd84416f1ddec9daa, type: 3}
-    m_TargetAsset: {fileID: 2800000, guid: 3b2b830c7c8e64ccd84416f1ddec9daa, type: 3}
+    m_MainAsset: {fileID: 0}
+    m_TargetAsset: {fileID: 0}
   - m_GUID: 496f422ec07e8488cbc4b8555ae8ff02
     m_Address: normalTile_4
     m_ReadOnly: 0
@@ -64,8 +64,8 @@ MonoBehaviour:
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tile
-    m_MainAsset: {fileID: 2800000, guid: 4b48d2af173e44899ba118bf50d193c7, type: 3}
-    m_TargetAsset: {fileID: 2800000, guid: 4b48d2af173e44899ba118bf50d193c7, type: 3}
+    m_MainAsset: {fileID: 0}
+    m_TargetAsset: {fileID: 0}
   - m_GUID: 51b39f4d7523d4df3a7e291ceb9fc25e
     m_Address: normalTile_10
     m_ReadOnly: 0
@@ -92,15 +92,15 @@ MonoBehaviour:
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tile
-    m_MainAsset: {fileID: 2800000, guid: 6595b0a3440994dd28e0d1f090bf49cd, type: 3}
-    m_TargetAsset: {fileID: 2800000, guid: 6595b0a3440994dd28e0d1f090bf49cd, type: 3}
+    m_MainAsset: {fileID: 0}
+    m_TargetAsset: {fileID: 0}
   - m_GUID: 6c8ca96e12baf4b62bfeb28f017b705e
     m_Address: goalTile_Orange
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tile
-    m_MainAsset: {fileID: 2800000, guid: 6c8ca96e12baf4b62bfeb28f017b705e, type: 3}
-    m_TargetAsset: {fileID: 2800000, guid: 6c8ca96e12baf4b62bfeb28f017b705e, type: 3}
+    m_MainAsset: {fileID: 0}
+    m_TargetAsset: {fileID: 0}
   - m_GUID: 6cf2e60e46bfa4964b97af696aab6d8a
     m_Address: normalTile_8
     m_ReadOnly: 0
@@ -120,8 +120,8 @@ MonoBehaviour:
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tile
-    m_MainAsset: {fileID: 2800000, guid: 7d3ed51b6e99a4f3bbb3f27f15f6977b, type: 3}
-    m_TargetAsset: {fileID: 2800000, guid: 7d3ed51b6e99a4f3bbb3f27f15f6977b, type: 3}
+    m_MainAsset: {fileID: 0}
+    m_TargetAsset: {fileID: 0}
   - m_GUID: 8723518ab12fa4ff9a973c664acbdc08
     m_Address: normalTile_2
     m_ReadOnly: 0
@@ -162,8 +162,8 @@ MonoBehaviour:
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tile
-    m_MainAsset: {fileID: 2800000, guid: b4bf03d01835f4e97beb24125076a0d4, type: 3}
-    m_TargetAsset: {fileID: 2800000, guid: b4bf03d01835f4e97beb24125076a0d4, type: 3}
+    m_MainAsset: {fileID: 0}
+    m_TargetAsset: {fileID: 0}
   - m_GUID: b9d906ecbf1694e63aa7160b78a3e0bf
     m_Address: normalTile_15
     m_ReadOnly: 0
@@ -190,8 +190,8 @@ MonoBehaviour:
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tile
-    m_MainAsset: {fileID: 2800000, guid: d44bd624a79704929a06a1b06346c89d, type: 3}
-    m_TargetAsset: {fileID: 2800000, guid: d44bd624a79704929a06a1b06346c89d, type: 3}
+    m_MainAsset: {fileID: 0}
+    m_TargetAsset: {fileID: 0}
   - m_GUID: e104cc7fc139d423fa1bf074ecfcb842
     m_Address: normalTile_3
     m_ReadOnly: 0
@@ -204,8 +204,8 @@ MonoBehaviour:
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tile
-    m_MainAsset: {fileID: 2800000, guid: e181d0ca67b4547d6bfdad363e38853d, type: 3}
-    m_TargetAsset: {fileID: 2800000, guid: e181d0ca67b4547d6bfdad363e38853d, type: 3}
+    m_MainAsset: {fileID: 0}
+    m_TargetAsset: {fileID: 0}
   - m_GUID: f9de4f74096404b6f8f21c34a2d39bdd
     m_Address: normalTile_6
     m_ReadOnly: 0
@@ -223,4 +223,6 @@ MonoBehaviour:
   m_ReadOnly: 0
   m_Settings: {fileID: 11400000, guid: 86a9d3876e9534cd69e69f31dd11bb5f, type: 2}
   m_SchemaSet:
-    m_Schemas: []
+    m_Schemas:
+    - {fileID: 11400000, guid: 5e3cbd6dbdbd6438c8cd3aef82bf5aef, type: 2}
+    - {fileID: 11400000, guid: 948b83f8fa0294e95aea572439012210, type: 2}

--- a/Assets/AddressableAssetsData/AssetGroups/Trees.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Trees.asset
@@ -18,12 +18,12 @@ MonoBehaviour:
   m_GUID: 68e81847d52824f739163f8362c0913a
   m_SerializeEntries:
   - m_GUID: 9e7f743572fbb425fae19c56a677e14d
-    m_Address: Tree_Spring_1
+    m_Address: Assets/Project/GameDatas/Trees/Spring-1.asset
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tree
-    m_MainAsset: {fileID: 0}
-    m_TargetAsset: {fileID: 0}
+    m_MainAsset: {fileID: 11400000, guid: 9e7f743572fbb425fae19c56a677e14d, type: 2}
+    m_TargetAsset: {fileID: 11400000, guid: 9e7f743572fbb425fae19c56a677e14d, type: 2}
   - m_GUID: 1a2e5236c5c0f4d9fa04e1764c5ef874
     m_Address: Assets/Project/GameDatas/Trees/Autumn-1.asset
     m_ReadOnly: 0

--- a/Assets/AddressableAssetsData/AssetGroups/Trees.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Trees.asset
@@ -104,4 +104,6 @@ MonoBehaviour:
   m_ReadOnly: 0
   m_Settings: {fileID: 11400000, guid: 86a9d3876e9534cd69e69f31dd11bb5f, type: 2}
   m_SchemaSet:
-    m_Schemas: []
+    m_Schemas:
+    - {fileID: 11400000, guid: 859088b7d47e04478bc5692b746a4294, type: 2}
+    - {fileID: 11400000, guid: d84b170957a6c4d3aa167b0464397966, type: 2}

--- a/Assets/AddressableAssetsData/AssetGroups/Trees.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Trees.asset
@@ -18,84 +18,84 @@ MonoBehaviour:
   m_GUID: 68e81847d52824f739163f8362c0913a
   m_SerializeEntries:
   - m_GUID: 9e7f743572fbb425fae19c56a677e14d
-    m_Address: Assets/Project/GameDatas/Trees/Spring-1.asset
+    m_Address: Spring-1
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tree
     m_MainAsset: {fileID: 11400000, guid: 9e7f743572fbb425fae19c56a677e14d, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 9e7f743572fbb425fae19c56a677e14d, type: 2}
   - m_GUID: 1a2e5236c5c0f4d9fa04e1764c5ef874
-    m_Address: Assets/Project/GameDatas/Trees/Autumn-1.asset
+    m_Address: Autumn-1
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tree
     m_MainAsset: {fileID: 11400000, guid: 1a2e5236c5c0f4d9fa04e1764c5ef874, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 1a2e5236c5c0f4d9fa04e1764c5ef874, type: 2}
   - m_GUID: 9e3c175831b8e49c497a198012d43e0b
-    m_Address: Assets/Project/GameDatas/Trees/Autumn-2.asset
+    m_Address: Autumn-2
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tree
     m_MainAsset: {fileID: 11400000, guid: 9e3c175831b8e49c497a198012d43e0b, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 9e3c175831b8e49c497a198012d43e0b, type: 2}
   - m_GUID: d8c43e5711b1448bcb9731281d482520
-    m_Address: Assets/Project/GameDatas/Trees/Autumn-3.asset
+    m_Address: Autumn-3
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tree
     m_MainAsset: {fileID: 11400000, guid: d8c43e5711b1448bcb9731281d482520, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: d8c43e5711b1448bcb9731281d482520, type: 2}
   - m_GUID: 1e6504cf76f6c4c00add7b99917ad58c
-    m_Address: Assets/Project/GameDatas/Trees/Spring-2.asset
+    m_Address: Spring-2
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tree
     m_MainAsset: {fileID: 11400000, guid: 1e6504cf76f6c4c00add7b99917ad58c, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 1e6504cf76f6c4c00add7b99917ad58c, type: 2}
   - m_GUID: bcc57ff26e5bd46e09b8f01f6168b089
-    m_Address: Assets/Project/GameDatas/Trees/Spring-3.asset
+    m_Address: Spring-3
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tree
     m_MainAsset: {fileID: 11400000, guid: bcc57ff26e5bd46e09b8f01f6168b089, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: bcc57ff26e5bd46e09b8f01f6168b089, type: 2}
   - m_GUID: 7147f8fad5475483d8fac7ed30386e3f
-    m_Address: Assets/Project/GameDatas/Trees/Summer-1.asset
+    m_Address: Summer-1
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tree
     m_MainAsset: {fileID: 11400000, guid: 7147f8fad5475483d8fac7ed30386e3f, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 7147f8fad5475483d8fac7ed30386e3f, type: 2}
   - m_GUID: f37564722243b47cd836e07cf1b78c84
-    m_Address: Assets/Project/GameDatas/Trees/Summer-2.asset
+    m_Address: Summer-2
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tree
     m_MainAsset: {fileID: 11400000, guid: f37564722243b47cd836e07cf1b78c84, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: f37564722243b47cd836e07cf1b78c84, type: 2}
   - m_GUID: f06669457ee82427b8fd80b7d4b6f4bc
-    m_Address: Assets/Project/GameDatas/Trees/Summer-3.asset
+    m_Address: Summer-3
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tree
     m_MainAsset: {fileID: 11400000, guid: f06669457ee82427b8fd80b7d4b6f4bc, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: f06669457ee82427b8fd80b7d4b6f4bc, type: 2}
   - m_GUID: 709d33a8540a7431593ded2bfc9ae909
-    m_Address: Assets/Project/GameDatas/Trees/Winter-1.asset
+    m_Address: Winter-1
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tree
     m_MainAsset: {fileID: 11400000, guid: 709d33a8540a7431593ded2bfc9ae909, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: 709d33a8540a7431593ded2bfc9ae909, type: 2}
   - m_GUID: bf5a9813bbcae4217b70937823784510
-    m_Address: Assets/Project/GameDatas/Trees/Winter-2.asset
+    m_Address: Winter-2
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tree
     m_MainAsset: {fileID: 11400000, guid: bf5a9813bbcae4217b70937823784510, type: 2}
     m_TargetAsset: {fileID: 11400000, guid: bf5a9813bbcae4217b70937823784510, type: 2}
   - m_GUID: 3c7a08596934543df8dfefb95fc45d47
-    m_Address: Assets/Project/GameDatas/Trees/Winter-3.asset
+    m_Address: Winter-3
     m_ReadOnly: 0
     m_SerializedLabels:
     - Tree

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -171,7 +171,7 @@ PlayerSettings:
   keepLoadedShadersAlive: 0
   StripUnusedMeshComponents: 0
   VertexChannelCompressionMask: 214
-  iPhoneSdkVersion: 988
+  iPhoneSdkVersion: 989
   iOSTargetOSVersionString: 11.0
   tvOSSdkVersion: 0
   tvOSRequireExtendedGameController: 0


### PR DESCRIPTION
### 対象イシュー
Close #953 

### 概要
- `AAS` の `Group` において `Trees` と `Tiles` の設定が不十分だったので修正 → f9a5342 590efa8

|Before|After|
|---|---|
|<img width="659" alt="スクリーンショット 2021-06-10 22 23 39" src="https://user-images.githubusercontent.com/26104258/121533813-9a90e380-ca3b-11eb-8e12-19f03b6e3ab1.png">|<img width="665" alt="スクリーンショット 2021-06-10 22 23 27" src="https://user-images.githubusercontent.com/26104258/121533808-98c72000-ca3b-11eb-9092-942bed1e4e30.png">|

- デバッグがしやすいので、一時的に実機の代わりに `Simulator` でビルドできるようにする（実機と `Simulator` の動作は基本的には変わらないです）→ 8bd9854

|Before|After|
|---|---|
|<img width="952" alt="スクリーンショット 2021-06-10 22 26 12" src="https://user-images.githubusercontent.com/26104258/121534301-112de100-ca3c-11eb-8e6c-b61249153926.png">|<img width="955" alt="スクリーンショット 2021-06-10 22 26 25" src="https://user-images.githubusercontent.com/26104258/121534315-13903b00-ca3c-11eb-9236-672ec2de4923.png">|

- `Spring-1.asset` が明らかに意味不明な path を指していたので修正 → c657f87

### 動作確認方法
- [ ] https://github.com/LITO-apps/Treevel-client/issues/953#issuecomment-855244034 のエラーログが出なくなっていること
- [ ] https://github.com/LITO-apps/Treevel-client/issues/953#issuecomment-856836201 のエラーログが代わりに出るようになったこと → #971 
