### PR TITLE
エラー内容を表示しないようにする

### DIFF
--- a/Assets/Project/Editor/DebugTools.cs
+++ b/Assets/Project/Editor/DebugTools.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Linq;
+using Cysharp.Threading.Tasks;
+using Treevel.Common.Entities;
+using Treevel.Common.Managers;
+using UnityEditor;
+using UnityEngine;
+
+namespace Treevel
+{
+    public class DebugTools : MonoBehaviour
+    {
+        [MenuItem("Tools/Debug Command/Open Error Window")]
+        private static void OpenErrorWindow()
+        {
+            if (!EditorApplication.isPlaying) {
+                Debug.LogWarning("Only available in play mode");
+                return;
+            }
+
+            var errorCodes = Enum.GetValues(typeof(EErrorCode)) as EErrorCode[];
+            var rand = new System.Random();
+            var errorCode = errorCodes?.ElementAt(rand.Next(errorCodes.Length)) ?? EErrorCode.UnknownError;
+
+            UIManager.Instance.ShowErrorMessageAsync(errorCode).Forget();
+        }
+    }
+}

--- a/Assets/Project/Editor/DebugTools.cs
+++ b/Assets/Project/Editor/DebugTools.cs
@@ -13,16 +13,20 @@ namespace Treevel
         [MenuItem("Tools/Debug Command/Open Error Window")]
         private static void OpenErrorWindow()
         {
-            if (!EditorApplication.isPlaying) {
-                Debug.LogWarning("Only available in play mode");
-                return;
-            }
-
             var errorCodes = Enum.GetValues(typeof(EErrorCode)) as EErrorCode[];
             var rand = new System.Random();
             var errorCode = errorCodes?.ElementAt(rand.Next(errorCodes.Length)) ?? EErrorCode.UnknownError;
 
             UIManager.Instance.ShowErrorMessageAsync(errorCode).Forget();
+        }
+
+        /// <summary>
+        /// Open Error Window が実行可能かを判断する関数
+        /// </summary>
+        [MenuItem("Tools/Debug Command/Open Error Window", true)]
+        private static bool ValidateOpenErrorWindow()
+        {
+            return EditorApplication.isPlaying;
         }
     }
 }

--- a/Assets/Project/Editor/DebugTools.cs.meta
+++ b/Assets/Project/Editor/DebugTools.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fde1c68df41ba44fabfafc48f0d09835
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/Resources/GameDatas/translation.csv
+++ b/Assets/Project/Resources/GameDatas/translation.csv
@@ -35,16 +35,8 @@ GamePauseQuit,諦める,GiveUp
 GameBack,戻る,Stage Menu
 Error,エラー,ERROR
 Downloading,ダウンロード中...,Downloading...
-ErrorUnknown,不明なエラー,Unknwon Error
 ReturnToTitle,タイトルに戻る,Return to title
-ErrorLoadDataFailed,データの読み込みが失敗しました。,Failed to load data
 StartGame,スタート！,Tap to Start
-ErrorInvalidBottleAccess,ボトルの不正アクセスが発生しました。,Invalid bottle access.
-ErrorInvalidBottleColor,ボトルの色が正しく設定されていません。,Invalid bottle color.
-ErrorInvalidLifeValue,ライフの値が正しく設定されいません。,Invalid life value.
-ErrorInvalidTileColor,タイルの色が正しく設定されていません。,Invalid tile color.
-ErrorInvalidGimmickData,ギミックデータが正しく設定されていません。。,Invalid gimmick data.
-SaveStageRecordError,ステージの記録を保存することに失敗しました,Failed to save stage record.
 RecordShareButton,共有,Share
 RecordToIndividualButton,個別記録へ,Individual
 RecordToGeneralButton,総合記録へ,General

--- a/Assets/Project/Scripts/Common/Components/UIs/ErrorMessageBox.cs
+++ b/Assets/Project/Scripts/Common/Components/UIs/ErrorMessageBox.cs
@@ -32,10 +32,8 @@ namespace Treevel.Common.Components.UIs
             get => _errorCode;
             set {
                 _errorCode = value;
-                // エラーコードから対応するエラーメッセージを取得
-                _text.TextIndex = (ETextIndex)((int)ETextIndex.ErrorTextStart + (int)_errorCode);
                 // _errorCodeが1なら001と出力
-                _text.text += $"(ErrorCode:{(int)_errorCode:D3})";
+                _text.text = $"(ErrorCode:{(int)_errorCode:D3})";
             }
         }
 

--- a/Assets/Project/Scripts/Common/Entities/ErrorCode.cs
+++ b/Assets/Project/Scripts/Common/Entities/ErrorCode.cs
@@ -2,8 +2,6 @@
 {
     /// <summary>
     /// エラー発生時に追跡し易くするため、各種エラーコードを定義し、<see cref="ErrorMessageBox">からユーザに提示する。
-    /// エラーメッセージは<see cref="ETextIndex.ErrorTextStart">からエラーコードと同じ順序で追加する。
-    /// Enumのインデックスを3桁の数字としてErrorCode=000のようにエラーメッセージの後ろに付けてユーザに提示する
     /// </summary>
     public enum EErrorCode
     {

--- a/Assets/Project/Scripts/Common/Entities/TextIndex.cs
+++ b/Assets/Project/Scripts/Common/Entities/TextIndex.cs
@@ -64,14 +64,5 @@ namespace Treevel.Common.Entities
         MessageDlgCancelBtnText,         // メッセージダイアログーCancelボタン
         MessageDlgOkBtnRetryText,        // メッセージダイアログーリトライボタン
         MessageDlgOkBtnGiveUpText,       // メッセージダイアログー諦めるボタン
-        ErrorTextStart = 10000,          // ここからはエラーメッセージ
-        ErrorUnknown = ErrorTextStart,   // 不明なエラー
-        ErrorLoadDataFailed,             // データの読み込みが失敗しました
-        ErrorInvalidBottleAccess,        // ボトルの不正アクセスが発生しました。
-        ErrorInvalidBottleColor,         // ボトルの色が正しく設定されていません。
-        ErrorInvalidLifeValue,           // ライフの値が正しく設定されていません。
-        ErrorInvalidTileColor,           // タイルの色が正しく設定されていません。
-        ErrorInvalidGimmickData,         // ギミックデータが正しく設定されていません。
-        SaveStageRecordError,            // ステージの記録を保存することに失敗しました。
     }
 }


### PR DESCRIPTION
### 対象イシュー
Close #792 

### 概要
エラーの内容をユーザに伝える必要ないと判断したので、
表示しないように対応しました。

### 詳細

#### 技術的な内容
* 翻訳など、エラー内容を表示する関連コードも合わせて削除。
* エラーメッセージを意図的に起こすことは現状難しそうなので、デバッグツールを作りました。


### キャプチャ
![image](https://user-images.githubusercontent.com/17778395/124394003-4cb88400-dd38-11eb-9143-013175839c30.png)

![image](https://user-images.githubusercontent.com/17778395/124394035-770a4180-dd38-11eb-987d-9325be1499b7.png)


### 動作確認方法
- [x] デバッグツールからエラーメッセージボックスを開き、エラーコードのみ表示されることを確認

### 参考 URL
* [MenuItemのレファレンス（Validate~の使い方）](https://docs.unity3d.com/ScriptReference/MenuItem.html)