### PR TITLE
Bottleの移動が完全に終了してから成功判定を行う

### DIFF
--- a/Assets/Project/GameDatas/Stages/Spring_1/8.asset
+++ b/Assets/Project/GameDatas/Stages/Spring_1/8.asset
@@ -49,7 +49,7 @@ MonoBehaviour:
     pairNumber: 0
   bottles:
   - type: 2
-    initPos: 4
+    initPos: 7
     goalColor: 1
     life: 1
     isSelfish: 0
@@ -70,7 +70,7 @@ MonoBehaviour:
     isDark: 0
     isReverse: 0
   - type: 2
-    initPos: 7
+    initPos: 10
     goalColor: 1
     life: 1
     isSelfish: 0
@@ -91,7 +91,7 @@ MonoBehaviour:
     isDark: 0
     isReverse: 0
   - type: 2
-    initPos: 10
+    initPos: 13
     goalColor: 1
     life: 1
     isSelfish: 0
@@ -104,14 +104,43 @@ MonoBehaviour:
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  gimmicks: []
+  - type: 0
+    initPos: 1
+    goalColor: 0
+    life: 0
+    isSelfish: 0
+    isDark: 0
+    isReverse: 0
+  gimmicks:
+  - loop: 1
+    appearTime: 3
+    interval: 5
+    type: 5
+    targetDirections: 
+    targetLines: 
+    randomDirection: 
+    randomRow: 
+    randomColumn: 
+    targetRow: -1
+    targetColumn: 0
+    targetBottle: 0
+    randomAttackableBottles: 
+    isRandom: 0
+    targets: []
+    targetDirection: 2
+    attackTimes: 0
+    duration: 0
+    width: 0
+    height: 0
   overviewGimmicks: 
   tutorial:
     type: 0
     image:
       m_AssetGUID: 
       m_SubObjectName: 
+      m_SubObjectType: 
     video:
       m_AssetGUID: 
       m_SubObjectName: 
+      m_SubObjectType: 
   constraintStages: []

--- a/Assets/Project/Scripts/Modules/GamePlayScene/BoardManager.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/BoardManager.cs
@@ -70,6 +70,8 @@ namespace Treevel.Modules.GamePlayScene
         {
             _tokenSource = new CancellationTokenSource();
             _disposable = GamePlayDirector.Instance.GameEnd.Subscribe(_ => EndProcess()).AddTo(this);
+            _numOfGoalBottles = 0;
+            _numOfSuccessBottles = 0;
         }
 
         private void EndProcess()

--- a/Assets/Project/Scripts/Modules/GamePlayScene/BoardManager.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/BoardManager.cs
@@ -82,7 +82,9 @@ namespace Treevel.Modules.GamePlayScene
 
         /// <summary>
         /// 盤面のGoalBottleの成功状態を更新する
+        /// GoalBottleの状態が成功->失敗 or 失敗->成功に変化した時のみ呼ぶ
         /// </summary>
