### PR TITLE
`HolyTile` の無敵が消えた瞬間に接触中のギミックの当たり判定を行う

### DIFF
--- a/Assets/Project/GameDatas/Stages/Spring_2/1.asset
+++ b/Assets/Project/GameDatas/Stages/Spring_2/1.asset
@@ -47,11 +47,15 @@ MonoBehaviour:
     goalColor: 1
     number: 11
     pairNumber: 0
+  - type: 3
+    goalColor: 0
+    number: 1
+    pairNumber: 0
   bottles:
   - type: 2
     initPos: 4
     goalColor: 1
-    life: 1
+    life: 2
     isSelfish: 0
     isDark: 0
     isReverse: 0
@@ -104,14 +108,36 @@ MonoBehaviour:
     isSelfish: 0
     isDark: 0
     isReverse: 0
-  gimmicks: []
+  gimmicks:
+  - loop: 1
+    appearTime: 0
+    interval: 2
+    type: 0
+    targetDirections: 00000000
+    targetLines: 00000000
+    randomDirection: 
+    randomRow: 
+    randomColumn: 
+    targetRow: 0
+    targetColumn: 0
+    targetBottle: 0
+    randomAttackableBottles: 
+    isRandom: 0
+    targets: []
+    targetDirection: 0
+    attackTimes: 0
+    duration: 0
+    width: 0
+    height: 0
   overviewGimmicks: 
   tutorial:
     type: 0
     image:
       m_AssetGUID: 
       m_SubObjectName: 
+      m_SubObjectType: 
     video:
       m_AssetGUID: 
       m_SubObjectName: 
+      m_SubObjectType: 
   constraintStages: []

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Bottle/BottleControllerBase.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Bottle/BottleControllerBase.cs
@@ -72,10 +72,9 @@ namespace Treevel.Modules.GamePlayScene.Bottle
         public bool IsInvincible => IsInvincibleAfterDamaged || isInvincibleByHoly.Value;
 
         /// <summary>
-        /// ギミックに当たった後の無敵時間効果が消えるとき発火するイベント
+        /// 無敵時間効果が消えるとき発火するイベント
         /// </summary>
-        private readonly Subject<GameObject> _onInvincibleAfterDamagedExpiredSubject = new Subject<GameObject>();
-        public IObservable<GameObject> OnInvincibleAfterDamagedExpired => _onInvincibleAfterDamagedExpiredSubject;
+        public readonly Subject<GameObject> onInvincibleExpiredSubject = new Subject<GameObject>();
 
         protected virtual void Awake()
         {
@@ -93,7 +92,7 @@ namespace Treevel.Modules.GamePlayScene.Bottle
                 .Delay(TimeSpan.FromSeconds(_INVINCIBLE_AFTER_DAMAGED_INTERVAL))
                 .Subscribe(_ => {
                     IsInvincibleAfterDamaged = false;
-                    _onInvincibleAfterDamagedExpiredSubject.OnNext(gameObject);
+                    onInvincibleExpiredSubject.OnNext(gameObject);
                 })
                 .AddTo(this);
         }

--- a/Assets/Project/Scripts/Modules/GamePlayScene/Tile/HolyTileController.cs
+++ b/Assets/Project/Scripts/Modules/GamePlayScene/Tile/HolyTileController.cs
@@ -62,6 +62,7 @@ namespace Treevel.Modules.GamePlayScene.Tile
             {
                 // 親ボトルを無敵状態から元に戻す
                 bottle.GetComponent<BottleControllerBase>().isInvincibleByHoly.Value = false;
+                bottle.GetComponent<BottleControllerBase>().onInvincibleExpiredSubject.OnNext(bottle);
 
                 // ボトルが出る演出再生
                 _animator.SetTrigger(_ANIMATOR_PARAM_TRIGGER_BOTTLE_EXIT);


### PR DESCRIPTION
### 対象イシュー
Close #1000 

### 概要
- #932 実装時に用意された `OnInvincibleAfterDamagedExpired` を利用して、`HolyTile` の無敵が外れた瞬間に接触中のギミックの当たり判定を行うようにした

### キャプチャ
https://user-images.githubusercontent.com/26104258/123963895-dc36fd80-d9ed-11eb-80ff-daebe97f7f98.mov

### 動作確認方法
- [ ] `Spring_2_1` において、#1000 の問題が解消されていること
- [ ] `Spring_2_1` において、#932 の動作が変わっていないこと

https://github.com/LITO-apps/Treevel-client/blob/cc6e6d116b59ea786180d0d9340e32e9bf769962/Assets/Project/Scripts/Modules/GamePlayScene/Bottle/BottleControllerBase.cs#L59-L62

を `3.0` とかにしないと確認しづらいかもしれません