### PR TITLE
LevelSelectの背景を縦横比の異なるデバイスに対応させる

### DIFF
--- a/Assets/Project/Scenes/MenuSelectScene.unity
+++ b/Assets/Project/Scenes/MenuSelectScene.unity
@@ -208,8 +208,8 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 28692796}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 90}
-  m_LocalScale: {x: 0.65681446, y: 0.65681446, z: 0.65681446}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 1182595682}
   m_Father: {fileID: 1704228718}
@@ -218,8 +218,8 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 1125, y: 2436}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
 --- !u!114 &28692798
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -259,7 +259,7 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 1
+  m_PresetInfoIsWorld: 0
 --- !u!223 &28692800
 Canvas:
   m_ObjectHideFlags: 0
@@ -269,7 +269,7 @@ Canvas:
   m_GameObject: {fileID: 28692796}
   m_Enabled: 1
   serializedVersion: 3
-  m_RenderMode: 2
+  m_RenderMode: 1
   m_Camera: {fileID: 644600156}
   m_PlaneDistance: 100
   m_PixelPerfect: 0
@@ -19754,18 +19754,6 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 2089056029}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &797824668 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: -2037017567522478634, guid: b96ed1f8e21744424bcf6618ef1e699c,
-    type: 3}
-  m_PrefabInstance: {fileID: 2089056029}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 648957590}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &799340586
 GameObject:
   m_ObjectHideFlags: 0
@@ -26553,7 +26541,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: -1, y: -0.5}
   m_AnchorMax: {x: 2, y: 1.5}
-  m_AnchoredPosition: {x: 185.82983, y: 0}
+  m_AnchoredPosition: {x: 319.09912, y: 10.099365}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1755488822
@@ -28408,6 +28396,12 @@ PrefabInstance:
     m_RemovedComponents:
     - {fileID: 0}
   m_SourcePrefab: {fileID: 100100000, guid: b96ed1f8e21744424bcf6618ef1e699c, type: 3}
+--- !u!1 &2089056030 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4164795490632793632, guid: b96ed1f8e21744424bcf6618ef1e699c,
+    type: 3}
+  m_PrefabInstance: {fileID: 2089056029}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &2124527414
 GameObject:
   m_ObjectHideFlags: 0
@@ -28483,12 +28477,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2124527414}
   m_CullTransparentMesh: 0
---- !u!1 &2089056030 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 4164795490632793632, guid: b96ed1f8e21744424bcf6618ef1e699c,
-    type: 3}
-  m_PrefabInstance: {fileID: 2089056029}
-  m_PrefabAsset: {fileID: 0}
 --- !u!224 &2140313129 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 8678026271308743277, guid: b96ed1f8e21744424bcf6618ef1e699c,


### PR DESCRIPTION
### 対象イシュー
Close #974

### 概要
タイトルまま

### 詳細
MenuSelectScene/LevelSelect/BackgroundCanvasのRender modeを`Screen Space - Camera`に設定

#### 現実装になった経緯


#### 技術的な内容
<img width="1696" alt="スクリーンショット 2021-06-14 0 25 55" src="https://user-images.githubusercontent.com/26213141/121813454-1b074c80-cca7-11eb-84af-3ffc77368ee7.png">


### キャプチャ
変更前 | 変更後
<img width="342" alt="スクリーンショット 2021-06-14 0 21 11" src="https://user-images.githubusercontent.com/26213141/121813468-2490b480-cca7-11eb-949f-b684eee977cf.png"> <img width="338" alt="スクリーンショット 2021-06-14 0 21 44" src="https://user-images.githubusercontent.com/26213141/121813472-26f30e80-cca7-11eb-88d6-9aaedfd1e142.png">


### 動作確認方法

- [ ] 1920x1080 Portraitなどで実行。LevelSelectで最も縮小した状態で、色々スクロールしてもBackgroundの領域外が見えない

### 参考 URL