+        /// <param name="isSuccess"> 1つのGoalBottleの成功状態 </param>
         public void UpdateNumOfSuccessBottles(bool isSuccess)
         {
             if (!isSuccess) {

--- a/Assets/Project/Scripts/Modules/GamePlayScene/BoardManager.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/BoardManager.cs
@@ -86,11 +86,11 @@ namespace Treevel.Modules.GamePlayScene
         public void CheckClear(bool isSuccess)
         {
             if (!isSuccess) {
-                _numOfSuccessBottles--;
+                Interlocked.Decrement(ref _numOfSuccessBottles);
                 return;
             }
 
-            _numOfSuccessBottles++;
+            Interlocked.Increment(ref _numOfSuccessBottles);
             // 成功判定
             if (_numOfSuccessBottles >= _numOfGoalBottles) GamePlayDirector.Instance.Dispatch(GamePlayDirector.EGameState.Success);
         }

--- a/Assets/Project/Scripts/Modules/GamePlayScene/BoardManager.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/BoardManager.cs
@@ -81,9 +81,9 @@ namespace Treevel.Modules.GamePlayScene
         }
 
         /// <summary>
-        /// 盤面の成功判定
+        /// 盤面のGoalBottleの成功状態を更新する
         /// </summary>
-        public void CheckClear(bool isSuccess)
+        public void UpdateNumOfSuccessBottle(bool isSuccess)
         {
             if (!isSuccess) {
                 Interlocked.Decrement(ref _numOfSuccessBottles);
@@ -91,7 +91,7 @@ namespace Treevel.Modules.GamePlayScene
             }
 
             Interlocked.Increment(ref _numOfSuccessBottles);
-            // 成功判定
+            // 盤面の成功判定
             if (_numOfSuccessBottles >= _numOfGoalBottles) GamePlayDirector.Instance.Dispatch(GamePlayDirector.EGameState.Success);
         }
 

--- a/Assets/Project/Scripts/Modules/GamePlayScene/BoardManager.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/BoardManager.cs
@@ -30,6 +30,16 @@ namespace Treevel.Modules.GamePlayScene
         private IDisposable _disposable;
         private CancellationTokenSource _tokenSource;
 
+        /// <summary>
+        /// GoalBottleの数
+        /// </summary>
+        private int _numOfGoalBottles;
+
+        /// <summary>
+        /// 成功状態のBottleの数
+        /// </summary>
+        private int _numOfSuccessBottles;
+
         private void Awake()
         {
             // `squares` の初期化
@@ -66,6 +76,21 @@ namespace Treevel.Modules.GamePlayScene
         {
             _tokenSource.Cancel();
             _disposable.Dispose();
+        }
+
+        /// <summary>
+        /// 盤面の成功判定
+        /// </summary>
+        public void CheckClear(bool isSuccess)
+        {
+            if (!isSuccess) {
+                _numOfSuccessBottles--;
+                return;
+            }
+
+            _numOfSuccessBottles++;
+            // 成功判定
+            if (_numOfSuccessBottles >= _numOfGoalBottles) GamePlayDirector.Instance.Dispatch(GamePlayDirector.EGameState.Success);
         }
 
         /// <summary>
@@ -262,26 +287,6 @@ namespace Treevel.Modules.GamePlayScene
         }
 
         /// <summary>
-        /// ボトルを特定のタイルに移動する（瞬間移動）
-        /// </summary>
-        /// <param name="bottle"> 移動するボトル </param>
-        /// <param name="tileNum"> 移動先のタイル番号 </param>
-        /// <param name="direction"> どちら方向から移動してきたか (単位ベクトル) </param>
-        /// <returns> ボトルが移動できたかどうか </returns>
-        public bool MoveAsync(DynamicBottleController bottle, int tileNum)
-        {
-            if (!MoveBottleInSquares(bottle, tileNum, out var targetSquare)) return false;
-
-            var bottleObject = bottle.gameObject;
-            // ボトルを瞬間移動させる
-            bottle.transform.position = targetSquare.worldPosition;
-            targetSquare.bottle.OnEnterTile(targetSquare.tile.gameObject);
-            targetSquare.tile.OnBottleEnter(bottleObject, null);
-
-            return true;
-        }
-
-        /// <summary>
         /// ボトル移動(BoardManager内部)
         /// </summary>
         /// <param name="bottle">ボトルインスタンス</param>
@@ -411,6 +416,9 @@ namespace Treevel.Modules.GamePlayScene
 
                 // 適切な場所に設置
                 targetSquare.bottle.transform.position = targetSquare.worldPosition;
+
+                // GoalBottleの個数を数える
+                if (bottle is GoalBottleController) _numOfGoalBottles++;
             }
         }
 

--- a/Assets/Project/Scripts/Modules/GamePlayScene/BoardManager.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/BoardManager.cs
@@ -83,7 +83,7 @@ namespace Treevel.Modules.GamePlayScene
         /// <summary>
         /// 盤面のGoalBottleの成功状態を更新する
         /// </summary>
