### PR TITLE
new acquire activation file workflow

### DIFF
--- a/.github/workflows/aquire_activation_file.yml
+++ b/.github/workflows/aquire_activation_file.yml
@@ -1,0 +1,20 @@
+name: Acquire activation file
+on:
+  workflow_dispatch: {}
+jobs:
+  activation:
+    name: Request manual activation file 🔑
+    runs-on: ubuntu-latest
+    steps:
+      # Request manual activation file
+      - name: Request manual activation file
+        id: getManualLicenseFile
+        uses: game-ci/unity-request-activation-file@v2
+        with:
+          unityVersion: 2021.1.2f1
+      # Upload artifact
+      - name: Expose as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ steps.getManualLicenseFile.outputs.filePath }}
+          path: ${{ steps.getManualLicenseFile.outputs.filePath }}


### PR DESCRIPTION
認証ファイルのバージョンが古かったので、
アクティブ用のフローを作り直し、Github ActionsのUIから実行できるようにした

https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow