### PR TITLE
GoalBottleのSpriteGlowEffectが光らない問題を修正

### DIFF
--- a/Assets/Project/Scenes/GamePlayScene.unity
+++ b/Assets/Project/Scenes/GamePlayScene.unity
@@ -5575,7 +5575,7 @@ MonoBehaviour:
   volumeTrigger: {fileID: 574476888}
   volumeLayer:
     serializedVersion: 2
-    m_Bits: 256
+    m_Bits: 4096
   stopNaNPropagation: 1
   finalBlitToCameraTarget: 1
   antialiasingMode: 0


### PR DESCRIPTION
### 対象イシュー
Close #977

### 概要
タイトルまま

### 詳細
特になし

#### 現実装になった経緯
特になし

#### 技術的な内容
GamePlayScene/Main CameraのPost Process LayerのVolume Layerを`Bottle`に設定
<img width="443" alt="スクリーンショット 2021-06-21 23 12 04" src="https://user-images.githubusercontent.com/26213141/122776490-1ca7c480-d2e6-11eb-8e05-95660e1dbeab.png">



### キャプチャ
変更前 | 変更後
<img width="278" alt="スクリーンショット 2021-06-21 23 11 04" src="https://user-images.githubusercontent.com/26213141/122776334-f8e47e80-d2e5-11eb-9b6f-70c8426273a4.png"> <img width="280" alt="スクリーンショット 2021-06-21 23 09 31" src="https://user-images.githubusercontent.com/26213141/122776142-c76bb300-d2e5-11eb-92ab-b6c66267b90a.png">


### 動作確認方法

- [ ] ステージを１つプレイ。Goal状態のGoalBottleを確認する

### 参考 URL