-        public void UpdateNumOfSuccessBottle(bool isSuccess)
+        public void UpdateNumOfSuccessBottles(bool isSuccess)
         {
             if (!isSuccess) {
                 Interlocked.Decrement(ref _numOfSuccessBottles);

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Bottle/DarkAttributeController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Bottle/DarkAttributeController.cs
@@ -32,11 +32,10 @@ namespace Treevel.Modules.GamePlayScene.Bottle
             _bottleController = bottleController;
 
             // イベントに処理を登録する
-            _bottleController.EnterTile.Merge(_bottleController.ExitTile)
-                .Subscribe(_ => {
-                    _isSuccess = _bottleController.IsSuccess();
-                    animator.SetBool(_ANIMATOR_IS_DARK, !_isSuccess);
-                }).AddTo(this);
+            _bottleController.isSuccess.Subscribe(value => {
+                _isSuccess = value;
+                animator.SetBool(_ANIMATOR_IS_DARK, !_isSuccess);
+            }).AddTo(this);
             _bottleController.longPressGesture.OnLongPress.AsObservable().Subscribe(_ => animator.SetBool(_ANIMATOR_IS_DARK, false)).AddTo(compositeDisposableOnGameEnd, this);
             _bottleController.releaseGesture.OnRelease.AsObservable().Subscribe(_ => animator.SetBool(_ANIMATOR_IS_DARK, !_isSuccess)).AddTo(compositeDisposableOnGameEnd, this);
         }

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Bottle/GoalBottleController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Bottle/GoalBottleController.cs
@@ -50,7 +50,7 @@ namespace Treevel.Modules.GamePlayScene.Bottle
             // 状態変化時の処理
             isSuccess.SkipLatestValueOnSubscribe().Subscribe(value => {
                 _spriteGlowEffect.enabled = value;
-                BoardManager.Instance.CheckClear(value);
+                BoardManager.Instance.UpdateNumOfSuccessBottle(value);
             }).AddTo(this);
         }
 

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Bottle/GoalBottleController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Bottle/GoalBottleController.cs
@@ -50,7 +50,7 @@ namespace Treevel.Modules.GamePlayScene.Bottle
             // 状態変化時の処理
             isSuccess.SkipLatestValueOnSubscribe().Subscribe(value => {
                 _spriteGlowEffect.enabled = value;
-                BoardManager.Instance.UpdateNumOfSuccessBottle(value);
+                BoardManager.Instance.UpdateNumOfSuccessBottles(value);
             }).AddTo(this);
         }
 

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Bottle/GoalBottleController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Bottle/GoalBottleController.cs
@@ -44,7 +44,7 @@ namespace Treevel.Modules.GamePlayScene.Bottle
             longPressGesture.TimeToPress = 0.15f;
             spriteRendererUnifier = GetComponent<SpriteRendererUnifier>();
             // 成功判定
-            EnterTile.Subscribe(_ => isSuccess.Value = GoalColor != EGoalColor.None && BoardManager.Instance.GetTileColor(this) == GoalColor).AddTo(this);
+            EnterTile.Where(_ => GoalColor != EGoalColor.None).Subscribe(_ => isSuccess.Value = BoardManager.Instance.GetTileColor(this) == GoalColor).AddTo(this);
             // 移動開始時は非成功に遷移
             ExitTile.Subscribe(_ => isSuccess.Value = false).AddTo(this);
             // 状態変化時の処理

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Bottle/GoalBottleController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Bottle/GoalBottleController.cs
@@ -17,6 +17,11 @@ namespace Treevel.Modules.GamePlayScene.Bottle
     [RequireComponent(typeof(LongPressGesture))]
     public class GoalBottleController : DynamicBottleController
     {
+        /// <summary>
+        /// 成功状態かどうか
+        /// </summary>
+        public readonly ReactiveProperty<bool> isSuccess = new ReactiveProperty<bool>(false);
+
         public LongPressGesture longPressGesture;
 
         /// <summary>
@@ -38,8 +43,15 @@ namespace Treevel.Modules.GamePlayScene.Bottle
             longPressGesture.UseUnityEvents = true;
             longPressGesture.TimeToPress = 0.15f;
             spriteRendererUnifier = GetComponent<SpriteRendererUnifier>();
-            EnterTile.Where(_ => IsSuccess()).Subscribe(_ => DoWhenSuccess()).AddTo(this);
-            ExitTile.Subscribe(_ => _spriteGlowEffect.enabled = false).AddTo(this);
+            // 成功判定
+            EnterTile.Subscribe(_ => isSuccess.Value = GoalColor != EGoalColor.None && BoardManager.Instance.GetTileColor(this) == GoalColor).AddTo(this);
+            // 移動開始時は非成功に遷移
+            ExitTile.Subscribe(_ => isSuccess.Value = false).AddTo(this);
+            // 状態変化時の処理
+            isSuccess.SkipLatestValueOnSubscribe().Subscribe(value => {
+                _spriteGlowEffect.enabled = value;
+                BoardManager.Instance.CheckClear(value);
+            }).AddTo(this);
         }
 
         /// <summary>
@@ -72,26 +84,6 @@ namespace Treevel.Modules.GamePlayScene.Bottle
             #if UNITY_EDITOR
             name = Constants.BottleName.NORMAL_BOTTLE + Id;
             #endif
-        }
-
-        /// <summary>
-        /// 目標タイルにいる時の処理
-        /// </summary>
-        private void DoWhenSuccess()
-        {
-            // 光らせる
-            _spriteGlowEffect.enabled = true;
-            // ステージの成功判定
-            GamePlayDirector.Instance.CheckClear();
-        }
-
-        /// <summary>
-        /// 目標タイルにいるかどうか
-        /// </summary>
-        /// <returns></returns>
-        public bool IsSuccess()
-        {
-            return GoalColor != EGoalColor.None && BoardManager.Instance.GetTileColor(this) == GoalColor;
         }
     }
 }

--- a/Assets/Project/Scripts/Modules/GamePlayScene/GamePlayDirector.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/GamePlayDirector.cs
@@ -273,20 +273,6 @@ namespace Treevel.Modules.GamePlayScene
         }
 
         /// <summary>
-        /// ゲームがクリアしているかをチェックする
-        /// </summary>
-        public void CheckClear()
-        {
-            if (!StageGenerator.CreatedFinished) return;
-
-            var bottles = FindObjectsOfType<GoalBottleController>();
-            if (bottles.Any(bottle => bottle.IsSuccess() == false)) return;
-
-            // 全ての成功判定が付くボトルが成功の場合，成功状態に遷移
-            Dispatch(EGameState.Success);
-        }
-
-        /// <summary>
         /// ゲームの状態を変更する
         /// </summary>
         /// <param name="nextState"> 変更したい状態 </param>

--- a/Assets/Project/Scripts/Modules/GamePlayScene/GamePlayDirector.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/GamePlayDirector.cs
@@ -525,6 +525,7 @@ namespace Treevel.Modules.GamePlayScene
                 }
 
                 // 成功盤面を一定時間表示
+                // TODO: アニメーションの終了を待つ
                 await Task.Delay(500);
                 // 成功ポップアップ表示
                 _successPopup.SetActive(true);
@@ -568,6 +569,7 @@ namespace Treevel.Modules.GamePlayScene
 
                 if (from is PlayingState) {
                     // 失敗盤面を一定時間表示
+                    // TODO: アニメーションの終了を待つ
                     await Task.Delay(500);
                     // 失敗ポップアップを表示
                     _failurePopup.SetActive(true);

--- a/Assets/Project/Scripts/Modules/GamePlayScene/GamePlayDirector.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/GamePlayDirector.cs
@@ -503,9 +503,6 @@ namespace Treevel.Modules.GamePlayScene
 
                 SoundManager.Instance.PlaySE(ESEKey.GamePlay_Success);
 
-                // 成功ポップアップ表示
-                _successPopup.SetActive(true);
-
                 // 成功イベント
                 Instance._gameSucceededSubject.OnNext(Unit.Default);
 
@@ -525,6 +522,8 @@ namespace Treevel.Modules.GamePlayScene
                         },
                         false);
                 }
+                // 成功ポップアップ表示
+                _successPopup.SetActive(true);
             }
 
             public override void OnExit(StateBase to)
@@ -557,14 +556,16 @@ namespace Treevel.Modules.GamePlayScene
                     // 失敗SE
                     SoundManager.Instance.PlaySERandom(new[] { ESEKey.GamePlay_Failed_1, ESEKey.GamePlay_Failed_2 });
 
-                    // 失敗ポップアップを表示
-                    _failurePopup.SetActive(true);
-
                     // 失敗イベント
                     Instance._gameFailedSubject.OnNext(Unit.Default);
                 }
 
                 await StageRecordService.Instance.SaveAsync(treeId, stageNumber, Instance._stageRecord);
+
+                if (from is PlayingState) {
+                    // 失敗ポップアップを表示
+                    _failurePopup.SetActive(true);
+                }
 
                 // Pausingから来たらステージ選択画面へ
                 if (from is PausingState) {

--- a/Assets/Project/Scripts/Modules/GamePlayScene/GamePlayDirector.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/GamePlayDirector.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 using Cysharp.Threading.Tasks;
 using GoogleMobileAds.Api;
 using Treevel.Common.Attributes;
@@ -522,6 +523,9 @@ namespace Treevel.Modules.GamePlayScene
                         },
                         false);
                 }
+
+                // 成功盤面を一定時間表示
+                await Task.Delay(500);
                 // 成功ポップアップ表示
                 _successPopup.SetActive(true);
             }
@@ -563,6 +567,8 @@ namespace Treevel.Modules.GamePlayScene
                 await StageRecordService.Instance.SaveAsync(treeId, stageNumber, Instance._stageRecord);
 
                 if (from is PlayingState) {
+                    // 失敗盤面を一定時間表示
+                    await Task.Delay(500);
                     // 失敗ポップアップを表示
                     _failurePopup.SetActive(true);
                 }

--- a/Assets/Project/Scripts/Modules/GamePlayScene/GamePlayDirector.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/GamePlayDirector.cs
@@ -514,6 +514,15 @@ namespace Treevel.Modules.GamePlayScene
             public override async void OnEnter(StateBase from = null)
             {
                 Instance._stageRecord.Succeed();
+
+                SoundManager.Instance.PlaySE(ESEKey.GamePlay_Success);
+
+                // 成功ポップアップ表示
+                _successPopup.SetActive(true);
+
+                // 成功イベント
+                Instance._gameSucceededSubject.OnNext(Unit.Default);
+
                 try {
                     await StageRecordService.Instance.SaveAsync(treeId, stageNumber, Instance._stageRecord);
                 } catch {
@@ -530,14 +539,6 @@ namespace Treevel.Modules.GamePlayScene
                         },
                         false);
                 }
-
-                SoundManager.Instance.PlaySE(ESEKey.GamePlay_Success);
-
-                // 成功ポップアップ表示
-                _successPopup.SetActive(true);
-
-                // 成功イベント
-                Instance._gameSucceededSubject.OnNext(Unit.Default);
             }
 
             public override void OnExit(StateBase to)
@@ -564,13 +565,9 @@ namespace Treevel.Modules.GamePlayScene
             {
                 Instance._stageRecord.Fail();
                 Instance._stageRecord.failureReasonNum.Increment(Instance.failureReason);
-                await StageRecordService.Instance.SaveAsync(treeId, stageNumber, Instance._stageRecord);
-
-                // Pausingから来たらステージ選択画面へ
-                if (from is PausingState) {
-                    // StageSelectSceneに戻る
-                    AddressableAssetManager.LoadScene(seasonId.GetSceneName());
-                } else {
+                
+                // 通常の失敗時
+                if (from is PlayingState) {
                     // 失敗SE
                     SoundManager.Instance.PlaySERandom(new[] { ESEKey.GamePlay_Failed_1, ESEKey.GamePlay_Failed_2 });
 
@@ -579,6 +576,14 @@ namespace Treevel.Modules.GamePlayScene
 
                     // 失敗イベント
                     Instance._gameFailedSubject.OnNext(Unit.Default);
+                }
+
+                await StageRecordService.Instance.SaveAsync(treeId, stageNumber, Instance._stageRecord);
+
+                // Pausingから来たらステージ選択画面へ
+                if (from is PausingState) {
+                    // StageSelectSceneに戻る
+                    AddressableAssetManager.LoadScene(seasonId.GetSceneName());
                 }
             }
 


### PR DESCRIPTION
### 対象イシュー
Close #762 
Close #546


### 概要
- ゲーム終了時のイベントの発火後にゲーム結果を保存するようにした（詳細1）
- ゲームの成功判定をGamePlayDirectorではなくBoardManagerが行うようにした
- ゲームのクリア判定のロジックを変更（詳細2）
- ゲームの終了時に一定時間、盤面を表示。
（成功してすぐ盤面が見えなくなるのも悲しいのでとりあえず0.5秒待つようにした。この変更は別にmergeしなくても良いけど、将来的に何かしら盤面が一定時間見える演出入れたい）

### 詳細
1. ゲーム結果の保存処理の終了を待ってからゲーム終了時のイベント（ギミックを止めたりなど）が発火していたので、先にイベントを発火してゲーム結果を保存するようにした
↓
成功判定や失敗判定が遅延しなくなったので、本来の問題解決（Bottleの移動が完全に終了してから成功判定）を行えるようになる

2. ゲームのクリア判定
(以前)
あるBottleが成功状態になると、全てのBottleが成功しているかどうかを調べてゲームのクリア判定を行なっていた
その結果、BottleAが移動中に、BottleBがGustwindの効果で高速移動し成功判定を行うと、BottleAがまだ目的のTileに移動しきっていないのに、ゲームがクリアされてしまっていた。
(今回)
あるBottleが成功状態になると、成功しているBottleの数を１増やす。成功しているBottleがGoalBottleの数と等しければゲームクリアとする。
これにより、各Bottleは自分自身が成功状態になった時にのみ、自分が成功状態になったことを通知するようになり、上記の不具合は起きなくなった。

#### 現実装になった経緯
不具合があったので。

#### 技術的な内容
特になし

### キャプチャ
変更前（わかりやすいようにDynamicBottleControlletの移動速度を3fに設定）
https://user-images.githubusercontent.com/26213141/121785250-b4752680-cbf3-11eb-8cd6-d316a5596b8b.mov


変更後
https://user-images.githubusercontent.com/26213141/121785080-b4c0f200-cbf2-11eb-9235-624ae26136ff.mov



### 動作確認方法

- [ ] Spring_1_8をプレイ。変更前のキャプチャの状態が再現されないことを確認。

### 参考 URL
